### PR TITLE
Render series to TeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [Unreleased]
 
-- `sicmutils.render/->TeX` will render `Series` and `PowerSeries` as an infinite
-  series (showing the first four terms). In the case of `PowerSeries`, it will
-  default to `ax^n`.
+- `sicmutils.render/->infix` and `sicmutils.render/->TeX` will render `Series`
+  and `PowerSeries` as an infinite sum (showing the first four terms).
+  In the case of unnaplied `PowerSeries`, it will represent the unbound
+  variable as `_`.
 
 - `sicmutils.expression.render/->infix` and `sicmutils.expression.render/->TeX` now
   handle equality/inequality symbols (`=`, `>=`, `>`, ...) as infix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- `sicmutils.render/->TeX` will render `Series` and `PowerSeries` as an infinite
+  series (showing the first four terms). In the case of `PowerSeries`, it will
+  default to `ax^n`.
+
 - `sicmutils.expression.render/->infix` and `sicmutils.expression.render/->TeX` now
   handle equality/inequality symbols (`=`, `>=`, `>`, ...) as infix.
 

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -278,6 +278,7 @@
    "asin" "\\arcsin",
    "acos" "\\arccos",
    "atan" "\\arctan",
+   "_" "\\_"
    "..." "\\ldots"
    })
 

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -278,6 +278,7 @@
    "asin" "\\arcsin",
    "acos" "\\arccos",
    "atan" "\\arctan",
