### PR TITLE
slightly better test in bigint?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+- #310: `g/make-rectangular` and `g/make-polar` now return non-Complex numbers
+  on the JVM if you pass `0` for the (respectively) imaginary or angle
+  components. Previously this behavior only occurred on an integer 0; now it
+  happens with 0.0 too, matching CLJS.
+
 - #309: `sicmutils.util/bigint` is aliased as `sicmutils.env/bigint` in
   Clojurescript only. This is available natively in Clojure.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 - #309: `sicmutils.util/bigint` is aliased as `sicmutils.env/bigint` in
   Clojurescript only. This is available natively in Clojure.
 
-- #308 adds:
+- #308 and #310 add:
 
-  - `sicmutils.ratio/{numerator,denominator}` are now aliased as
-    `sicmutils.env/{numerator, denominator}` in Clojurescript. These are
-    available natively in Clojure.
+  - `sicmutils.ratio/{numerator,denominator,ratio?,rationalize}` and are now
+    aliased into `sicmutils.env` in Clojurescript. These are available natively
+    in Clojure. `sicmutils.complex/complex?` is aliased into `sicmutils.env` for
+    both platforms.
 
   - Proper superscript support in `->infix` and `->TeX` renderers.
 

--- a/deps.edn
+++ b/deps.edn
@@ -11,5 +11,5 @@
         org.clojure/core.match {:mvn/version "1.0.0"},
         nrepl/nrepl {:mvn/version "0.7.0"},
         cljsjs/complex {:mvn/version "2.0.11-0"},
-        borkdude/sci {:mvn/version "0.1.1-alpha.8"},
+        borkdude/sci {:mvn/version "0.2.1"},
         cljsjs/bigfraction {:mvn/version "4.0.12-0"}}}

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -73,13 +73,13 @@
      :cljs (obj/get a "im")))
 
 (defmethod g/make-rectangular [::v/real ::v/real] [re im]
-  (if (v/exact-zero? im)
+  (if (v/zero? im)
     re
     (complex re im)))
 
 (defmethod g/make-polar [::v/real ::v/real] [radius angle]
-  (cond (v/exact-zero? radius) radius
-        (v/exact-zero? angle)  radius
+  (cond (v/zero? radius) radius
+        (v/zero? angle)  radius
         :else
         #?(:cljs (Complex. #js {:abs (js/Number radius)
                                 :arg (js/Number angle)})

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -27,20 +27,24 @@
   (:require [sicmutils.generic :as g]
             [sicmutils.util :as u]
             [sicmutils.value :as v]
+            #?(:cljs [goog.object :as obj])
             #?(:cljs ["complex.js" :as Complex]))
   #?(:clj
      (:import [org.apache.commons.math3.complex Complex ComplexFormat])))
 
 (def ^{:doc "A [[Complex]] value equal to 0 (south pole on the Riemann Sphere)."}
   ZERO
-  #?(:clj Complex/ZERO :cljs (.-ZERO Complex)))
+  #?(:clj Complex/ZERO
+     :cljs (obj/get Complex "ZERO")))
 
 (def ^{:doc "A [[Complex]] value equal to 1."}
-  ONE #?(:clj Complex/ONE :cljs (.-ONE Complex)))
+  ONE #?(:clj Complex/ONE
+         :cljs (obj/get Complex "ONE")))
 
 (def  ^{:doc "A [[Complex]] value equal to `i`."}
   I
-  #?(:clj Complex/I :cljs (.-I Complex)))
+  #?(:clj Complex/I
+     :cljs (obj/get Complex "I")))
 
 (def ^:no-doc complextype Complex)
 
@@ -60,6 +64,14 @@
   [a]
   (instance? Complex a))
 
