### PR TITLE
Render equality symbols correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- `sicmutils.expression.render/->infix` and `sicmutils.expression.render/->TeX` now
+  handle equality/inequality symbols (`=`, `>=`, `>`, ...) as infix.
+
 - `sicmutils.modint` gains more efficient implementations for `inverse`,
   `quotient`, `exact-divide` and `expt` on the JVM (#251).
 

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -239,8 +239,8 @@
   "Converts an S-expression to printable infix form. Numeric exponents are
   written as superscripts. Partial derivatives get subscripts."
   (make-infix-renderer
-   :precedence-map '{D 9, expt 7, :apply 5, u- 4, / 3, * 3, + 1, - 1}
-   :infix? '#{* + - / expt u-}
+   :precedence-map '{D 9, expt 7, :apply 5, u- 4, / 3, * 3, + 1, - 1, = 0, > 0, < 0, >= 0, <= 0}
+   :infix? '#{* + - / expt u- = > < >= <=}
    :juxtapose-multiply " "
    :rewrite-trig-squares true
    :special-handlers
@@ -311,9 +311,9 @@
     (make-infix-renderer
      ;; here we set / to a very low precedence because the fraction bar we will
      ;; use in the rendering groups things very strongly.
-     :precedence-map '{D 9, expt 8, :apply 7, u- 6, * 5, + 3, - 3, / 1}
+     :precedence-map '{D 9, expt 8, :apply 7, u- 6, * 5, + 3, - 3, / 1, = 0, > 0, < 0, >= 0, <= 0}
      :parenthesize #(str "\\left(" % "\\right)")
-     :infix? '#{* + - / expt u-}
+     :infix? '#{* + - / expt u- = > < >= <=}
      :juxtapose-multiply "\\,"
      :rewrite-trig-squares true
      :special-handlers
@@ -340,7 +340,9 @@
                 (str "\\begin{bmatrix}"
                      body
                      "\\end{bmatrix}")))
-      'sqrt #(str "\\sqrt " (maybe-brace (first %)))}
+      'sqrt #(str "\\sqrt " (maybe-brace (first %)))
+      '<= #(s/join " \\leq " %)
+      '>= #(s/join " \\geq " %)}
      :render-primitive
      (fn r [v]
        (cond (r/ratio? v)

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -152,6 +152,37 @@
   (is (= "\\frac{a + b}{c + d}" (->TeX (/ (+ 'a 'b) (+ 'c 'd)))))
   (is (= "\\frac{a}{b}" (->TeX (/ 'a 'b)))))
 
+(deftest equations
+  (is (= "x = 4" (->infix '(= x 4))))
+  (is (= "x = 4" (->TeX '(= x 4))))
+
+  (is (= "x > 4" (->infix '(> x 4))))
+  (is (= "x > 4" (->TeX '(> x 4))))
+
+  (is (= "x < 4" (->infix '(< x 4))))
+  (is (= "x < 4" (->TeX '(< x 4))))
+
+  (is (= "x >= 4" (->infix '(>= x 4))))
+  (is (= "x \\geq 4" (->TeX '(>= x 4))))
+  
+  (is (= "x <= 4" (->infix '(<= x 4))))
+  (is (= "x \\leq 4" (->TeX '(<= x 4))))
+
+  (is (= "e^(i pi) + 1 = 0"
+         (->infix '(= (+ (expt e (* i pi)) 1) 0))))
+  (is (= "{e}^{\\left(i\\,\\pi\\right)} + 1 = 0"
+         (->TeX '(= (+ (expt e (* i pi)) 1) 0))))
+
+  (is (= "4 = 2 + 2 = 1 + 3"
+         (->infix '(= 4 (+ 2 2) (+ 1 3)))))
+  (is (= "4 = 2 + 2 = 1 + 3"
+         (->TeX '(= 4 (+ 2 2) (+ 1 3)))))
+
+  (is (= "4 \\leq 2 + 2 \\leq 1 + 3"
+         (->TeX '(<= 4 (+ 2 2) (+ 1 3)))))
+  (is (= "4 \\geq 2 + 2 \\geq 1 + 3"
+         (->TeX '(>= 4 (+ 2 2) (+ 1 3))))))
+
 (defn ^:private make-symbol-generator
   [p]
   (let [i (atom 0)]


### PR DESCRIPTION
`sicmutils.expression.render/->infix` and `sicmutils.expression.render/->TeX` now handle equality/inequality symbols (`=`, `>=`, `>`, ...) as infix. (sicmutils/placeholder#81)