### PR TITLE
Add missing generic methods to env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Install `sicmutils.generic/{quotient,modulo,remainder,partial-derivative}`
+  into `sicmutils.env` (#273). Thanks to @pangloss for pointing out that these
+  were missing!
+
 - Add a proper namespace to `demo.clj`, to make it easier to use outside of
   `lein repl` (#264).
 

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -194,53 +194,33 @@
  [sicmutils.operator commutator]
  [sicmutils.series binomial-series partial-sums]
  [sicmutils.generic
-  * + - /
-  abs
-  square
-  cube
-  exp exp2 exp10
-  expt
-  invert
-  log log2 log10
+  * + - / divide
   negate
-  simplify
+  negative?
+  invert
+  abs
   sqrt
+  quotient remainder modulo
+  expt
+  exp exp2 exp10
+  log log2 log10
   gcd lcm
-  cos
-  sin
-  tan
-  acos
-  asin
-  atan
-  cosh
-  sinh
-  cot
-  sec
-  csc
-  tanh
-  sech
-  csch
-  acosh
-  asinh
-  atanh
-  dimension
-  transpose
-  trace
-  determinant
-  dot-product
-  inner-product
-  outer-product
-  cross-product
-  make-rectangular
-  make-polar
-  real-part
-  imag-part
-  magnitude
-  angle
-  conjugate
-  Lie-derivative
-  factorial
-  quotient modulo remainder partial-derivative]
+  exact-divide
+  square cube
+  cos sin tan
+  acos asin atan
+  cosh sinh tanh
+  acosh asinh atanh
+  sec csc cot
+  sech csch
+  make-rectangular make-polar
+  real-part imag-part
+  magnitude angle conjugate
+  transpose trace determinant dimension
+  dot-product inner-product outer-product cross-product
+  partial-derivative Lie-derivative
+  simplify
+  factorial]
  [sicmutils.structure
   compatible-shape
   down

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -225,6 +225,7 @@
   atanh
   dimension
   transpose
+  trace
   determinant
   dot-product
   inner-product
@@ -238,7 +239,8 @@
   angle
   conjugate
   Lie-derivative
-  factorial]
+  factorial
+  quotient modulo remainder partial-derivative]
  [sicmutils.structure
   compatible-shape
   down


### PR DESCRIPTION
Addresses #272 (thanks @pangloss for reporting this!) by adding missing `sicmutils.generic` methods to the `env` namespace.

CHANGELOG:

- Install `sicmutils.generic/{quotient,modulo,remainder,partial-derivative}`
   into `sicmutils.env` (#273). Thanks to @pangloss for pointing out that these
   were missing!