### PR TITLE
Alias docstrings in aliased defs in sicmutils.env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+- #279: Function aliases in `sicmutils.env` now properly mirror over docstrings
+  and other `Var` metadata, thanks to
+  [Potemkin](https://github.com/clj-commons/potemkin)'s `import-def`. This
+  doesn't quite work in Clojurescript since we can't use `resolve` inside of a
+  macro (special form!).
+
 - Install `sicmutils.generic/{quotient,modulo,remainder,partial-derivative}`
   into `sicmutils.env` (#273). Thanks to @pangloss for pointing out that these
   were missing!

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -40,8 +40,8 @@
   (:refer-clojure :rename {ref core-ref
                            partial core-partial
                            compare core-compare}
-                  :exclude [+ - * / zero? compare #?(:cljs partial)])
-  (:require #?(:clj [potemkin :refer [import-vars]])
+                  :exclude [+ - * / zero? compare divide #?(:cljs partial)])
+  (:require #?(:clj [potemkin :refer [import-def import-vars]])
             #?(:clj [nrepl.middleware.print])
             [sicmutils.abstract.function :as af #?@(:cljs [:include-macros true])]
             [sicmutils.abstract.number :as an]
@@ -55,7 +55,9 @@
             [sicmutils.value :as v]
             [sicmutils.matrix :as matrix]
             [sicmutils.series :as series]
-            [sicmutils.util :as u #?@(:cljs [:refer-macros [import-vars]])]
+            [sicmutils.util :as u
+             #?@(:cljs [:refer [import-def import-vars]
+                        :include-macros true])]
             [sicmutils.util.aggregate]
             [sicmutils.util.stream :as us]
             [sicmutils.numerical.derivative]
@@ -112,7 +114,7 @@
 (defmacro using-coordinates [& args]
   `(cc/using-coordinates ~@args))
 
-(def print-expression simp/print-expression)
+(import-def simp/print-expression)
 
 (defn ref
   "A shim so that ref can act like nth in SICM contexts, as clojure core ref
@@ -153,27 +155,30 @@
 
 ;; Constants
 
-(def pi Math/PI)
-(def -pi (g/- Math/PI))
+(def ^{:doc "The mathematical constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
+  pi Math/PI)
+(def ^{:doc "The negation of the mathematical
+constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
+  -pi (g/- Math/PI))
 
-(def s:generate structure/generate)
-(def m:generate matrix/generate)
-(def v:make-basis-unit structure/basis-unit)
-(def qp-submatrix #(matrix/without % 0 0))
-(def matrix-by-rows matrix/by-rows)
-(def matrix-by-cols matrix/by-cols)
-(def row-matrix matrix/row)
-(def column-matrix matrix/column)
+(import-def structure/generate s:generate)
+(import-def matrix/generate m:generate)
+(import-def structure/basis-unit v:make-basis-unit)
 
-(def principal-value v/principal-value)
+(import-def matrix/by-rows matrix-by-rows)
+(import-def matrix/by-cols matrix-by-cols)
+(import-def matrix/row row-matrix)
+(import-def matrix/column column-matrix)
 
-(def series series/series)
-(def power-series series/power-series)
-(def constant-series series/constant)
-(def series:sum series/sum)
+(import-def v/principal-value principal-value)
 
-(def seq:print us/seq-print)
-(def seq:pprint us/pprint)
+(import-def series/series series)
+(import-def series/power-series power-series)
+(import-def series/constant constant-series)
+(import-def series/sum series:sum)
+
+(import-def us/seq-print seq:print)
+(import-def us/pprint seq:pprint)
 
 (defn tex$
   "Returns a string containing a LaTeX representation of `expr`, wrapped in single
@@ -339,6 +344,7 @@
   momentum-tuple
   polar-canonical
   standard-map
+  qp-submatrix
   symplectic-transform?
   symplectic-unit
   time-independent-canonical?]

--- a/src/sicmutils/mechanics/hamilton.cljc
+++ b/src/sicmutils/mechanics/hamilton.cljc
@@ -206,15 +206,18 @@
         J (symplectic-unit (quot twoN 2))]
     (- J (* M J (matrix/transpose M)))))
 
+(defn qp-submatrix [m]
+  (matrix/without m 0 0))
+
 (defn symplectic-transform?
   "p. 334"
   [C]
   (fn [s]
     (symplectic-matrix?
-     (matrix/without
+     (qp-submatrix
       (matrix/s->m (s/compatible-shape s)
                    ((D C) s)
-                   s) 0 0))))
+                   s)))))
 
 (defn ^:private Hamiltonian-Lie-derivative
   "p. 428"

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -44,15 +44,16 @@
               (swap! count inc)
               (f x))])))
 
-(defmacro import-def
-  "import a single fn or var:
+(declare illegal)
 
-  ```clojure
-  (import-def a b) => (def b a/b)
-  ```"
-  [from-ns def-name]
-  (let [from-sym# (symbol (str from-ns) (str def-name))]
-    `(def ~def-name ~from-sym#)))
+(defmacro import-def
+  "Given a regular def'd var from another namespace, defined a new var with the
+   same name in the current namespace.."
+  ([sym]
+   `(import-def ~sym nil))
+  ([sym var-name]
+   (let [n (or var-name (symbol (name sym)))]
+     `(def ~n ~sym))))
 
 (defmacro import-vars
   "import multiple defs from multiple namespaces. works for vars and fns. not
@@ -69,12 +70,13 @@
     ...
    (def d m.n.ns2/d)
     ... etc
-  ```
-  "
+  ```"
   [& imports]
   (let [expanded-imports (for [[from-ns & defs] imports
-                               d defs]
-                           `(import-def ~from-ns ~d))]
+                               d defs
+                               :let [sym (symbol (str from-ns)
+                                                 (str d))]]
+                           `(def ~d ~sym))]
     `(do ~@expanded-imports)))
 
 (def compute-sqrt #?(:clj nt/sqrt :cljs Math/sqrt))

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -44,8 +44,6 @@
               (swap! count inc)
               (f x))])))
 
-(declare illegal)
-
 (defmacro import-def
   "Given a regular def'd var from another namespace, defined a new var with the
    same name in the current namespace.."

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -46,7 +46,16 @@
 
 (defmacro import-def
   "Given a regular def'd var from another namespace, defined a new var with the
-   same name in the current namespace.."
+   same name in the current namespace.
+
+  This macro is modeled after `potemkin.namespaces/import-def` but meant to be
+  usable from Clojurescript. In Clojurescript, it's not possible to:
+
+  - alter the metadata of a var after definition
+  - call `resolve` at macro-time
+
+  And therefore not possible to mirror the metadata from one var to another.
+  This simplified version therefore suffices in the cljs case."
   ([sym]
    `(import-def ~sym nil))
   ([sym var-name]

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -31,11 +31,9 @@
                            compare core-compare}
                   #?@(:cljs [:exclude [zero? number? = compare]]))
   (:require [sicmutils.util :as u]
-            #?(:clj [potemkin :refer [import-def]])
-            #?@(:cljs
-                [[goog.array :as garray]
-                 [goog.math.Long]
-                 [goog.math.Integer]]))
+            #?@(:cljs [[goog.array :as garray]
+                       [goog.math.Long]
+                       [goog.math.Integer]]))
   #?(:clj
      (:import (clojure.lang BigInt PersistentVector Sequential Symbol))))
 

--- a/test/sicmutils/env_test.cljc
+++ b/test/sicmutils/env_test.cljc
@@ -30,6 +30,7 @@
                                          cross-product
                                          cot csc sec]
              #?@(:cljs [:include-macros true])]
+            [sicmutils.matrix :as matrix]
             [sicmutils.operator :as o]))
 
 (deftest partial-shim
@@ -82,6 +83,15 @@
              (simplify (f5 (down 'p_x 'p_y))))))))
 
 (deftest shortcuts
+  (testing "env aliases alias the actual object from the original namespace"
+    (is (= matrix/by-rows
+           e/matrix-by-rows)))
+
+  #?(:clj
+     (testing "aliases keep metadata from original var. Only works in Clojure."
+       (is (= (meta #'matrix/by-rows)
+              (meta #'e/matrix-by-rows)))))
+
   (testing "cot"
     (is (= '(/ (cos x) (sin x)) (simplify (cot 'x))))
     (is (= '(/ 1 (sin x)) (simplify (csc 'x))))


### PR DESCRIPTION
From the CHANGELOG:

- Function aliases in `sicmutils.env` now properly mirror over docstrings
  and other `Var` metadata, thanks to
  [Potemkin](https://github.com/clj-commons/potemkin)'s `import-def`. This
  doesn't quite work in Clojurescript since we can't use `resolve` inside of a
  macro (special form!).