### PR TITLE
Add optional :equation (and label) arguments to render/->TeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+- #280 adds a new `:equation` keyword argument to `sicmutils.render/->TeX`. If
+  you pass a truthy value to `:equation`, the result will be wrapped in an
+  equation environment. `:equation <string>` will insert a `\\label{<string>}`
+  entry inside the equation environment.
+
+    - `sicmutils.env/->tex-equation` is identical to `#(sicmutils.render/->TeX
+      (g/simplify %) :equation true)`; If you pass a `:label` keyword argument
+      to `->tex-equation` it will be forwarded to `->TeX`, creating the expected
+      label entry.
+
 - #279: Function aliases in `sicmutils.env` now properly mirror over docstrings
   and other `Var` metadata, thanks to
   [Potemkin](https://github.com/clj-commons/potemkin)'s `import-def`. This

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -192,6 +192,15 @@ constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   [expr]
   (str "$$" (-> expr g/simplify render/->TeX) "$$"))
 
+(defn ->tex-equation
+  "Returns a string containing a LaTeX representation of `expr`, wrapped in an
+  `equation` environment.
+
+  Optionally supply a `:label` keyword argument to set a custom label."
+  [expr & {:keys [label]}]
+  (-> (g/simplify expr)
+      (render/->TeX :equation (or label true))))
+
 (import-vars
  [sicmutils.abstract.number literal-number]
  [sicmutils.complex complex]

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -317,7 +317,8 @@
 (def ^:no-doc ->TeX*
   (let [TeX-accent (fn [accent]
                      (fn [[_ stem]]
-                       (str "\\" accent " " (maybe-brace (->TeX stem)))))
+                       (str "\\" accent " " (maybe-brace
+                                             (->TeX* stem)))))
         dot (TeX-accent "dot")
         ddot (TeX-accent "ddot")
         hat (TeX-accent "hat")
@@ -360,7 +361,7 @@
       '<= #(s/join " \\leq " %)
       '>= #(s/join " \\geq " %)}
      :render-primitive
-     (fn [v]
+     (fn r [v]
        (cond (r/ratio? v)
              (str "\\frac" (brace (r/numerator v)) (brace (r/denominator v)))
 
@@ -404,16 +405,17 @@
     (println
       (->TeX expr :equation \"label!\")))
 
-  \begin{equation}
-  \label{label!}
+  \\begin{equation}
+  \\label{label!}
   x + y
-  \end{equation}
+  \\end{equation}
   ```
   "
   [expr & {:keys [equation]}]
   (let [tex-string (->TeX* expr)]
     (if equation
-      (let [label (if (string? equation)
+      (let [label (if (and (string? equation)
+                           (not (empty? equation)))
                     (str "\\label{" equation "}\n")
                     "")]
         (str "\\begin{equation}\n"

--- a/test/sicmutils/env_test.cljc
+++ b/test/sicmutils/env_test.cljc
@@ -68,6 +68,23 @@
          (is (= [99] (dosync (alter r conj 99))))
          (is (= {:b 88} (dosync (alter s assoc :b 88))))))))
 
+(deftest tex-tests
+  (testing "inline and block tex environments"
+    (is (= "$x+y$" (e/tex$ (+ 'x 'y))))
+    (is (= "$$x+y$$" (e/tex$$ (+ 'x 'y)))))
+
+  (testing "tex equation environment"
+    (is (= (str "\\begin{equation}\n"
+                "x + y\n"
+                "\\end{equation}")
+           (e/->tex-equation (+ 'x 'y))))
+
+    (is (= (str "\\begin{equation}\n"
+                "\\label{face}\n"
+                "x + y\n"
+                "\\end{equation}")
+           (e/->tex-equation (+ 'x 'y) :label "face")))))
+
 (deftest literal-function-shim
   (testing "works for signatures"
     (let [f1 (literal-function 'f)

--- a/test/sicmutils/env_test.cljc
+++ b/test/sicmutils/env_test.cljc
@@ -70,8 +70,8 @@
 
 (deftest tex-tests
   (testing "inline and block tex environments"
-    (is (= "$x+y$" (e/tex$ (+ 'x 'y))))
-    (is (= "$$x+y$$" (e/tex$$ (+ 'x 'y)))))
+    (is (= "$x + y$" (e/tex$ (+ 'x 'y))))
+    (is (= "$$x + y$$" (e/tex$$ (+ 'x 'y)))))
 
   (testing "tex equation environment"
     (is (= (str "\\begin{equation}\n"

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -183,6 +183,25 @@
   (is (= "4 \\geq 2 + 2 \\geq 1 + 3"
          (->TeX '(>= 4 (+ 2 2) (+ 1 3))))))
 
+(deftest equation-wrapper-tests
+  (is (= (str "\\begin{equation}\n"
+              "x + y\n"
+              "\\end{equation}")
+         (->TeX (g/+ 'x 'y) :equation true)
+         (->TeX (g/+ 'x 'y) :equation 5)
+         (->  (g/+ 'x 'y)
+              (->TeX :equation "")))
+      "truthy (including empty-string) :equation option wraps the result in an
+      equation environment.")
+
+  (is (= (str "\\begin{equation}\n"
+              "\\label{label}\n"
+              "x + y\n"
+              "\\end{equation}")
+         (->TeX (g/+ 'x 'y)
+                :equation "label"))
+      "Supplying a non-empty string triggers a label."))
+
 (deftest symbol-rendering-tests
   (is (= "x" (->TeX 'x)))
   (is (= "\\mathsf{PV}" (->TeX 'PV)))


### PR DESCRIPTION
This PR gives `->TeX` the ability to emit its form wrapped in an equation environment; optionally, the user can set a label.

From the CHANGELOG:

- #280 adds a new `:equation` keyword argument to `sicmutils.render/->TeX`. If
  you pass a truthy value to `:equation`, the result will be wrapped in an
  equation environment. `:equation <string>` will insert a `\\label{<string>}`
  entry inside the equation environment.

    - `sicmutils.env/->tex-equation` is identical to `#(sicmutils.render/->TeX %
      :equation true)`; If you pass a `:label` keyword argument to
      `->tex-equation` it will be forwarded to `->TeX`, creating the expected
      label entry.