### PR TITLE
Use pr-str inside Literal toString, allowing proper lazy sequence printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 - `sicmutils.expression/Literal` instances now use `pr-str` to generate a string
   representation; this allows this type to wrap lazy-sequence expressions such
-  as those returned from `g/simplify`.
+  as those returned from `g/simplify` (#259)
 
-- `sicmutils.expression.render/->infix` and `sicmutils.expression.render/->TeX` now
-  handle equality/inequality symbols (`=`, `>=`, `>`, ...) as infix.
+- `sicmutils.expression.render/->infix` and `sicmutils.expression.render/->TeX`
+  now handle equality/inequality symbols (`=`, `>=`, `>`, ...) as infix (#257).
 
 - `sicmutils.expression.render/*TeX-sans-serif-symbols*` binding to control if
-  symbols longer than 1 char should have `\mathsf` applied.
+  symbols longer than 1 char should have `\mathsf` applied (#258).
 
 - `sicmutils.modint` gains more efficient implementations for `inverse`,
   `quotient`, `exact-divide` and `expt` on the JVM (#251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- `sicmutils.expression/Literal` instances now use `pr-str` to generate a string
+  representation; this allows this type to wrap lazy-sequence expressions such
+  as those returned from `g/simplify`.
+
 - `sicmutils.expression.render/->infix` and `sicmutils.expression.render/->TeX` now
   handle equality/inequality symbols (`=`, `>=`, `>`, ...) as infix.
 

--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -68,7 +68,7 @@
   (kind [_] type)
 
   Object
-  (toString [_] (str expression))
+  (toString [_] (pr-str expression))
   #?(:cljs
      (valueOf [this]
               (cond (number? expression)   expression

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -177,7 +177,15 @@
             (is (=  (+ 1 (Math/cos x))
                     (g/+ 1 (g/cos x)))
                 "You get a floating-point inexact result by calling generic fns
-    on a number directly, by comparison.")))
+    on a number directly, by comparison."))
+
+  (testing "literal-number properly prints wrapped sequences, even if they're lazy."
+    (is (= "(* 2 x)"
+           (pr-str
+            (an/literal-number (g/simplify (g/* 'x 2))))))
+    (is (= "(* x 2)"
+           (pr-str
+            (an/literal-number (lazy-seq ['* 'x 2])))))))
 
 ;; Generators
 


### PR DESCRIPTION
Prior to this change, we saw this:

```clojure
sicmutils.env> (pr-str (literal-number (simplify (* 'x 2))))
"clojure.lang.LazySeq@8ca01a75"
```

After, it all works as you'd expect!