### PR TITLE
fix comparison between Literal and non-literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+- #292 fixes a `StackOverflow` that would sometimes appear when comparing
+  symbolic expressions to non-expressions. `(= (literal-number x) y)` now
+  returns true if `(= x y)` (AND if `y` is not a collection!), false otherwise.
+  #255 is currently blocking pass-through equality with collections. Thanks to
+  @daslu for the report here!
+
 - #289 adds many namespaces to `sicmutils.env.sci`:
 
   - `sicmutils.{complex,expression,modint,numsymb,polynomial,ratio,rational-function,util,value}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 - #292 fixes a `StackOverflow` that would sometimes appear when comparing
   symbolic expressions to non-expressions. `(= (literal-number x) y)` now
-  returns true if `(= x y)` (AND if `y` is not a collection!), false otherwise.
-  #255 is currently blocking pass-through equality with collections. Thanks to
-  @daslu for the report here!
+  returns true if `(= x y)` (AND, in clj, if `y` is not a collection!), false
+  otherwise. #255 is currently blocking pass-through equality with collections
+  on the JVM. Thanks to @daslu for the report here!
 
 - #289 adds many namespaces to `sicmutils.env.sci`:
 

--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -86,7 +86,7 @@
                  (and (= type (.-type b))
                       (= expression (.-expression b))
                       (= m (.-m b))))
-               (v/= a b))))
+               (v/= expression b))))
 
   #?@(:clj
       [IObj
@@ -113,7 +113,7 @@
                    (and (= type (.-type b))
                         (= expression (.-expression b))
                         (= m (.-m b))))
-                 (v/= a b)))
+                 (v/= expression b)))
 
        IComparable
        (-compare [a b]

--- a/test/sicmutils/expression_test.cljc
+++ b/test/sicmutils/expression_test.cljc
@@ -19,6 +19,9 @@
 
 (ns sicmutils.expression-test
   (:require [clojure.test :refer [is deftest testing]]
+            [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]
+             #?@(:cljs [:include-macros true])]
             [sicmutils.abstract.number :as an]
             [sicmutils.expression :as e]
             [sicmutils.generic :as g]
@@ -61,12 +64,25 @@
     (is (e/abstract?
          (an/literal-number 12))))
 
+  (checking "(= expr non-expr) compares non-expr against internally captured
+    expression" 100
+            [x gen/any-equatable]
+            (if (coll? x)
+              (is (not= (an/literal-number x) x)
+                  "expressions don't support `seq`, so can't compare against
+                  proper collections. ")
+              (is (= (an/literal-number x) x)
+                  "Anything else's equality passes through."))
+
+            (is (zero? (compare (an/literal-number x) x))
+                "comparison properly passes through."))
+
   (testing "metadata support"
     (let [m {:real? true :latex! "face"}]
       (is (not= (e/make-literal ::blah 12)
                 (-> (e/make-literal ::blah 12)
                     (with-meta m)))
-          "Metadata currently affects equality.")
+          "Metadata affects equality")
 
       (is (= m (meta
                 (-> (e/make-literal ::blah 12)

--- a/test/sicmutils/expression_test.cljc
+++ b/test/sicmutils/expression_test.cljc
@@ -68,14 +68,16 @@
     expression" 100
             [x gen/any-equatable]
             (if (coll? x)
-              (is (not= (an/literal-number x) x)
-                  "expressions don't support `seq`, so can't compare against
-                  proper collections. ")
+              (is (#?(:clj not= :cljs =)
+                   (an/literal-number x) x)
+                  "in CLJ, expressions don't support `seq`, so can't compare
+                  against proper collections. Not so in CLJS!")
               (is (= (an/literal-number x) x)
                   "Anything else's equality passes through."))
 
-            (is (zero? (compare (an/literal-number x) x))
-                "comparison properly passes through."))
+            (when #?(:clj true :cljs (instance? IComparable x))
+              (is (zero? (compare (an/literal-number x) x))
+                  "comparison properly passes through.")))
 
   (testing "metadata support"
     (let [m {:real? true :latex! "face"}]


### PR DESCRIPTION
This PR addresses the issue @daslu raised in #291.

From the CHANGELOG:

- #292 fixes a `StackOverflow` that would sometimes appear when comparing
  symbolic expressions to non-expressions. `(= (literal-number x) y)` now
  returns true if `(= x y)` (AND if `y` is not a collection!), false otherwise.
  #255 is currently blocking pass-through equality with collections. Thanks to
  @daslu for the report here!