### PR TITLE
Only trigger tag replacement in nested calls (suggested by GJS)

### DIFF
--- a/src/sicmutils/differential.cljc
+++ b/src/sicmutils/differential.cljc
@@ -861,7 +861,16 @@
    (collect-terms tags->coefs)))
 
 ;; ## Differential API
-;;
+
+(def ^:dynamic *active-tags* #{})
+
+(defn with-active-tag [tag f args]
+  (binding [*active-tags* (conj *active-tags* tag)]
+    (apply f args)))
+
+(defn tag-active? [tag]
+  (contains? *active-tags* tag))
+
 ;; This next section lifts slightly-augmented versions of [[terms:+]]
 ;; and [[terms:*]] up to operate on [[Differential]] instances. These work just
 ;; as before, but handle wrapping and unwrapping the term list.

--- a/test/sicmutils/calculus/derivative_test.cljc
+++ b/test/sicmutils/calculus/derivative_test.cljc
@@ -25,6 +25,7 @@
             [sicmutils.abstract.function :as af #?@(:cljs [:include-macros true])]
             [sicmutils.calculus.derivative :as d :refer [D partial]]
             [sicmutils.complex :as c]
+            [sicmutils.differential :as sd]
             [sicmutils.function :as f]
             [sicmutils.generic :as g :refer [acos asin atan cos sin tan
                                              cot sec csc
@@ -38,6 +39,24 @@
             [sicmutils.value :as v]))
 
 (use-fixtures :each hermetic-simplify-fixture)
+
+(deftest fn-iperturbed-tests
+  (testing "tag-active? responds appropriately"
+    (let [tag 0
+          f   (fn [x] (fn [g] (g x)))
+          Df  (-> (f (sd/bundle-element 'x 1 tag))
+                  (sd/extract-tangent tag))]
+      (is (not (sd/tag-active? tag))
+          "Outside the context of a derivative, the tag is not marked as
+          active.")
+
+      (is (= '(* 3 (expt x 2))
+             (g/simplify
+              (Df (fn [x]
+                    (is (sd/tag-active? tag)
+                        "Df is a function looking to extract `tag`, so inside a
+                        call to Df the `tag` IS active.")
+                    (g/cube x)))))))))
 
 (deftest basic-D-tests
   (testing "D of linear returns slope"

--- a/test/sicmutils/differential_test.cljc
+++ b/test/sicmutils/differential_test.cljc
@@ -279,6 +279,19 @@
              ((D (d/bundle-element g/sin g/cos 0)) 't))
           "partial-derivative is linear through a differential"))))
 
+(deftest active-tag-tests
+  (testing "with-active-tag works"
+    (is (not (d/tag-active? 'tag))
+        "this tag is not active if it's not bound.")
+
+    (is (= 6 (d/with-active-tag 'tag
+               (fn [& xs]
+                 (is (d/tag-active? 'tag)
+                     "the supplied tag is active inside the scope of `f`.")
+                 (reduce + xs))
+               [1 2 3]))
+        "d/with-active-tag calls its fn with the supplied args.")))
+
 (deftest differential-arithmetic-tests
   (checking "(d:+ diff 0) == (d:+ 0 diff) == diff" 100 [diff real-diff-gen]
             (is (d/eq diff


### PR DESCRIPTION
This PR adds an `*active-tags*` stack that allows us to save work in the case of a nested derivative. `*active-tags*` is a stack containing the tags of all nested calls; in #226 , this is going to save us trouble when deciding whether a `TapeCell` should wrap a `Differential` or vice versa if both show up in a computation.