### PR TITLE
Generalize F->C, add more accessors to mechanics.lagrange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+- #284 added:
+
+  - new functions `sicmutils.mechanics.lagrange/acceleration-tuple` for creating
+    the acceleration entry in a local tuple
+
+  - `sicmutils.mechanics.lagrange/acceleration` for extracting the acceleration
+    component of a local tuple
+
+  - An upgraded `sicmutils.mechanics.lagrange/F->C` to handle local tuples of
+    arbitrary length. This version of `F->C` is more general than the version
+    from the textbook that was previously included.
+
+  - These are all aliased in `sicmutils.env`, along with a new `Γ-bar` alias for
+    `sicmutils.mechanics.lagrange/Γ-bar`.
+
 - #280 adds a new `:equation` keyword argument to `sicmutils.render/->TeX`. If
   you pass a truthy value to `:equation`, the result will be wrapped in an
   equation environment. `:equation <string>` will insert a `\\label{<string>}`

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -307,25 +307,21 @@ constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   ->local
   Euler-Lagrange-operator
   F->C
-  Gamma
-  Gamma-bar
+  Gamma Γ
+  Gamma-bar Γ-bar
   Lagrange-equations
   Lagrange-equations-first-order
   Lagrange-interpolation-function
   Lagrangian->energy
   Lagrangian->state-derivative
   Lagrangian-action
-  coordinate
-  coordinate-tuple
   find-path
   linear-interpolants
   osculating-path
   p->r
   s->r
-  velocity
-  velocity-tuple
-  state->t
-  Γ]
+  state->t coordinate velocity acceleration
+  coordinate-tuple velocity-tuple acceleration-tuple]
  [sicmutils.matrix
   s->m
   m->s

--- a/src/sicmutils/mechanics/hamilton.cljc
+++ b/src/sicmutils/mechanics/hamilton.cljc
@@ -28,9 +28,7 @@
             [sicmutils.util :as u]
             [sicmutils.value :as v]))
 
-(defn momentum-tuple
-  [& ps]
-  (apply down ps))
+(def momentum-tuple down)
 
 (defn momentum
   "See coordinate: this returns the momentum element of a

--- a/test/sicmutils/mechanics/lagrange_test.cljc
+++ b/test/sicmutils/mechanics/lagrange_test.cljc
@@ -74,14 +74,28 @@
       (is (= 'a (g/simplify (f 'w)))))))
 
 (deftest misc
+  (let [local (up 't
+                  (L/coordinate-tuple 'x 'y)
+                  (L/velocity-tuple 'xdot 'ydot)
+                  (L/acceleration-tuple 'xdotdot 'ydotdot))]
+    (testing "constructors and accessors round-trip"
+      (is (= (up 'x 'y)
+             (L/coordinate local)))
+      (is (= (up 'xdot 'ydot)
+             (L/velocity local)))
+      (is (= (up 'xdotdot 'ydotdot)
+             (L/acceleration local)))))
+
   (let [vs (L/velocity-tuple
             (L/velocity-tuple 'vx1 'vy1)
             (L/velocity-tuple 'vx2 'vy2))
         L1 (fn [[v1 v2]]
              (g/+ (g/* (/ 1 2) 'm1 (g/square v1))
                   (g/* (/ 1 2) 'm2 (g/square v2))))]
-    (is (= '(down (down (down (down m1 0) (down 0 0)) (down (down 0 m1) (down 0 0)))
-                  (down (down (down 0 0) (down m2 0)) (down (down 0 0) (down 0 m2))))
+    (is (= '(down (down (down (down m1 0) (down 0 0))
+                        (down (down 0 m1) (down 0 0)))
+                  (down (down (down 0 0) (down m2 0))
+                        (down (down 0 0) (down 0 m2))))
            (g/simplify (((g/expt D 2) L1) vs))))
     (is (= '(matrix-by-rows [m1 0 0 0]
                             [0 m1 0 0]
@@ -165,9 +179,25 @@
                            (up r φ))
                           't))))
 
-      (is (= '(up (+ (* -1 r φdot (sin φ)) (* rdot (cos φ)))
-                  (+ (* r φdot (cos φ)) (* rdot (sin φ))))
-             (g/simplify
-              (L/velocity
-               ((L/F->C L/p->r)
-                (L/->local 't (up 'r 'φ) (up 'rdot 'φdot))))))))))
+      (testing "F->C correctly transforms local tuples of any arity you supply"
+        (is (= '(up t
+                    (up (* r (cos φ))
+                        (* r (sin φ)))
+                    (up (+ (* -1 r φdot (sin φ))
+                           (* rdot (cos φ)))
+                        (+ (* r φdot (cos φ))
+                           (* rdot (sin φ))))
+                    (up (+ (* -1 r (expt φdot 2) (cos φ))
+                           (* -1 r φdotdot (sin φ))
+                           (* -2 rdot φdot (sin φ))
+                           (* rdotdot (cos φ)))
+                        (+ (* -1 r (expt φdot 2) (sin φ))
+                           (* r φdotdot (cos φ))
+                           (* 2 rdot φdot (cos φ))
+                           (* rdotdot (sin φ)))))
+               (g/simplify
+                ((L/F->C L/p->r)
+                 (L/->local 't
+                            (up 'r 'φ)
+                            (up 'rdot 'φdot)
+                            (up 'rdotdot 'φdotdot))))))))))


### PR DESCRIPTION
From the CHANGELOG:

- #284 added:

  - new functions `sicmutils.mechanics.lagrange/acceleration-tuple` for creating
    the acceleration entry in a local tuple

  - `sicmutils.mechanics.lagrange/acceleration` for extracting the acceleration
    component of a local tuple

  - An upgraded `sicmutils.mechanics.lagrange/F->C` to handle local tuples of
    arbitrary length. This version of `F->C` is more general than the version
    from the textbook that was previously included.

  - These are all aliased in `sicmutils.env`, along with a new `Γ-bar` alias for
    `sicmutils.mechanics.lagrange/Γ-bar`.