+(defn- real [^Complex a]
+  #?(:clj (.getReal a)
+     :cljs (obj/get a "re")))
+
+(defn- imaginary [^Complex a]
+  #?(:clj (.getImaginary a)
+     :cljs (obj/get a "im")))
+
 (defmethod g/make-rectangular [::v/real ::v/real] [re im]
   (if (v/exact-zero? im)
     re
@@ -75,8 +87,8 @@
                   (Complex. (* radius (Math/cos angle))
                             (* radius (Math/sin angle)))))))
 
-(defmethod g/real-part [::complex] [^Complex a] (#?(:clj .getReal :cljs .-re) a))
-(defmethod g/imag-part [::complex] [^Complex a] (#?(:clj .getImaginary :cljs .-im) a))
+(defmethod g/real-part [::complex] [a] (real a))
+(defmethod g/imag-part [::complex] [a] (imaginary a))
 (defmethod g/magnitude [::complex] [^Complex a] (.abs a))
 (defmethod g/angle [::complex] [^Complex a] (#?(:clj .getArgument :cljs .arg) a))
 (defmethod g/conjugate [::complex] [^Complex a] (.conjugate a))
@@ -87,8 +99,8 @@
   #?(:clj (let [cf (ComplexFormat.)]
             (fn [s]
               (let [v (.parse cf s)]
-                `(complex ~(g/real-part v)
-                          ~(g/imag-part v)))))
+                `(complex ~(real v)
+                          ~(imaginary v)))))
 
      :cljs (fn [s] `(complex ~s))))
 
@@ -122,13 +134,13 @@
   (zero-like [_] ZERO)
   (one-like [_] ONE)
   (identity-like [_] ONE)
-  (freeze [c] (let [re (g/real-part c)
-                    im (g/imag-part c)]
+  (freeze [c] (let [re (real c)
+                    im (imaginary c)]
                 (if (v/zero? im)
                   re
                   (list 'complex re im))))
-  (exact? [c] (and (v/exact? (g/real-part c))
-                   (v/exact? (g/imag-part c))))
+  (exact? [c] (and (v/exact? (real c))
+                   (v/exact? (imaginary c))))
   (kind [_] ::complex))
 
 (defmethod g/add [::complex ::complex] [^Complex a ^Complex b] (.add a b))
@@ -154,17 +166,19 @@
 (defmethod g/sinh [::complex] [^Complex a] (.sinh a))
 (defmethod g/tanh [::complex] [^Complex a] (.tanh a))
 
-(defmethod g/integer-part [::complex] [^Complex a]
-  (let [re (g/integer-part (#?(:clj .getReal :cljs .-re) a))
-        im (g/integer-part (#?(:clj .getImaginary :cljs .-im) a))]
+(defmethod g/integer-part [::complex] [a]
+  (let [re (g/integer-part (real a))
+        im (g/integer-part (imaginary a))]
     (if (v/zero? im)
       re
       (complex re im))))
 
-(defmethod g/fractional-part [::complex] [^Complex a]
-  (complex
-   (g/fractional-part (#?(:clj .getReal :cljs .-re) a))
-   (g/fractional-part (#?(:clj .getImaginary :cljs .-im) a))))
+(defmethod g/fractional-part [::complex] [a]
+  (let [re (g/fractional-part (real a))
+        im (g/fractional-part (imaginary a))]
+    (if (v/zero? im)
+      re
+      (complex re im))))
 
 #?(:cljs
    ;; These are all defined explicitly in Complex.js.

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -218,8 +218,9 @@ constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
 
 (import-vars
  [sicmutils.abstract.number literal-number]
- [sicmutils.complex complex]
- #?(:cljs [sicmutils.ratio numerator denominator])
+ [sicmutils.complex complex complex?]
+ #?(:cljs [sicmutils.ratio
+           ratio? rationalize numerator denominator])
  #?(:cljs [sicmutils.util bigint])
  [sicmutils.function arity compose arg-shift arg-scale I]
  [sicmutils.modint chinese-remainder]

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -33,6 +33,7 @@
                               numerator core-numerator}))
   (:require #?(:clj [clojure.edn] :cljs [cljs.reader])
             #?(:cljs [goog.array :as garray])
+            #?(:cljs [goog.object :as obj])
             [sicmutils.complex :as c]
             [sicmutils.expression :as x]
             [sicmutils.generic :as g]
@@ -51,13 +52,13 @@
 (def numerator
   #?(:clj core-numerator
      :cljs (fn [^Fraction x]
-             (if (pos? (.-s x))
-               (.-n x)
-               (- (.-n x))))))
+             (if (pos? (obj/get x "s"))
+               (obj/get x "n")
+               (- (obj/get x "n"))))))
 
 (def denominator
   #?(:clj core-denominator
-     :cljs (fn [^Fraction x] (.-d x))))
+     :cljs #(obj/get % "d")))
 
 (defn- promote [x]
   (if (v/one? (denominator x))
@@ -227,7 +228,7 @@
      (defmethod g/div [Fraction Fraction] [^Fraction a ^Fraction b] (promote (.div a b)))
      (defmethod g/exact-divide [Fraction Fraction] [^Fraction a ^Fraction b] (promote (.div a b)))
      (defmethod g/negate [Fraction] [^Fraction a] (promote (.neg a)))
-     (defmethod g/negative? [Fraction] [^Fraction a] (neg? (.-s a)))
+     (defmethod g/negative? [Fraction] [^Fraction a] (neg? (obj/get a "s")))
      (defmethod g/invert [Fraction] [^Fraction a] (promote (.inverse a)))
      (defmethod g/square [Fraction] [^Fraction a] (promote (.mul a a)))
      (defmethod g/cube [Fraction] [^Fraction a] (promote (.pow a 3)))
@@ -257,7 +258,7 @@
      (defmethod g/quotient [Fraction Fraction] [^Fraction a ^Fraction b]
        (promote
         (let [^Fraction x (.div a b)]
-          (if (pos? (.-s x))
+          (if (pos? (obj/get x "s"))
             (.floor x)
             (.ceil x)))))
 

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -70,10 +70,8 @@
 (defn ^boolean bigint?
   "Returns true if the supplied `x` is a `BigInt`, false otherwise."
   [x]
-  #?(:clj (instance? BigInt x)
-     :cljs (if-not (nil? x)
-             (identical? (.-constructor x) js/BigInt)
-             false)))
+  #?(:clj  (instance? BigInt x)
+     :cljs (= "bigint" (goog/typeOf x))))
 
 (defn parse-bigint [x]
   `(bigint ~x))

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -147,7 +147,9 @@
     (testing "integer-part"
       (is (= (c/complex 1 2) (g/integer-part (c/complex 1 2))))
       (is (= (c/complex 1 2) (g/integer-part (c/complex 1.5 2.9))))
-      (is (= (c/complex -1 -2) (g/integer-part (c/complex -1.5 -2.9)))))
+      (is (= (c/complex -1 -2) (g/integer-part (c/complex -1.5 -2.9))))
+      (is (= -1 (g/integer-part (c/complex -1.5 0.9)))
+          "imaginary part drops off if == zero"))
 
     (checking "integer-part pushes through to complex components" 100
               [x sg/complex]
@@ -159,7 +161,9 @@
     (testing "fractional-part unit tests"
       (is (= (c/complex 0 0) (g/fractional-part (c/complex 1 2))))
       (is (near (c/complex 0.5 0.9) (g/fractional-part (c/complex 1.5 2.9))))
-      (is (near (c/complex 0.5 0.1) (g/fractional-part (c/complex -1.5 -2.9)))))
+      (is (near (c/complex 0.5 0.1) (g/fractional-part (c/complex -1.5 -2.9))))
+      (is (= 0.5 (g/fractional-part (c/complex -1.5 2)))
+          "imaginary part drops off if == zero"))
 
     (checking "fractional-part pushes through to complex components" 100
               [x sg/complex]

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -144,6 +144,24 @@
       (is (= (c/complex -2 2)
              (g/modulo (c/complex 6 4) (c/complex 3 5)))))
 
+    (checking "make-rectangular with 0 complex == identity" 100
+              [x sg/real]
+              (is (= x (g/make-rectangular x 0.0))
+                  "inexact zero on JVM")
+
+              (is (= x (g/make-rectangular x 0))
+                  "exact zero"))
+
+    (checking "make-polar with 0 radius or angle == radius" 100
+              [x sg/real]
+              (is (= x (g/make-polar x 0.0)))
+              (is (= 0.0 (g/make-polar 0.0 x)))
+              (is (= 0 (g/make-polar 0 x))))
+
+    (checking "make-rectangular with 0 complex == identity" 100
+              [x sg/real]
+              (is (= x (g/make-rectangular x 0.0))))
+
     (testing "integer-part"
       (is (= (c/complex 1 2) (g/integer-part (c/complex 1 2))))
       (is (= (c/complex 1 2) (g/integer-part (c/complex 1.5 2.9))))
@@ -159,9 +177,9 @@
                       (g/integer-part (g/imag-part x))))))
 
     (testing "fractional-part unit tests"
-      (is (= (c/complex 0 0) (g/fractional-part (c/complex 1 2))))
       (is (near (c/complex 0.5 0.9) (g/fractional-part (c/complex 1.5 2.9))))
       (is (near (c/complex 0.5 0.1) (g/fractional-part (c/complex -1.5 -2.9))))
+      (is (= 0.0 (g/fractional-part (c/complex 1 2))))
       (is (= 0.5 (g/fractional-part (c/complex -1.5 2)))
           "imaginary part drops off if == zero"))
 

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -480,28 +480,19 @@
                 (is (ish? n (g/tanh (g/atanh n))))))))
 
 (deftest complex-constructor-tests
-  (checking "make-rectangular with zero acts as id" 100 [n sg/real]
-            (let [z (g/make-rectangular n 0)]
+  (checking "make-rectangular with zero (exact and inexact) acts as id" 100
+            [n sg/real]
+            (doseq [z [(g/make-rectangular n 0.0)
+                       (g/make-rectangular n 0)]]
               (is (= n z))
-              (is (not (c/complex? z))))
+              (is (not (c/complex? z)))))
 
-            #?(:clj
-               (is (c/complex? (g/make-rectangular n 0.0))
-                   "On the JVM we can make a non-exact zero and show that this
-                   forces a conversion to complex.")))
-
-  (checking "make-polar with zero angle or radius acts as id" 100 [n sg/real]
-            (let [z (g/make-polar n 0)]
+  (checking "make-polar with zero angle or radius acts as id" 100
+            [n sg/real]
+            (doseq [z [(g/make-polar n 0)
+                       (g/make-polar n 0.0)]]
               (is (= n z))
-              (is (not (c/complex? z))))
-
-            #?(:clj
-               (if (v/exact-zero? n)
-                 (is (not (c/complex? (g/make-polar n 0.0)))
-                     "exactly-zero radius stays itself.")
-                 (is (c/complex? (g/make-polar n 0.0))
-                     "On the JVM we can make a non-exact zero and show that this
-                   forces a conversion to complex."))))
+              (is (not (c/complex? z)))))
 
   (checking "make-rectangular" 100
             [real-part      (sg/reasonable-real 1e4)


### PR DESCRIPTION
Small improvements, plus an SCI version bump. I've changed all JS property access to `goog.object/get`, which I HOPE will fix the bug in nextjournal in production, where `(imag-part (complex 1 2))` returns nil.

From the CHANGELOG:

- #310: `g/make-rectangular` and `g/make-polar` now return non-Complex numbers
   on the JVM if you pass `0` for the (respectively) imaginary or angle
   components. Previously this behavior only occurred on an integer 0; now it
   happens with 0.0 too, matching CLJS.

- `sicmutils.ratio/{ratio?,rationalize}` and are now aliased into `sicmutils.env` in Clojurescript. 
   `sicmutils.complex/complex?` is aliased into `sicmutils.env` for both platforms.

