### PR TITLE
Add symbolic derivative, boolean operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,27 @@
 
 ## [unreleased]
 
+- #319: adds
+
+  - symbolic boolean implementations for `sym:=`, `sym:and`, `sym:or` and
+    `sym:not` with infix, latex and JavaScript renderers.
+  - `sym:derivative`, for purely symbolic derivatives
+
+  The boolean operators will act just like `=`, `and` and `or` on booleans, and
+  appropriately respond if just one side is a boolean. If both sides are
+  symbolic, These return a form like `(= a b)`, `(and a b)` or `(or a b)`.
+
+  The functions currently live in `sicmutils.numsymb` only; access them via
+  `(numsymb/symbolic-operator <sym>)`, where `<sym>` is one of `'=`, `'and`,
+  `'or`, `'not` or `'derivative'`.
+
 - #320: `Operator` gains a new simplifier for its `name` field; the simplifier
-  applies the associative rule to products and sums of operators, and collapses
-  (adjacent) products down into exponents. `Operator` multiplication (function
-  composition) is associative but NOT commutative, so the default simplifier is
-  not appropriate.
+  applies the associative rule to products and sums of operators, collapses
+  (adjacent) products down into exponents, and removes instances of `identity`
+  (the multiplicative identity for operators).
+
+  `Operator` multiplication (function composition) is associative but NOT
+  commutative, so the default simplifier is not appropriate.
 
   Before this change:
 
@@ -25,8 +41,8 @@ sicmutils.env> (series/exp-series D)
 sicmutils.env> (series/exp-series D)
 #object[sicmutils.series.Series
   "(+ identity
-      (* D identity)
-      (* (/ 1 2) (expt D 2) identity)
+      D
+      (* (/ 1 2) (expt D 2))
       (* (/ 1 6) (expt D 3)) ...)"]
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
   The functions currently live in `sicmutils.numsymb` only; access them via
   `(numsymb/symbolic-operator <sym>)`, where `<sym>` is one of `'=`, `'and`,
-  `'or`, `'not` or `'derivative'`.
+  `'or`, `'not` or `'derivative`.
 
 - #320: `Operator` gains a new simplifier for its `name` field; the simplifier
   applies the associative rule to products and sums of operators, collapses

--- a/src/sicmutils/abstract/function.cljc
+++ b/src/sicmutils/abstract/function.cljc
@@ -34,8 +34,7 @@
             [sicmutils.polynomial]
             [sicmutils.structure :as s]
             [sicmutils.util :as u]
-            [sicmutils.value :as v]
-            [sicmutils.calculus.derivative :refer [derivative-symbol]])
+            [sicmutils.value :as v])
   #?(:clj
      (:import [clojure.lang IFn])))
 
