### PR TITLE
Add Peek reference, fix github workflow issue on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release to Clojars
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   release:

--- a/doc/faq.adoc
+++ b/doc/faq.adoc
@@ -12,7 +12,7 @@
   https://kloimhardt.github.io/cljtiles.html?page=freeparticle[this demo] for a
   lovely example of Lagrangian Mechanics in ``clj-tiles``.
 
-- @light-matters and @MagusMachine are collaborating on
+- @light-matters and @MagusMachinae are collaborating on
   [Peek](https://gitlab.com/LightMatters/peek): "A Clojure implementation of
   symbolic quantum mechanics, or, as it could be called, measurement mechanics.
   The current name reflects my idea of one of the, if not most, distinguishing

--- a/doc/faq.adoc
+++ b/doc/faq.adoc
@@ -11,3 +11,9 @@
   https://github.com/kloimhardt/clj-tiles[clj-tiles]. See
   https://kloimhardt.github.io/cljtiles.html?page=freeparticle[this demo] for a
   lovely example of Lagrangian Mechanics in ``clj-tiles``.
+
+- @light-matters and @MagusMachine are collaborating on
+  [Peek](https://gitlab.com/LightMatters/peek): "A Clojure implementation of
+  symbolic quantum mechanics, or, as it could be called, measurement mechanics.
+  The current name reflects my idea of one of the, if not most, distinguishing
+  features of quantum mechanics: that observation changes the result."

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  :exclusions [org.clojure/clojurescript]])
 
 (defproject sicmutils "0.15.0"
-  :description "A port of the Scmutils computer algebra/mechanics system to Clojure"
+  :description "A port of the Scmutils computer algebra/mechanics system to Clojure."
   :url "http://github.com/sicmutils/sicmutils"
   :scm {:name "git" :url "https://github.com/sicmutils/sicmutils"}
   :license {:name "GPLv3"


### PR DESCRIPTION
The "publish" action wasn't triggering because I had the event wrong! I've fixed that and added a reference to Peek from @light-matters and @MagusMachinae.