### PR TITLE
prime, primeprime TeX rendering, change down to vertical by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+- #283 changes the default `TeX` rendering style for `down` tuples to vertical
+  vs horizontal.
+
+- Symbols like `'qprime` ending with `prime` or `primeprime` will render as `q'`
+  or `q''` respectively in `TeX`, rather than the fully-spelled-out
+  `\mathsf{qprime}` (#282).
+
 - #280 adds a new `:equation` keyword argument to `sicmutils.render/->TeX`. If
   you pass a truthy value to `:equation`, the result will be wrapped in an
   equation environment. `:equation <string>` will insert a `\\label{<string>}`

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -303,8 +303,8 @@
 
 (def ^{:dynamic true
        :doc "If true, [[->TeX]] will render down tuples as vertical matrices
-  with square braces. Defaults to false."}
-  *TeX-vertical-down-tuples* false)
+  with square braces. Defaults to true."}
+  *TeX-vertical-down-tuples* true)
 
 (def ^{:dynamic true
        :doc "If true, [[->TeX]] will render symbols with more than 1 character
@@ -319,12 +319,19 @@
                      (fn [[_ stem]]
                        (str "\\" accent " " (maybe-brace
                                              (->TeX* stem)))))
-        dot (TeX-accent "dot")
-        ddot (TeX-accent "ddot")
-        hat (TeX-accent "hat")
-        bar (TeX-accent "bar")
-        vec (TeX-accent "vec")
-        tilde (TeX-accent "tilde")]
+        dot   (TeX-accent "dot")
+        ddot  (TeX-accent "ddot")
+        hat   (TeX-accent "hat")
+        bar   (TeX-accent "bar")
+        vec   (TeX-accent "vec")
+        tilde (TeX-accent "tilde")
+        prime (fn [[_ stem]]
+                (let [x (maybe-brace (->TeX* stem))]
+                  (str x "^\\prime")))
+        primeprime
+        (fn [[_ stem]]
+          (let [x (maybe-brace (->TeX* stem))]
+            (str x "^{\\prime\\prime}")))]
     (make-infix-renderer
      ;; here we set / to a very low precedence because the fraction bar we will
      ;; use in the rendering groups things very strongly.
@@ -378,6 +385,8 @@
                              #"(.+)dotdot$" :>> ddot
                              #"(.+)dot$" :>> dot
                              #"(.+)hat$" :>> hat
+                             #"(.+)primeprime$" :>> primeprime
+                             #"(.+)prime$" :>> prime
                              #"(.+)bar$" :>> bar
                              #"(.+)vec$" :>> vec
                              #"(.+)tilde$" :>> tilde

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -116,10 +116,44 @@
 (deftest structures
   (is (= "down(up(1, 2), up(3, 4))"
          (->infix (g/simplify
-                   (down (up 1 2) (up 3 4)))))))
+                   (down (up 1 2) (up 3 4))))))
+
+  (testing "customizable down tuple rendering in TeX"
+    (is (= (str "\\begin{bmatrix}\\"
+                "displaystyle{1} \\cr \\cr "
+                "\\displaystyle{2} \\cr \\cr "
+                "\\displaystyle{3}"
+                "\\end{bmatrix}")
+           (->TeX (down 1 2 3)))
+        "Downs render vertically by default")
+
+    (binding [r/*TeX-vertical-down-tuples* false]
+      (is (= (str "\\begin{bmatrix}"
+                  "\\displaystyle{1}&\\displaystyle{2}&\\displaystyle{3}"
+                  "\\end{bmatrix}")
+             (->TeX (down 1 2 3)))
+          "bind the dynamic variable falsey to get horz down tuples."))))
 
 (deftest variable-subscripts
   (is (= "x₀ + y₁ + z₂" (->infix (+ 'x_0 'y_1 'z_2)))))
+
+(deftest accent-tests
+  (testing "various accents and special exponents in TeX"
+    (is (= (str "\\begin{pmatrix}"
+                "\\displaystyle{\\dot q} \\cr \\cr "
+                "\\displaystyle{\\dot {qd}} \\cr \\cr "
+                "\\displaystyle{\\hat {vz}} \\cr \\cr "
+                "\\displaystyle{\\bar {cake}} \\cr \\cr "
+                "\\displaystyle{\\vec x} \\cr \\cr "
+                "\\displaystyle{\\tilde {zcake}} \\cr \\cr "
+                "\\displaystyle{q^\\prime} \\cr \\cr "
+                "\\displaystyle{{xx}^{\\prime\\prime}}"
+                "\\end{pmatrix}")
+           (->TeX (up 'qdot 'qddot
+                      'vzhat 'cakebar
+                      'xvec
+                      'zcaketilde
+                      'qprime 'xxprimeprime))))))
 
 (deftest ratio-tests
   (testing "one-arg / == inverse"


### PR DESCRIPTION
I'm changing the default down tuple rendering to match scmutils style because a lot of the exercises from SICM end up being ULTRA wide if we render them this way. I think the square braces are already a nice touch. @littleredcomputer , I know you made a deliberate choice to _not_ do this, so I'm submitting this to you for judgement!

I also added missing handling for `prime` and `primeprime` suffixed symbols.

`scmutils` does nothing special for `'qprimeprimeprime`, while this implementation nests exponents. I am bad / uneducated with regexes... anyone have a suggestion for how to match >1 instances of `"prime"`, ending with newline, and do the right thing in the renderer?

From the CHANGELOG:

- #283 changes the default `TeX` rendering style for `down` tuples to vertical
  vs horizontal.

- Symbols like `'qprime` ending with `prime` or `primeprime` will render as `q'`
  or `q''` respectively in `TeX`, rather than the fully-spelled-out
  `\mathsf{qprime}` (#282).