### PR TITLE
Alias u/bigint into sicmutils.env for cljs only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+- #309: `sicmutils.util/bigint` is aliased as `sicmutils.env/bigint` in
+  Clojurescript only. This is available natively in Clojure.
+
 - #308 adds:
 
-  - `sicmutils.env/{numerator, denominator}` aliases in Clojurescript
+  - `sicmutils.ratio/{numerator,denominator}` are now aliased as
+    `sicmutils.env/{numerator, denominator}` in Clojurescript. These are
+    available natively in Clojure.
 
   - Proper superscript support in `->infix` and `->TeX` renderers.
 

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -220,6 +220,7 @@ constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
  [sicmutils.abstract.number literal-number]
  [sicmutils.complex complex]
  #?(:cljs [sicmutils.ratio numerator denominator])
+ #?(:cljs [sicmutils.util bigint])
  [sicmutils.function arity compose arg-shift arg-scale I]
  [sicmutils.modint chinese-remainder]
  [sicmutils.operator commutator]


### PR DESCRIPTION
This gives users a way to build these things identical to the Clojure way.