### PR TITLE
Expose sci namespaces and re-add bindings

### DIFF
--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -59,10 +59,10 @@
     (into {} (mapcat process) sym->var)))
 
 (def ^{:doc "Map whose values are the symbols of of all namespaces explicitly
-checked and whitelisted for SCI compilation and interesting enough in their own
-right to expose to a user by default. Each value is the sym->var map for the
-corresponding namespace."}
-  ns-map
+ checked and whitelisted for SCI compilation and interesting enough in their own
+ right to expose to a user by default. Each value is the sym->var map for the
+ corresponding namespace."}
+  ns->publics
   {'sicmutils.env                              (ns-publics 'sicmutils.env)
    'sicmutils.generic                          (ns-publics 'sicmutils.generic)
    'sicmutils.function                         (ns-publics 'sicmutils.function)
@@ -98,15 +98,22 @@ corresponding namespace."}
    'sicmutils.numerical.unimin.brent           (ns-publics 'sicmutils.numerical.unimin.brent)
    'sicmutils.numerical.unimin.golden          (ns-publics 'sicmutils.numerical.unimin.golden)})
 
+(def ^{:doc "SCI namespace map generated from `ns->publics`. Consumers wishing
+ to use a more minmal SCI environment, should can select interested namespaces
+ from this map. Since in normal (not self-hosted) ClojureScript `ns-publics`
+ does not include macros, they are added explicitly."}
+  namespaces
+  (let [ns-map (into {}
+                     (map (fn [[k v]] [k (sci-ns v)]))
+                     ns->publics)]
+    (merge-with merge ns-map macros/ns-bindings)))
+
 (def ^{:doc "Default sci context options required (currently only `:namespace`
   bindings) required to evaluate SICMUtils forms from inside of an SCI
   context. Pass these to `sci/init` to generate an sci context."}
   context-opts
-  (let [ns-map (into {}
-                     (map (fn [[k v]] [k (sci-ns v)]))
-                     ns-map)
-        with-macros (merge-with merge ns-map macros/ns-bindings)]
-    {:namespaces with-macros}))
+  {:namespaces namespaces
+   :bindings (namespaces 'sicmutils.env)})
 
 (def ^{:doc "sci context (currently only `:namespace` bindings) required to
   evaluate SICMUtils forms via SCI"}

--- a/test/sicmutils/env/sci_test.cljc
+++ b/test/sicmutils/env/sci_test.cljc
@@ -25,12 +25,8 @@
             [sicmutils.env.sci :as es]
             [sicmutils.operator :as o]))
 
-(let [ns-map  (:namespaces es/context-opts)
-      env     (ns-map 'sicmutils.env)
-      context (sci/init {:namespaces
-                         (assoc ns-map 'user env)})]
-  (defn eval [form]
-    (sci/eval-form (sci/fork context) form)))
+(defn eval [form]
+  (sci/eval-form (sci/fork es/context) form))
 
 (deftest basic-sci-tests
   (is (= 1 (eval '(simplify (+ (square (sin 'x))


### PR DESCRIPTION
A small follow-up to #216 and #230.

Makes the default sci context more batteries-included but allows consumers that are only interested in the sci namespace map to access that directly.