### PR TITLE
Avoid sans-serif symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+=======
+- `sicmutils.expression.render/*TeX-sans-serif-symbols*` binding to control if
+  symbols longer than 1 char should have `\mathsf` applied.
+
 - `sicmutils.modint` gains more efficient implementations for `inverse`,
   `quotient`, `exact-divide` and `expt` on the JVM (#251).
 

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -293,6 +293,7 @@
     (brace s)))
 
 (def ^:dynamic *TeX-vertical-down-tuples* false)
+(def ^:dynamic *TeX-sans-serif-symbols* true)
 
 (defn- displaystyle [s]
   (str "\\displaystyle{" s "}"))
@@ -367,7 +368,9 @@
                              (if (and (symbol? v)
                                       (> (count s) 1)
                                       (not (re-matches #"^d[a-zαωθφ]" s)))
-                               (str "\\mathsf" (brace s))
+                               (if *TeX-sans-serif-symbols*
+                                 (str "\\mathsf" (brace s))
+                                 (brace s))
                                v)))))))))
 
 (def ->JavaScript

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -152,6 +152,12 @@
   (is (= "\\frac{a + b}{c + d}" (->TeX (/ (+ 'a 'b) (+ 'c 'd)))))
   (is (= "\\frac{a}{b}" (->TeX (/ 'a 'b)))))
 
+(deftest symbols
+  (is (= "x" (->TeX 'x)))
+  (is (= "\\mathsf{PV}" (->TeX 'PV)))
+  (binding [sicmutils.expression.render/*TeX-sans-serif-symbols* false]
+    (is (= "{PV}" (->TeX 'PV)))))
+
 (defn ^:private make-symbol-generator
   [p]
   (let [i (atom 0)]


### PR DESCRIPTION
`sicmutils.expression.render/*TeX-sans-serif-symbols*` binding to control if symbols longer than 1 char should have `\mathsf` applied.