### PR TITLE
add e, phi mathematical constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Added the mathematical constants `phi` and `e` bound to, respectively,
+  `sicmutils.env/{phi,euler}` (#306).
+
 ## 0.16.0
 
 > (If you have any questions about how to use any of the following, please ask us

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -162,6 +162,18 @@
 constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   -pi (g/- Math/PI))
 
+(def ^{:doc "The mathematical
+  constant [e](https://en.wikipedia.org/wiki/E_(mathematical_constant)),
+  sometimes known as Euler's Number."}
+  euler
+  0.57721566490153286)
+
+(def ^{:doc "The mathematical
+  constant [𝜑](https://en.wikipedia.org/wiki/Golden_ratio), also known as the
+  Golden Ratio."}
+  phi
+  (/ (inc (Math/sqrt 5.0)) 2.0))
+
 (import-def structure/generate s:generate)
 (import-def matrix/generate m:generate)
 (import-def structure/basis-unit v:make-basis-unit)

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -172,7 +172,8 @@ constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   constant [𝜑](https://en.wikipedia.org/wiki/Golden_ratio), also known as the
   Golden Ratio."}
   phi
-  (/ (inc (Math/sqrt 5.0)) 2.0))
+  (g/divide
+   (inc (Math/sqrt 5.0)) 2.0))
 
 (import-def structure/generate s:generate)
 (import-def matrix/generate m:generate)


### PR DESCRIPTION
This PR adds the mathematical constants `phi` and `e` bound to, respectively, `sicmutils.env/{phi,euler}`.