+   "..." "\\ldots"
    })
 
 (defn ^:private brace
@@ -294,7 +295,6 @@
 
 (def ^:dynamic *TeX-vertical-down-tuples* false)
 (def ^:dynamic *TeX-sans-serif-symbols* true)
-(def ^:dynamic *TeX-render-infinite-series* true)
 
 (defn- displaystyle [s]
   (str "\\displaystyle{" s "}"))
@@ -349,20 +349,6 @@
      (fn r [v]
        (cond (r/ratio? v)
              (str "\\frac" (brace (r/numerator v)) (brace (r/denominator v)))
-
-             (and *TeX-render-infinite-series* (vector? v) (= (first v) 'Series))
-             (brace (-> `(~'+ ~@(subvec v 1 5)) ;; frozen value
-                        ->TeX
-                        (str " + \\ldots")))
-
-             (and *TeX-render-infinite-series* (vector? v) (= (first v) 'PowerSeries))
-             (brace (-> `(~'+
-                          ~@(map (fn [a n]
-                                   `(~'* ~a ~`(~'expt ~'x ~n)))
-                                 (subvec v 1 5) ;; frozen value
-                                 (range 4)))
-                        ->TeX
-                        (str " + \\ldots")))
 
              :else
              (let [s (str v)]

--- a/src/sicmutils/series.cljc
+++ b/src/sicmutils/series.cljc
@@ -73,7 +73,7 @@
   (exact? [_] false)
   (freeze [_]
     (let [prefix (g/simplify (take 4 xs))]
-      `[~'Series ~@prefix ~'...]))
+      `(~'+ ~@prefix ~'...)))
   (kind [_] ::series)
 
   Object
@@ -227,8 +227,9 @@
   (identity-like [_] identity)
   (exact? [_] false)
   (freeze [_]
-    (let [prefix (g/simplify (take 4 xs))]
-      `[~'PowerSeries ~@prefix ~'...]))
+    (let [prefix (map-indexed (fn [n a] `(~'* ~a (~'expt ~'_ ~n)))
+                              (g/simplify (take 4 xs)))]
+      `(~'+ ~@prefix ~'...)))
   (kind [_] ::power-series)
 
   Object

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -190,14 +190,22 @@
     (is (= "{PV}" (->TeX 'PV)))))
 
 (deftest series-tests
-  (is (= "{1 + 1 + \\frac{1}{2} + \\frac{1}{6} + \\ldots}"
+  (is (= "1 + 1 + 1/2 + 1/6 + ..."
+         (->infix (series/exp-series 1))))
+  (is (= "1 + 1 + \\frac{1}{2} + \\frac{1}{6} + \\ldots"
          (->TeX (series/exp-series 1))))
-  (is (= "{1 + a + \\frac{1}{2}\\,{a}^{2} + \\frac{1}{6}\\,{a}^{3} + \\ldots}"
-         (->TeX (series/exp-series 'a))))
-  (is (= "{1\\,{x}^{0} + 2\\,{x}^{1} + 3\\,{x}^{2} + 4\\,{x}^{3} + \\ldots}"
+  (is (= "(k + 1) + 1 + 1/2 + 1/6 + ..."
+         (->infix (+ 'k (series/exp-series 1)))))
+  (is (= "\\left(k + 1\\right) + 1 + \\frac{1}{2} + \\frac{1}{6} + \\ldots"
+         (->TeX (+ 'k (series/exp-series 1)))))
+  (is (= "1 _⁰ + 2 _¹ + 3 _² + 4 _³ + ..."
+         (->infix (series/power-series 1 2 3 4))))
+  (is (= "1\\,{_}^{0} + 2\\,{_}^{1} + 3\\,{_}^{2} + 4\\,{_}^{3} + \\ldots"
          (->TeX (series/power-series 1 2 3 4))))
-  (is (= "{i\\,{x}^{0} + j\\,{x}^{1} + k\\,{x}^{2} + l\\,{x}^{3} + \\ldots}"
-         (->TeX (series/power-series 'i 'j 'k 'l 'm 'n)))))
+  (is (= "1 + 2 x + 3 x² + 4 x³ + ..."
+         (->infix ((series/power-series 1 2 3 4) 'x))))
+  (is (= "1 + 2\\,x + 3\\,{x}^{2} + 4\\,{x}^{3} + \\ldots"
+         (->TeX ((series/power-series 1 2 3 4) 'x)))))
 
 (defn ^:private make-symbol-generator
   [p]

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -200,7 +200,7 @@
          (->TeX (+ 'k (series/exp-series 1)))))
   (is (= "1 _⁰ + 2 _¹ + 3 _² + 4 _³ + ..."
          (->infix (series/power-series 1 2 3 4))))
-  (is (= "1\\,{_}^{0} + 2\\,{_}^{1} + 3\\,{_}^{2} + 4\\,{_}^{3} + \\ldots"
+  (is (= "1\\,{\\_}^{0} + 2\\,{\\_}^{1} + 3\\,{\\_}^{2} + 4\\,{\\_}^{3} + \\ldots"
          (->TeX (series/power-series 1 2 3 4))))
   (is (= "1 + 2 x + 3 x² + 4 x³ + ..."
          (->infix ((series/power-series 1 2 3 4) 'x))))

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -189,6 +189,16 @@
   (binding [sicmutils.expression.render/*TeX-sans-serif-symbols* false]
     (is (= "{PV}" (->TeX 'PV)))))
 
+(deftest series-tests
+  (is (= "{1 + 1 + \\frac{1}{2} + \\frac{1}{6} + \\ldots}"
+         (->TeX (series/exp-series 1))))
+  (is (= "{1 + a + \\frac{1}{2}\\,{a}^{2} + \\frac{1}{6}\\,{a}^{3} + \\ldots}"
+         (->TeX (series/exp-series 'a))))
+  (is (= "{1\\,{x}^{0} + 2\\,{x}^{1} + 3\\,{x}^{2} + 4\\,{x}^{3} + \\ldots}"
+         (->TeX (series/power-series 1 2 3 4))))
+  (is (= "{i\\,{x}^{0} + j\\,{x}^{1} + k\\,{x}^{2} + l\\,{x}^{3} + \\ldots}"
+         (->TeX (series/power-series 'i 'j 'k 'l 'm 'n)))))
+
 (defn ^:private make-symbol-generator
   [p]
   (let [i (atom 0)]


### PR DESCRIPTION
`sicmutils.render/->TeX` will render `Series` and `PowerSeries` as an infinite series (showing the first four terms). In the case of `PowerSeries`, it will default to `ax^n`.