@@ -250,25 +249,25 @@
   (and (sequential? expr)
        ;; XXX GJS uses 'derivative here; should we? doesn't he just
        ;; have to change it back to D when printing?
-       (= (first expr) derivative-symbol)))
+       (= (first expr) g/derivative-symbol)))
 
 (defn ^:no-doc iterated-symbolic-derivative? [expr]
   (and (sequential? expr)
        (sequential? (first expr))
        (sym/expt? (first expr))
-       (= (second (first expr)) derivative-symbol)))
+       (= (second (first expr)) g/derivative-symbol)))
 
 (defn ^:no-doc symbolic-increase-derivative [expr]
   (let [expt (sym/symbolic-operator 'expt)]
     (cond (symbolic-derivative? expr)
-          (list (expt derivative-symbol 2) (fnext expr))
+          (list (expt g/derivative-symbol 2) (fnext expr))
           (iterated-symbolic-derivative? expr)
-          (list (expt derivative-symbol
+          (list (expt g/derivative-symbol
                       (+ (first (nnext (first expr)))
                          1))
                 (fnext expr))
           :else
-          (list derivative-symbol expr))))
+          (list g/derivative-symbol expr))))
 
 (defn- make-partials [f v]
   ;; GJS calls this function (the loop below) "fd"; we have no idea

--- a/src/sicmutils/calculus/derivative.cljc
+++ b/src/sicmutils/calculus/derivative.cljc
@@ -441,8 +441,6 @@
 ;; This section exposes various differential operators as [[o/Operator]]
 ;; instances.
 
-(def ^:no-doc derivative-symbol 'D)
-
 (def ^{:doc "Derivative operator. Takes some function `f` and returns a function
   whose value at some point can multiply an increment in the arguments, to
   produce the best linear estimate of the increment in the function value.
@@ -456,7 +454,7 @@
   opposite orientation as [[D]]. Both of these functions use forward-mode
   automatic differentiation."} D
   (o/make-operator #(g/partial-derivative % [])
-                   derivative-symbol))
+                   g/derivative-symbol))
 
 (defn partial
   "Returns an operator that, when applied to a function `f`, produces a function

--- a/src/sicmutils/differential.cljc
+++ b/src/sicmutils/differential.cljc
@@ -787,7 +787,12 @@
   ([dx dy]
    (terms->differential
     (terms:+ (->terms dx)
-             (->terms dy)))))
+             (->terms dy))))
+  ([dx dy & more]
+   (terms->differential
+    (transduce (map ->terms)
+               terms:+
+               (cons dx (cons dy more))))))
 
 (defn d:*
   "Returns an object representing the product of the two objects `dx` and `dy`.

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -604,6 +604,8 @@
 
 ;; ## More advanced generic operations
 
+(def ^:no-doc derivative-symbol 'D)
+
 (defgeneric partial-derivative 2)
 (defgeneric Lie-derivative 1)
 

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -463,6 +463,14 @@
 
 ;; ## Boolean Operations
 
+(defn- sym:and [l r]
+  (cond (true? l)  r
+        (false? l) l
+        (true? r)  l
+        (false? r) r
+        (= l r)    r
+        :else (list 'and l r)))
+
 (defn- sym:or [l r]
   (cond (true? l)   l
         (false? l)  r
@@ -471,13 +479,10 @@
         (= l r)     r
         :else (list 'or l r)))
 
-(defn- sym:and [l r]
-  (cond (true? l)  r
-        (false? l) l
-        (true? r)  l
-        (false? r) r
-        (= l r)    r
-        :else (list 'and l r)))
+(defn- sym:not [x]
+  (if (boolean? x)
+    (not x)
+    (list 'not x)))
 
 (defn- sym:= [l r]
   (let [num-l? (v/number? l)
@@ -506,6 +511,7 @@
    '= sym:=
    'and sym:and
    'or sym:or
+   'not sym:not
    '+ #(reduce add 0 %&)
    '- sub-n
    '* #(reduce mul 1 %&)

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -40,6 +40,7 @@
 (def expt? (is-expression? 'expt))
 (def quotient? (is-expression? '/))
 (def arctan? (is-expression? 'atan))
+(def derivative? (is-expression? g/derivative-symbol))
 (def operator first)
 (def operands rest)
 
@@ -436,10 +437,84 @@
       (atan (imag-part z)
             (real-part z)))))
 
+(defn iterated-derivative? [expr]
+  (and (seq? expr)
+       (expt? (operator expr))
+       (= g/derivative-symbol
+          (second
+           (operator expr)))))
+
+;; sicmutils.numsymb> (derivative '(g f))
+;; (D (g f))
+;; sicmutils.numsymb> (derivative (derivative '(g f)))
+;; ((expt D 2) (g f))
+;; sicmutils.numsymb> (derivative (derivative (derivative '(g f))))
+;; ((expt D 3) (g f))
+
+(defn derivative [expr]
+  (cond (derivative? expr)
+        (list (expt g/derivative-symbol 2)
+              (first (operands expr)))
+
+        (iterated-derivative? expr)
+        (let [pow (nth (operator expr) 2)]
+          (list (expt g/derivative-symbol (inc pow))
+                (fnext expr)))
+        :else
+        (list g/derivative-symbol expr)))
+
+(comment
+  (defn &
+    "Units!"
+    ([e u1]
+     (list '& e u1))
+    ([e u1 u2]
+     (list '& e u1 u2))))
+
+(defn bin= [l r]
+  (let [num-l? (v/number? l)
+        num-r? (v/number? r)]
+    (cond (and num-l? num-r?)
+          (and (v/exact? l) (v/exact? r) (= l r))
+
+          (or num-l? num-r?) false
+          (= l r) true
+          :else (list '= l r))))
+
+(defn sym:=
+  ([] true)
+  ([x] true)
+  ([x y] (bin= x y))
+  ([x y & more]
+   (loop [args more
+          larg y
+          ans (bin= x y)]
+     (if (empty? args)
+       ans
+       (recur (rest args)
+              (first args)
+              ;; TODO this is broken... if the first one is not `true` we'll
+              ;; continue!
+              (and ans (bin= larg (first args))))))))
+
+(defn sym:zero? [x]
+  (if (v/number? x)
+    (v/zero? x)
+    (list '= 0 x)))
+
+(defn sym:one? [x]
+  (if (v/number? x)
+    (v/one? x)
+    (list '= 1 x)))
+
 ;; ## Table
 
 (def ^:private symbolic-operator-table
-  {'+ #(reduce add 0 %&)
+  {'zero? sym:zero?
+   'one? sym:one?
+   'identity? sym:one?
+   '= sym:=
+   '+ #(reduce add 0 %&)
    '- sub-n
    '* #(reduce mul 1 %&)
    '/ div-n
@@ -474,7 +549,8 @@
    'imag-part imag-part
    'conjugate conjugate
    'magnitude magnitude
-   'angle angle})
+   'angle angle
+   'derivative derivative})
 
 (defn symbolic-operator
   "Given a symbol (like `'+`) returns an applicable operator if there is a

--- a/src/sicmutils/operator.cljc
+++ b/src/sicmutils/operator.cljc
@@ -35,10 +35,14 @@
 
 (def ^{:private true
        :doc "Simplifier that acts on associative products and sums, and collects
-  products into exponents. Operator multiplication is NOT associative, so only
-  adjacent products are collected."}
+  products into exponents. Any operator named `identity` is removed (we can't
+  verify that the operator does in fact _act_ like a proper `identity`.)
+
+  Operator multiplication is NOT associative, so only adjacent products are
+  collected."}
   simplify-operator-name
   (rule-simplifier
+   (rules/constant-elimination '* 'identity)
    (rules/associative '+ '*)
    rules/exponent-contract
    (rules/unary-elimination '+ '*)))

--- a/src/sicmutils/simplify/rules.cljc
+++ b/src/sicmutils/simplify/rules.cljc
@@ -84,8 +84,9 @@
   r)`."
   [op constant]
   (ruleset (:op :l :r)
-           #(or (= constant (% :l))
-                (= constant (% :r)))
+           #(and (= op (% :op))
+                 (or (= constant (% :l))
+                     (= constant (% :r))))
            (:? (fn [{:keys [l r]}]
                  (if (= constant l) r l)))))
 

--- a/src/sicmutils/simplify/rules.cljc
+++ b/src/sicmutils/simplify/rules.cljc
@@ -78,6 +78,17 @@
     (ruleset
      (:op :x) #(op-set (% :op)) :x)))
 
+(defn constant-elimination
+  "Takes an operation `op` and an identity element `constant` and returns a rule
+  that eliminates instances of `constant` inside binary forms like `(<op> l
+  r)`."
+  [op constant]
+  (ruleset (:op :l :r)
+           #(or (= constant (% :l))
+                (= constant (% :r)))
+           (:? (fn [{:keys [l r]}]
+                 (if (= constant l) r l)))))
+
 (def ^{:doc "Set of rules that collect adjacent products, exponents and nested
  exponents into exponent terms."}
   exponent-contract

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -786,3 +786,12 @@
                   (log (- 1 x)))
                2)
            (v/freeze (g/atanh 'x))))))
+
+(deftest symbolic-derivative-tests
+  (testing "structural utilities"
+    (is (sym/derivative? '(D f)))
+    (is (not (sym/derivative? '(e f))))
+    (is (not (sym/iterated-derivative? '(expt D 2))))
+    (is (sym/iterated-derivative? '((expt D 2) f)))
+    (is (= '((expt D 2) f) (sym/derivative '(D f))))
+    (is (= '((expt D 3) f) (sym/derivative '((expt D 2) f))))))

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -787,6 +787,66 @@
                2)
            (v/freeze (g/atanh 'x))))))
 
+(deftest boolean-tests
+  ;; These don't QUITE belong in the namespace for abstract number; TODO move
+  ;; these to sicmutils.abstract.boolean when we make that namespace.
+  (let [sym:or  (sym/symbolic-operator 'or)
+        sym:and (sym/symbolic-operator 'and)
+        sym:not (sym/symbolic-operator 'not)
+        sym:=   (sym/symbolic-operator '=)]
+    (is (= '(= (and (or a b) (not (or c d)))
+               (or x z))
+           (sym:= (sym:and (sym:or 'a 'b)
+                           (sym:not (sym:or 'c 'd)))
+                  (sym:or 'x 'z)))
+        "all forms work as expected with symbols.")
+
+    (checking "symbolic matches actual" 100 [l gen/boolean
+                                             r gen/boolean]
+              (is (= (and l r) (sym:and l r)))
+              (is (= (or l r) (sym:or l r)))
+              (is (= (not l) (sym:not l))))
+
+    (checking "sym:= matches = for numbers"
+              100 [l sg/number
+                   r sg/number]
+              (is (= (= l r)
+                     (sym:= l r)))
+
+              (is (false? (sym:= l 'x))
+                  "numbers are never equal to symbols, so false comes back")
+
+              (is (false? (sym:= 'x r))
+                  "numbers are never equal to symbols, so false comes back"))
+
+    (checking "symbolic `or` behavior with boolean"
+              100 [n gen/any-equatable]
+              (is (true? (sym:or n true))
+                  "true on right is always true")
+
+              (is (true? (sym:or true n))
+                  "true on left is always true")
+
+              (is (= n (sym:or false n))
+                  "false on left returns right side")
+
+              (is (= n (sym:or n false))
+                  "false on right returns left side"))
+
+    (checking "symbolic `and` behavior with boolean"
+              100 [n gen/any-equatable]
+              (is (false? (sym:and n false))
+                  "false on right is always false")
+
+              (is (false? (sym:and false n))
+                  "false on left is always false")
+
+              (is (= n (sym:and true n))
+                  "true on left returns right side")
+
+              (is (= n (sym:and n true))
+                  "true on right returns left side"))))
+
 (deftest symbolic-derivative-tests
   (let [derivative (sym/symbolic-operator 'derivative)]
     (testing "structural utilities"

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -788,10 +788,19 @@
            (v/freeze (g/atanh 'x))))))
 
 (deftest symbolic-derivative-tests
-  (testing "structural utilities"
-    (is (sym/derivative? '(D f)))
-    (is (not (sym/derivative? '(e f))))
-    (is (not (sym/iterated-derivative? '(expt D 2))))
-    (is (sym/iterated-derivative? '((expt D 2) f)))
-    (is (= '((expt D 2) f) (sym/derivative '(D f))))
-    (is (= '((expt D 3) f) (sym/derivative '((expt D 2) f))))))
+  (let [derivative (sym/symbolic-operator 'derivative)]
+    (testing "structural utilities"
+      (is (sym/derivative? '(D f)))
+      (is (not (sym/derivative? '(e f))))
+
+      (is (not (sym/iterated-derivative?
+                '(expt D 2))))
+
+      (is (sym/iterated-derivative?
+           '((expt D 2) f)))
+
+      (is (= '((expt D 2) f)
+             (derivative '(D f))))
+
+      (is (= '((expt D 3) f)
+             (derivative '((expt D 2) f)))))))

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -1,21 +1,21 @@
-;
-; Copyright © 2017 Colin Smith.
-; This work is based on the Scmutils system of MIT/GNU Scheme:
-; Copyright © 2002 Massachusetts Institute of Technology
-;
-; This is free software;  you can redistribute it and/or modify
-; it under the terms of the GNU General Public License as published by
-; the Free Software Foundation; either version 3 of the License, or (at
-; your option) any later version.
-;
-; This software is distributed in the hope that it will be useful, but
-; WITHOUT ANY WARRANTY; without even the implied warranty of
-; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-; General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License
-; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;
+;;
+;; Copyright © 2017 Colin Smith.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
 
 (ns sicmutils.expression.render-test
   (:refer-clojure :exclude [+ - * /])
@@ -27,6 +27,7 @@
             [sicmutils.expression.render :as r :refer [->infix ->TeX ->JavaScript]]
             [sicmutils.generic :as g :refer [expt sin cos + - * /]]
             [sicmutils.function :as f]
+            [sicmutils.numsymb :as sym]
             [sicmutils.series :as series]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
             [sicmutils.structure :refer [up down]]))
@@ -265,7 +266,21 @@
     (testing "Both sides if a subscript or superscript are rendered."
       (is (= "φ_θ" (->infix "phi_theta")))
       (is (= "φ↑θ₁↑ζ_π" (->infix 'phi↑theta_1↑zeta_pi))
-          "numbers are subscripted when they appear"))))
+          "numbers are subscripted when they appear")))
+
+  (testing "boolean operations"
+    (let [or    (sym/symbolic-operator 'or)
+          and   (sym/symbolic-operator 'and)
+          not   (sym/symbolic-operator 'not)
+          sym:= (sym/symbolic-operator '=)]
+      (is (= "\\left(a \\lor b\\right) \\land \\left(\\lnot\\left(c \\lor d\\right)\\right)"
+             (->TeX (and (or 'a 'b)
+                         (not (or 'c 'd))))))
+
+      (is (= "((a ∨ b) ∧ ¬(c ∨ d)) = (x ∨ z)"
+             (->infix (sym:= (and (or 'a 'b)
+                                  (not (or 'c 'd)))
+                             (or 'x 'z))))))))
 
 (deftest equation-wrapper-tests
   (is (= (str "\\begin{equation}\n"

--- a/test/sicmutils/operator_test.cljc
+++ b/test/sicmutils/operator_test.cljc
@@ -88,21 +88,35 @@
                           (with-meta o/identity m))))))))
 
 (deftest simplifier-tests
+  (testing "identity gets stripped from products"
+    (is (= 'D
+           (v/freeze (g/* D o/identity))
+           (v/freeze (g/* o/identity D)))))
+
+  (testing "identity does NOT get stripped from sums"
+    (is (= '(+ identity D)
+           (v/freeze
+            (g/+ o/identity D))))
+
+    (is (= '(+ D identity)
+           (v/freeze
+            (g/+ D o/identity)))))
+
   (let [x2 (-> (fn [f] (fn [x] (* 2 (f x))))
                (o/make-operator 'double))]
     (is (= '(+ D (* D double (expt D 2)))
            (v/freeze
             (g/+ D (g/* D x2 o/identity D D))))
         "operators next to each other are gathered into exponents, and `identity`
-      gets removed (since it's the multiplicative identity)"))
+      gets removed (since it's the multiplicative identity)")
 
-  (is (= '(expt D 2)
-         (v/freeze (g/* D D))))
+    (is (= '(expt D 2)
+           (v/freeze (g/* D D))))
 
-  (is (= '(* D identity D)
-         (v/freeze (g/* (* D o/identity) D)))
-      "multiplication is commutative but NOT associative, so we gather these
-       together.")
+    (is (= '(* D double D)
+           (v/freeze (g/* (* D x2) D)))
+        "multiplication is commutative but NOT associative, so we gather these
+       together."))
 
   (testing "internal multiplication on both sides"
     (is (= '(expt D 6)

--- a/test/sicmutils/operator_test.cljc
+++ b/test/sicmutils/operator_test.cljc
@@ -88,10 +88,13 @@
                           (with-meta o/identity m))))))))
 
 (deftest simplifier-tests
-  (is (= '(+ D (* D identity (expt D 2)))
-         (v/freeze
-          (g/+ D (g/* D o/identity D D))))
-      "operators next to each other are gathered into exponents.")
+  (let [x2 (-> (fn [f] (fn [x] (* 2 (f x))))
+               (o/make-operator 'double))]
+    (is (= '(+ D (* D double (expt D 2)))
+           (v/freeze
+            (g/+ D (g/* D x2 o/identity D D))))
+        "operators next to each other are gathered into exponents, and `identity`
+      gets removed (since it's the multiplicative identity)"))
 
   (is (= '(expt D 2)
          (v/freeze (g/* D D))))
@@ -355,4 +358,5 @@
       (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
                    (+ q p))))))
 
-    ;;; more testing to come as we implement multivariate literal functions that rely on operations on structures....
+    ;;; more testing to come as we implement multivariate literal functions that
+    ;;; rely on operations on structures....


### PR DESCRIPTION
I buckled and added to the simplifier for operators. Now `identity` gets stripped out of products. This will cause problems if someone names a NEW operator `identity`... but let's just hope no one does that!

From the CHANGELOG, this PR adds:

   - symbolic boolean implementations for `sym:=`, `sym:and`, `sym:or` and
     `sym:not` with infix, latex and JavaScript renderers.
   - `sym:derivative`, for purely symbolic derivatives

   The boolean operators will act just like `=`, `and` and `or` on booleans, and
   appropriately respond if just one side is a boolean. If both sides are
   symbolic, These return a form like `(= a b)`, `(and a b)` or `(or a b)`.

   The functions currently live in `sicmutils.numsymb` only; access them via
   `(numsymb/symbolic-operator <sym>)`, where `<sym>` is one of `'=`, `'and`,
   `'or`, `'not` or `'derivative`.