### PR TITLE
rendering impls for floor, ceil, integer-part, fractional-part, modulo, remainder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+- #278 adds new generic `floor`, `ceiling`, `integer-part` and `fractional-part`
+  generic functions, along with:
+
+  - implementations for all types in the numeric tower - ratios, integers,
+    reals, complex
+  - symbolic expression implementations
+  - symbolic implementations for `modulo` and `remainder`
+  - new support for these four generics plus `modulo` and `remainder` in
+    function compilation via `sicmutils.expression.compile` (#295)
+  - rendering support by `->infix`, `->TeX`, `->Javascript` (#295)
+
+  Thank you to @pangloss for this major contribution!
+
 - #292 fixes a `StackOverflow` that would sometimes appear when comparing
   symbolic expressions to non-expressions. `(= (literal-number x) y)` now
   returns true if `(= x y)` (AND, in clj, if `y` is not a collection!), false

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -156,9 +156,11 @@
 (defmethod g/simplify [::complex] [a] (v/freeze a))
 
 (defmethod g/integer-part [::complex] [^Complex a]
-  (complex
-   (g/integer-part (#?(:clj .getReal :cljs .-re) a))
-   (g/integer-part (#?(:clj .getImaginary :cljs .-im) a))))
+  (let [re (g/integer-part (#?(:clj .getReal :cljs .-re) a))
+        im (g/integer-part (#?(:clj .getImaginary :cljs .-im) a))]
+    (if (v/zero? im)
+      re
+      (complex re im))))
 
 (defmethod g/fractional-part [::complex] [^Complex a]
   (complex
@@ -183,11 +185,18 @@
 #?(:clj
    (do
      (defmethod g/floor [::complex] [^Complex a]
-       (complex (g/floor (.getReal a))
-                (g/floor (.getImaginary a))))
+       (let [re (g/floor (.getReal a))
+             im (g/floor (.getImaginary a))]
+         (if (v/zero? im)
+           re
+           (complex re im))))
+
      (defmethod g/ceiling [::complex] [^Complex a]
-       (complex (g/ceiling (.getReal a))
-                (g/ceiling (.getImaginary a))))
+       (let [re (g/ceiling (.getReal a))
+             im (g/ceiling (.getImaginary a))]
+         (if (v/zero? im)
+           re
+           (complex re im))))
 
      (defmethod g/sub [::complex ::complex] [^Complex a ^Complex b] (.subtract a b))
      (defmethod g/sub [::complex ::v/real] [^Complex a n] (.subtract a (double n)))

--- a/src/sicmutils/expression/compile.cljc
+++ b/src/sicmutils/expression/compile.cljc
@@ -102,6 +102,9 @@
    'cosh #(Math/cosh %)
    'sinh #(Math/sinh %)
    'tanh #(Math/tanh %)
+   'floor #(Math/floor %)
+   'ceiling #(Math/ceil %)
+   ;; TODO: modulo, remainder
    #?@(:cljs
        ;; JS-only entries.
        ['acosh #(Math/acosh %)

--- a/src/sicmutils/expression/compile.cljc
+++ b/src/sicmutils/expression/compile.cljc
@@ -90,7 +90,7 @@
    '/ /
    'expt #(Math/pow %1 %2)
    'sqrt #(Math/sqrt %)
-   'abs (fn [^double x] (Math/abs x))
+   'abs #(Math/abs %)
    'log #(Math/log %)
    'exp #(Math/exp %)
    'cos #(Math/cos %)
@@ -104,7 +104,13 @@
    'tanh #(Math/tanh %)
    'floor #(Math/floor %)
    'ceiling #(Math/ceil %)
-   ;; TODO: modulo, remainder
+   'modulo mod
+   'remainder rem
+   'quotient quot
+   'integer-part #?(:clj long
+                    :cljs #(Math/trunc %))
+   'fractional-part (fn [^double x]
+                      (- x (Math/floor x)))
    #?@(:cljs
        ;; JS-only entries.
        ['acosh #(Math/acosh %)

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -252,10 +252,10 @@
    :special-handlers
    {'floor (fn [[x]] (str "⌊" x "⌋"))
     'ceiling (fn [[x]] (str "⌈" x "⌉"))
-    'integer-part (fn [[x]] (str "[" x "]"))
-    'fractional-part (fn [[x]] (str "{" x "}"))
-    'modulo (fn [[x y]])
-    'remainder (fn [[x y]] (str " % "))
+    'integer-part (fn [[x]] (str "int(" x ")"))
+    'fractional-part (fn [[x]] (str "frac(" x ")"))
+    'modulo (fn [[x y]] (str x " mod " y))
+    'remainder (fn [[x y]] (str x " % " y))
     'expt (fn [[x e]]
             (if (and (integer? e) ((complement neg?) e))
               (str x (n->superscript e))))
@@ -359,11 +359,11 @@
 
       'integer-part
       (fn [[x]]
-        (str "\\left[ " x " \\right]"))
+        (str "\\mathsf{int} \\left(" x "\\right)"))
 
       'fractional-part
       (fn [[x]]
-        (str "\\left \\{ " x " \\right \\}"))
+        (str "\\mathsf{frac} \\left(" x "\\right)"))
 
       'modulo
       (fn [[x y]]

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -249,11 +249,12 @@
    :infix? '#{* + - / modulo remainder expt u- = > < >= <=}
    :juxtapose-multiply " "
    :rewrite-trig-squares true
+   :rename-functions
+   {'fractional-part "frac"
+    'integer-part "int"}
    :special-handlers
    {'floor (fn [[x]] (str "⌊" x "⌋"))
     'ceiling (fn [[x]] (str "⌈" x "⌉"))
-    'integer-part (fn [[x]] (str "int(" x ")"))
-    'fractional-part (fn [[x]] (str "frac(" x ")"))
     'modulo (fn [[x y]] (str x " mod " y))
     'remainder (fn [[x y]] (str x " % " y))
     'expt (fn [[x e]]
@@ -520,9 +521,12 @@
                               'log "Math.log"
                               'exp "Math.exp"
                               'floor "Math.floor"
-                              'ceiling "Math.ceil"}
+                              'ceiling "Math.ceil"
+                              'integer-part "Math.trunc"}
            :special-handlers {'up make-js-vector
                               'down make-js-vector
+                              'remainder (fn [[a b]]
+                                           (str a " % "))
                               '/ render-infix-ratio})]
     (fn [x & {:keys [symbol-generator parameter-order deterministic?]
              :or {symbol-generator (make-symbol-generator "_")

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -523,11 +523,20 @@
                               'floor "Math.floor"
                               'ceiling "Math.ceil"
                               'integer-part "Math.trunc"}
-           :special-handlers {'up make-js-vector
-                              'down make-js-vector
-                              'remainder (fn [[a b]]
-                                           (str a " % "))
-                              '/ render-infix-ratio})]
+           :special-handlers (let [parens (fn [x]
+                                            (str "(" x ")"))]
+                               {'up make-js-vector
+                                'down make-js-vector
+                                'modulo (fn [[a b]]
+                                          (-> (str a " % " b)
+                                              (parens)
+                                              (str " + " b)
+                                              (parens)
+                                              (str " % " b)
+                                              (parens)))
+                                'remainder (fn [[a b]]
+                                             (str a " % "))
+                                '/ render-infix-ratio}))]
     (fn [x & {:keys [symbol-generator parameter-order deterministic?]
              :or {symbol-generator (make-symbol-generator "_")
                   parameter-order sort}}]

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -246,11 +246,17 @@
   (make-infix-renderer
    :precedence-map '{D 9, partial 9,
                      expt 7, :apply 5, u- 4, / 3, * 3, + 1, - 1, = 0, > 0, < 0, >= 0, <= 0}
-   :infix? '#{* + - / expt u- = > < >= <=}
+   :infix? '#{* + - / modulo remainder expt u- = > < >= <=}
    :juxtapose-multiply " "
    :rewrite-trig-squares true
    :special-handlers
-   {'expt (fn [[x e]]
+   {'floor (fn [[x]] (str "⌊" x "⌋"))
+    'ceiling (fn [[x]] (str "⌈" x "⌉"))
+    'integer-part (fn [[x]] (str "[" x "]"))
+    'fractional-part (fn [[x]] (str "{" x "}"))
+    'modulo (fn [[x y]])
+    'remainder (fn [[x y]] (str " % "))
+    'expt (fn [[x e]]
             (if (and (integer? e) ((complement neg?) e))
               (str x (n->superscript e))))
     'partial (fn [ds]
@@ -343,7 +349,33 @@
      :juxtapose-multiply "\\,"
      :rewrite-trig-squares true
      :special-handlers
-     {'expt (fn [[x e]] (str (maybe-brace x) "^" (maybe-brace e)))
+     {'floor
+      (fn [[x]]
+        (str "\\left\\lfloor " x " \\right\\rfloor"))
+
+      'ceiling
+      (fn [[x]]
+        (str "\\left\\lceil " x " \\right\\rceil"))
+
+      'integer-part
+      (fn [[x]]
+        (str "\\left[ " x " \\right]"))
+
+      'fractional-part
+      (fn [[x]]
+        (str "\\left \\{ " x " \\right \\}"))
+
+      'modulo
+      (fn [[x y]]
+        (str (maybe-brace x) " \\bmod " (maybe-brace y)))
+
+      'remainder
+      (fn [[x y]]
+        (str (maybe-brace x) " \\mathbin{\\%} " (maybe-brace y)))
+
+      'expt (fn [[x e]]
+              (str (maybe-brace x) "^" (maybe-brace e)))
+
       'partial (fn [ds] (str "\\partial_" (maybe-brace (s/join "," ds))))
       '/ (fn [xs]
            (let [n (count xs)]
@@ -486,7 +518,9 @@
                               'abs "Math.abs"
                               'expt "Math.pow"
                               'log "Math.log"
-                              'exp "Math.exp"}
+                              'exp "Math.exp"
+                              'floor "Math.floor"
+                              'ceiling "Math.ceil"}
            :special-handlers {'up make-js-vector
                               'down make-js-vector
                               '/ render-infix-ratio})]

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -196,14 +196,14 @@ See [[*]] for a variadic version of [[mul]]."
 (defmethod ceiling :default [a]
   (negate (floor (negate a))))
 
-(defn modulo-default [a b]
+(defn- modulo-default [a b]
   (sub a (mul b (floor (div a b)))))
 
 (defgeneric modulo 2)
 (defmethod modulo :default [a b]
   (modulo-default a b))
 
-(defn remainder-default [n d]
+(defn- remainder-default [n d]
   (let [divnd (div n d)]
     (if (= (negative? n) (negative? d))
       (mul d (sub divnd (floor divnd)))

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -196,14 +196,29 @@ See [[*]] for a variadic version of [[mul]]."
 (defmethod ceiling :default [a]
   (negate (floor (negate a))))
 
-(defn- modulo-default [a b]
+(defn ^:no-doc modulo-default
+  "The default implementation for [[modulo]] depends on the identity:
+
+  x mod y == x - y ⌊x/y⌋
+
+  This is the Knuth definition described
+  by [Wikipedia](https://en.wikipedia.org/wiki/Modulo_operation)."
+  [a b]
   (sub a (mul b (floor (div a b)))))
 
-(defgeneric modulo 2)
+(defgeneric modulo 2
+  "Returns the result of the
+  mathematical [Modulo](https://en.wikipedia.org/wiki/Modulo_operation)
+  operation between `a` and `b`.
+
+ TODO note remainder and friends.
+
+ Truncates toward negative infinity.")
+
 (defmethod modulo :default [a b]
   (modulo-default a b))
 
-(defn- remainder-default [n d]
+(defn ^:no-doc remainder-default [n d]
   (let [divnd (div n d)]
     (if (= (negative? n) (negative? d))
       (mul d (sub divnd (floor divnd)))
@@ -212,7 +227,9 @@ See [[*]] for a variadic version of [[mul]]."
 ;; complex remainder returns numerator in maxima
 ;; fractional remainder returns 0 in maxima
 ;; remainder in wolfram alpha == modulo
-(defgeneric remainder 2)
+(defgeneric remainder 2
+  "TODO describe the difference here.")
+
 (defmethod remainder :default [n d]
   (remainder-default n d))
 

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -221,8 +221,13 @@
      (defmethod g/magnitude [js/BigInt] [a b]
        (if (neg? a) (core-minus a) a))
 
+     (defmethod g/div [js/BigInt js/BigInt] [a b]
+       (let [rem (js* "~{} % ~{}" a b)]
+         (if (v/zero? rem)
+           (core-div a b)
+           (r/rationalize a b))))
 
-     (doseq [op [g/add g/mul g/sub g/expt g/modulo g/remainder g/quotient]]
+     (doseq [op [g/add g/mul g/sub g/div g/expt g/modulo g/remainder g/quotient]]
        ;; Compatibility between js/BigInt and the other integral types.
        (defmethod op [js/BigInt ::v/integral] [a b]
          (op a (u/bigint b)))
@@ -231,8 +236,7 @@
          (op (u/bigint a) b))
 
        ;; For NON integrals, we currently have no choice but to downcast the
-       ;; BigInt to a floating point number. TODO if we introduce BigDecimal
-       ;; support this could get cleaner.
+       ;; BigInt to a floating point number.
        (defmethod op [js/BigInt ::v/floating-point] [a b]
          (op (js/Number a) b))
 

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -58,9 +58,11 @@
 (defmethod g/magnitude [::v/real] [a] (u/compute-abs a))
 (defmethod g/div [::v/real ::v/real] [a b] (core-div a b))
 (defmethod g/invert [::v/real] [a] (core-div a))
-(defmethod g/integer-part [::v/real] [a] (long a))
 (defmethod g/floor [::v/real] [a] (long (Math/floor a)))
 (defmethod g/ceiling [::v/real] [a] (long (Math/ceil a)))
+(defmethod g/integer-part [::v/real] [a]
+  #?(:clj (long a)
+     :cljs (Math/trunc a)))
 
 ;; ## Complex Operations
 (defmethod g/real-part [::v/real] [a] a)

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -61,7 +61,8 @@
         (process s)))))
 
 (defn- mod-rem
-  "Modulo and remainder are very similar, so can benefit from a shared set of simplifications."
+  "Modulo and remainder are very similar, so can benefit from a shared set of
+  simplifications."
   [a b f sym]
   (cond (and (v/number? a) (v/number? b)) (f a b)
         (= a b) 0
@@ -133,7 +134,6 @@
   (mod-rem a b remainder 'remainder))
 
 (defn- floor [a]
-  ;; TODO: should almost-integer? be used in floor and ceiling? (dw Feb 13 2021)
   (if (v/number? a)
     (g/floor a)
     (list 'floor a)))

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -227,12 +227,28 @@
      (defmethod g/div [Fraction Fraction] [^Fraction a ^Fraction b] (promote (.div a b)))
      (defmethod g/exact-divide [Fraction Fraction] [^Fraction a ^Fraction b] (promote (.div a b)))
 
-     (defmethod g/remainder [Fraction Fraction] [a b] (.mod a b))
-     (defmethod g/remainder [::v/integral Fraction] [a b] (.mod (Fraction. a) b))
-     (defmethod g/remainder [Fraction ::v/integral] [a b] (.mod a b))
-     (defmethod g/modulo [Fraction Fraction] [a b] (.. a (mod b) (add b) (mod b)))
-     (defmethod g/modulo [::v/integral Fraction] [a b] (.. (Fraction. a) (mod b) (add b) (mod b)))
-     (defmethod g/modulo [Fraction ::v/integral] [a b] (.. a (mod b) (add b) (mod b)))
+     (defmethod g/remainder [Fraction Fraction] [^Fraction a ^Fraction b]
+       (promote (.mod a b)))
+
+     (defmethod g/remainder [::v/integral Fraction] [a ^Fraction b]
+       (promote (.mod (Fraction. a 1) b)))
+
+     (defmethod g/remainder [Fraction ::v/integral] [^Fraction a b]
+       (promote (.mod a (Fraction. b 1))))
+
+     (defmethod g/modulo [Fraction Fraction] [^Fraction a ^Fraction b]
+       (promote
+        (.mod ^Fraction (.add ^Fraction (.mod a b) b) b)))
+
+     (defmethod g/modulo [::v/integral Fraction] [a ^Fraction b]
+       (promote
+        (.. (Fraction. a 1) (mod b) (add b) (mod b))))
+
+     (defmethod g/modulo [Fraction ::v/integral] [^Fraction a b]
+       (let [^Fraction b (Fraction. b 1)]
+         (promote
+          (.mod ^Fraction (.add ^Fraction (.mod a b) b) b))))
+
      (defmethod g/negate [Fraction] [^Fraction a] (promote (.neg a)))
      (defmethod g/negative? [Fraction] [^Fraction a] (neg? (.-s a)))
      (defmethod g/invert [Fraction] [^Fraction a] (promote (.inverse a)))

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -226,29 +226,6 @@
      (defmethod g/mul [Fraction Fraction] [^Fraction a ^Fraction b] (promote (.mul a b)))
      (defmethod g/div [Fraction Fraction] [^Fraction a ^Fraction b] (promote (.div a b)))
      (defmethod g/exact-divide [Fraction Fraction] [^Fraction a ^Fraction b] (promote (.div a b)))
-
-     (defmethod g/remainder [Fraction Fraction] [^Fraction a ^Fraction b]
-       (promote (.mod a b)))
-
-     (defmethod g/remainder [::v/integral Fraction] [a ^Fraction b]
-       (promote (.mod (Fraction. a 1) b)))
-
-     (defmethod g/remainder [Fraction ::v/integral] [^Fraction a b]
-       (promote (.mod a (Fraction. b 1))))
-
-     (defmethod g/modulo [Fraction Fraction] [^Fraction a ^Fraction b]
-       (promote
-        (.mod ^Fraction (.add ^Fraction (.mod a b) b) b)))
-
-     (defmethod g/modulo [::v/integral Fraction] [a ^Fraction b]
-       (promote
-        (.. (Fraction. a 1) (mod b) (add b) (mod b))))
-
-     (defmethod g/modulo [Fraction ::v/integral] [^Fraction a b]
-       (let [^Fraction b (Fraction. b 1)]
-         (promote
-          (.mod ^Fraction (.add ^Fraction (.mod a b) b) b))))
-
      (defmethod g/negate [Fraction] [^Fraction a] (promote (.neg a)))
      (defmethod g/negative? [Fraction] [^Fraction a] (neg? (.-s a)))
      (defmethod g/invert [Fraction] [^Fraction a] (promote (.inverse a)))
@@ -265,12 +242,17 @@
          (g/div (g/sqrt (u/double (numerator a)))
                 (g/sqrt (u/double (denominator a))))))
 
+     (defmethod g/modulo [Fraction Fraction] [^Fraction a ^Fraction b]
+       (promote
+        (.mod ^Fraction (.add ^Fraction (.mod a b) b) b)))
+
      ;; Only integral ratios let us stay exact. If a ratio appears in the
      ;; exponent, convert the base to a number and call g/expt again.
      (defmethod g/expt [Fraction Fraction] [a b]
        (if (v/one? (denominator b))
          (promote (.pow a (numerator b)))
-         (g/expt (.valueOf a) (.valueOf b))))
+         (g/expt (.valueOf a)
+                 (.valueOf b))))
 
      (defmethod g/quotient [Fraction Fraction] [^Fraction a ^Fraction b]
        (promote
@@ -310,6 +292,9 @@
      ;; We handle the cases above where the exponent connects with integrals and
      ;; stays exact.
      (downcast-fraction g/expt)
-     (doseq [op [g/add g/mul g/sub g/gcd g/remainder g/quotient g/div]]
+
+     (doseq [op [g/add g/mul g/sub g/gcd g/lcm
+                 g/modulo g/remainder
+                 g/quotient g/div]]
        (upcast-number op)
        (downcast-fraction op))))

--- a/test/sicmutils/collection_test.cljc
+++ b/test/sicmutils/collection_test.cljc
@@ -33,7 +33,7 @@
 
 (deftest vector-tests
   (testing "Vector protocol implementations"
-    (checking "f/arity" 100 [v (gen/vector sg/integer)]
+    (checking "f/arity" 100 [v (gen/vector sg/any-integral)]
               (is (= [:between 1 2] (f/arity v))
                   "vectors respond to f/arity correctly"))
 
@@ -49,7 +49,7 @@
                 (is (every? v/zero? zero-v)
                     "zero-like zeros out all values.")))
 
-    (checking "v/kind, one?, identity?" 100 [v (gen/vector sg/integer)]
+    (checking "v/kind, one?, identity?" 100 [v (gen/vector sg/any-integral)]
               (is (not (v/one? v))
                   "no vector is a multiplicative identity.")
 
@@ -67,7 +67,7 @@
                    (v/identity-like {:k "v"}))))
 
     (checking "v/exact?" 100
-              [v (gen/vector sg/integer)]
+              [v (gen/vector sg/any-integral)]
               (is (v/exact? v)
                   "all integral values == exact vector")
 
@@ -100,7 +100,7 @@
 
 (deftest map-tests
   (testing "Map protocol implementations"
-    (checking "f/arity" 100 [m (gen/map gen/keyword sg/integer)]
+    (checking "f/arity" 100 [m (gen/map gen/keyword sg/any-integral)]
               (is (= [:between 1 2] (f/arity m))
                   "maps respond to f/arity correctly"))
 
@@ -116,7 +116,7 @@
                 (is (= (u/keyset m) (u/keyset zero-m))
                     "The keyset is identical after zeroing.")))
 
-    (checking "v/kind, one?, identity?" 100 [m (gen/map gen/keyword sg/integer)]
+    (checking "v/kind, one?, identity?" 100 [m (gen/map gen/keyword sg/any-integral)]
               (is (not (v/one? m))
                   "no map is a multiplicative identity.")
 
@@ -135,7 +135,7 @@
                    (v/identity-like {:k "v"}))))
 
     (checking "v/exact?" 100
-              [m (gen/map gen/keyword sg/integer)]
+              [m (gen/map gen/keyword sg/any-integral)]
               (is (v/exact? m)
                   "all integral values == exact map")
 
@@ -148,7 +148,7 @@
           "v/freeze freezes values")))
 
   (checking "d/perturbed?" 100
-            [m (gen/map gen/keyword sg/integer)]
+            [m (gen/map gen/keyword sg/any-integral)]
             (is (not (d/perturbed? m))
                 "maps with no [[Differential]] aren't perturbed.")
 

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -149,20 +149,48 @@
       (is (= (c/complex 1 2) (g/integer-part (c/complex 1.5 2.9))))
       (is (= (c/complex -1 -2) (g/integer-part (c/complex -1.5 -2.9)))))
 
-    (testing "fractional-part"
+    (checking "integer-part pushes through to complex components" 100
+              [x sg/complex]
+              (is (= (g/integer-part x)
+                     (g/make-rectangular
+                      (g/integer-part (g/real-part x))
+                      (g/integer-part (g/imag-part x))))))
+
+    (testing "fractional-part unit tests"
       (is (= (c/complex 0 0) (g/fractional-part (c/complex 1 2))))
       (is (near (c/complex 0.5 0.9) (g/fractional-part (c/complex 1.5 2.9))))
       (is (near (c/complex 0.5 0.1) (g/fractional-part (c/complex -1.5 -2.9)))))
+
+    (checking "fractional-part pushes through to complex components" 100
+              [x sg/complex]
+              (is (= (g/fractional-part x)
+                     (g/make-rectangular
+                      (g/fractional-part (g/real-part x))
+                      (g/fractional-part (g/imag-part x))))))
 
     (testing "floor"
       (is (= (c/complex 1 2) (g/floor (c/complex 1 2))))
       (is (= (c/complex 1 2) (g/floor (c/complex 1.5 2.9))))
       (is (= (c/complex -2 -3) (g/floor (c/complex -1.5 -2.9)))))
 
+    (checking "floor pushes through to complex components" 100
+              [x sg/complex]
+              (is (= (g/floor x)
+                     (g/make-rectangular
+                      (g/floor (g/real-part x))
+                      (g/floor (g/imag-part x))))))
+
     (testing "ceiling"
       (is (= (c/complex 1 2) (g/ceiling (c/complex 1 2))))
       (is (= (c/complex 2 3) (g/ceiling (c/complex 1.5 2.9))))
       (is (= (c/complex -1 -2) (g/ceiling (c/complex -1.5 -2.9)))))
+
+    (checking "ceiling pushes through to complex components" 100
+              [x sg/complex]
+              (is (= (g/ceiling x)
+                     (g/make-rectangular
+                      (g/ceiling (g/real-part x))
+                      (g/ceiling (g/imag-part x))))))
 
     (testing "expt"
       (is (near -1 (g/expt (c/complex 0 1) 2)))


### PR DESCRIPTION
This is a follow-up to #278. Here's a test function:

```clojure
(println
 (->infix
  (g/floor (g// (g/floor (g/modulo 'n 'x)) 'n))))
```

Demo for some riffs on that:

![image](https://user-images.githubusercontent.com/69635/108532038-a0986400-7294-11eb-8ad6-5bcc76d3e297.png)

## Tasks

- [x] TeX Rendering! Notes on [fractional-part](https://math.stackexchange.com/questions/1882055/notation-for-specifying-the-fractional-part-of-a-number), and [integer-part](https://math.stackexchange.com/questions/1882055/notation-for-specifying-the-fractional-part-of-a-number), [floor](https://tex.stackexchange.com/questions/118173/how-to-write-ceil-and-floor-in-latex), [ceiling](https://tex.stackexchange.com/questions/118173/how-to-write-ceil-and-floor-in-latex).
- [x] change rendering to `int` and `frac` for integer and fractional parts
- [x] `->Javascript` and compile have to handle
  - [x] remainder
  - [x] modulo,
  - [x] integer-part
  - [x] fractional-part
- [x] switch to [Math.trunc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc) for CLJS integer-part impl
- [x] CHANGELOG entry
- [x] We'll need to look up the unicode characters for the infix renderer too.
- [x] Generative tests, lock in the "laws" for how these types interact
- [x] Docstrings for the new methods explaining how they relate, and the choices we've made
- [x] Change the Fraction implementation to match Clojure's Numbers.java impl