### PR TITLE
Add print-method implementation for `Structure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- `up` and `down` tuples from `sicmutils.structure` gain a proper `print-method`
+  implementation (#229); these now render as `(up 1 2 3)` and `(down 1 2 3)`,
+  instead of the former more verbose representation (when using `pr`.)
+
 - `sicmutils.env.sci` contains an SCI context and namespace mapping sufficient
   to evaluate all of sicmutils, macros and all, inside of an
   [SCI](https://github.com/borkdude/sci) environment (#216). Huge thanks to

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -18,6 +18,7 @@
 ;;
 
 (ns sicmutils.env.sci
+  (:refer-clojure :exclude [ns-map])
   (:require [sci.core :as sci]
             [sicmutils.env]
             [sicmutils.env.sci.macros :as macros]

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -158,10 +158,7 @@
 
        IPrintWithWriter
        (-pr-writer [x writer _]
-                   (write-all writer
-                              "#object[sicmutils.structure.Structure \""
-                              (.toString x)
-                              "\"]"))
+                   (write-all writer (.toString x)))
 
        ICollection
        (-conj [_ item] (Structure. orientation (-conj v item)))

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -240,6 +240,10 @@
                 (Structure. orientation (mapv #(apply % a b c d e f g h i j k l m n o p q r s t rest) v)))
        ]))
 
+#?(:clj
+   (defmethod print-method Structure [^Structure s ^java.io.Writer w]
+     (.write w (.toString s))))
+
 ;; ## Component Accessors
 
 (defn structure->vector

--- a/test/sicmutils/matrix_test.cljc
+++ b/test/sicmutils/matrix_test.cljc
@@ -110,38 +110,30 @@
     (is (= [[4 5 6] [7 8 9]] (drop 1 (m/by-rows [1 2 3] [4 5 6] [7 8 9])))))
 
   (testing "can be mapped"
-    (is (= (s/up 1 4 9) (map g/square (s/up 1 2 3)))))
+    (is (= [2 2] (map count (m/by-rows [1 2] [3 4])))))
 
   (testing "a structure can produce a seq"
-    (is (= [1 2 3] (seq (s/up 1 2 3))))
-    (is (= [4 5 6] (seq (s/down 4 5 6))))
-    (is (= [(s/up 1 2) (s/up 3 4)] (seq (s/down (s/up 1 2) (s/up 3 4)))))
-    (is (= [1 2 3 4] (flatten (s/down (s/up 1 2) (s/up 3 4))))))
+    (is (= [[1 2] [3 4]] (seq (m/by-rows [1 2] [3 4])))))
 
   (testing "seqable"
-    (is (= [1 2 3] (into [] (s/up 1 2 3)))))
+    (is (= [1 2 3 4] (into [] cat (m/by-rows [1 2] [3 4])))))
 
-  (testing "a structure has a nth element (ILookup)"
-    (is (= 14 (nth (s/up 10 12 14) 2)))
-    (is (= 5 (nth (s/up 4 5 6) 1)))
-    (is (thrown? #?(:clj IndexOutOfBoundsException :cljs js/Error)
-                 (nth (s/up 4 5 6) 4))))
+  (let [M (m/by-rows [1 2] [3 4])]
+    (testing "a structure has a nth element (ILookup)"
+      (is (= [1 2] (nth M 0)))
+      (is (= [3 4] (nth M 1)))
+      (is (= 2 (get-in M [0 1])))
+      (is (thrown? #?(:clj IndexOutOfBoundsException :cljs js/Error)
+                   (nth M 4)))))
 
   (testing "IFn"
-    (is (= (s/up 6 9 1)
-           ((s/up + * /) 3 3)))
-    (is (= (s/up 22 2048 (g/expt 2 -9))
-           ((s/up g/+ g/* g//) 2 2 2 2 2 2 2 2 2 2 2))))
-
-  (testing "print representation"
-    (let [s (pr-str (s/up 1 2 3))]
-      (is #?(:clj (clojure.string/includes? s "\"(up 1 2 3)\"")
-             :cljs (= s "#object[sicmutils.structure.Structure \"(up 1 2 3)\"]"))))
-    (is (= "(up 1 2 3)" (str (s/up 1 2 3)))))
+    (is (= (m/by-rows [6 9] [1 0])
+           ((m/by-rows [+ *] [/ -]) 3 3))))
 
   (testing "equality"
-    (= (s/up 1 2 3) [1 2 3])
-    (= (s/up 1 2 3) (s/up 1 2 3))))
+    (is (= [[1 2] [3 4]] (m/by-rows [1 2] [3 4])))
+    (is (= (m/by-rows [1 2] [3 4])
+           (m/by-rows [1 2] [3 4])))))
 
 (deftest matrix-basics
   (checking "square? is false for numbers" 100

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -167,8 +167,7 @@
 
   (testing "print representation"
     (let [s (pr-str (s/up 1 2 3))]
-      (is #?(:clj (clojure.string/includes? s "\"(up 1 2 3)\"")
-             :cljs (= s "#object[sicmutils.structure.Structure \"(up 1 2 3)\"]"))))
+      (is (= "(up 1 2 3)" s)))
     (is (= "(up 1 2 3)" (str (s/up 1 2 3)))))
 
   (testing "equality"


### PR DESCRIPTION
Small one... this allows structures to render like this, if you use `pr` to print at the REPL (I know I still need to document how to make this look nice!):

```clojure
sicmutils.env> (saddle-FF)
[(up 8.246324826140356E-6 8.246324826140356E-6) (up 8.246324826140356E-6 8.246324826140356E-6)]
```