### PR TITLE
Associative, non-commutative simplifier for operator names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [unreleased]
 
+- #320: `Operator` gains a new simplifier for its `name` field; the simplifier
+  applies the associative rule to products and sums of operators, and collapses
+  (adjacent) products down into exponents. `Operator` multiplication (function
+  composition) is associative but NOT commutative, so the default simplifier is
+  not appropriate.
+
+  Before this change:
+
+```clojure
+sicmutils.env> (series/exp-series D)
+#object[sicmutils.series.Series
+  "(+ identity
+      (* D identity)
+      (* (/ 1 2) (* D (* D identity)))
+      (* (/ 1 6) (* D (* D (* D identity)))) ...)"]
+```
+
+  After:
+
+```clojure
+sicmutils.env> (series/exp-series D)
+#object[sicmutils.series.Series
+  "(+ identity
+      (* D identity)
+      (* (/ 1 2) (expt D 2) identity)
+      (* (/ 1 6) (expt D 3)) ...)"]
+```
+
 - #315: `g/log2` and `g/log10` on symbolic expressions now stay exact, instead
   of evaluating `(log 2)` or `(log 10)` and getting a non-simplifiable real
   number in the denominator:

--- a/src/sicmutils/operator.cljc
+++ b/src/sicmutils/operator.cljc
@@ -40,7 +40,7 @@
   simplify-operator-name
   (rule-simplifier
    (rules/associative '+ '*)
-   rules/product->expt
+   rules/exponent-contract
    (rules/unary-elimination '+ '*)))
 
 (declare op:get)

--- a/src/sicmutils/operator.cljc
+++ b/src/sicmutils/operator.cljc
@@ -54,7 +54,7 @@
   (one-like [_] (Operator. core-identity arity 'identity context m))
   (identity-like [_] (Operator. core-identity arity 'identity context m))
   (freeze [_]
-    (simplify-operator
+    (simplify-operator-name
      (v/freeze name)))
   (kind [_] (:subtype context))
 

--- a/src/sicmutils/simplify/rules.cljc
+++ b/src/sicmutils/simplify/rules.cljc
@@ -78,27 +78,37 @@
     (ruleset
      (:op :x) #(op-set (% :op)) :x)))
 
-(def ^{:doc "Set of rules that collect adjacent products into exponents."}
-  product->expt
+(def ^{:doc "Set of rules that collect adjacent products, exponents and nested
+ exponents into exponent terms."}
+  exponent-contract
   (ruleset
+   ;; nested exponent case.
+   (expt (expt :op (:? n v/integral?))
+         (:? m v/integral?))
+   => (expt :op (:? #(g/+ (% 'n) (% 'm))))
+
+   ;; adjacent pairs of exponents
    (* :pre*
-      (expt :op (:? lexpt v/integral?))
-      (expt :op (:? rexpt v/integral?))
+      (expt :op (:? n v/integral?))
+      (expt :op (:? m v/integral?))
       :post*)
    => (* :pre*
-         (expt :op (:? #(g/+ (% 'lexpt)
-                             (% 'rexpt))))
+         (expt :op (:? #(g/+ (% 'n) (% 'm))))
          :post*)
+
+   ;; exponent on right, non-expt on left
    (* :pre*
       :op (expt :op (:? n v/integral?))
       :post*)
    => (expt :op (:? #(g/+ (% 'n) 1)))
 
+   ;; exponent on left, non-expt on right
    (* :pre*
       (expt :op (:? n v/integral?)) :op
       :post*)
    => (* :pre* (expt :op (:? #(g/+ (% 'n) 1))) :post*)
 
+   ;; non-exponent pairs
    (* :pre* :op :op :post*)
    => (* :pre* (expt :op 2) :post*)))
 

--- a/src/sicmutils/simplify/rules.cljc
+++ b/src/sicmutils/simplify/rules.cljc
@@ -78,8 +78,7 @@
     (ruleset
      (:op :x) #(op-set (% :op)) :x)))
 
-(def ^{:private true
-       :doc "Set of rules that collect adjacent products into exponents."}
+(def ^{:doc "Set of rules that collect adjacent products into exponents."}
   product->expt
   (ruleset
    (* :pre*

--- a/test/sicmutils/operator_test.cljc
+++ b/test/sicmutils/operator_test.cljc
@@ -87,6 +87,39 @@
                 (is (= m (meta
                           (with-meta o/identity m))))))))
 
+(deftest simplifier-tests
+  (is (= '(+ D (* D identity (expt D 2)))
+         (v/freeze
+          (g/+ D (g/* D o/identity D D))))
+      "operators next to each other are gathered into exponents.")
+
+  (is (= '(expt D 2)
+         (v/freeze (g/* D D))))
+
+  (is (= '(* D identity D)
+         (v/freeze (g/* (* D o/identity) D)))
+      "multiplication is commutative but NOT associative, so we gather these
+       together.")
+
+  (testing "internal multiplication on both sides"
+    (is (= '(expt D 6)
+           (v/freeze (g/* (g/* D D D) (g/* D D D)))
+           (v/freeze (g/* (g/* D (g/expt D 2)) (g/* D D D)))
+           (v/freeze (g/* (g/* (g/expt D 2) D) (g/* D D D)))
+           (v/freeze (g/* (g/* D D D) (g/* D (g/expt D 2))))
+           (v/freeze (g/* (g/* D D D) (g/* (g/expt D 2) D)))
+           (v/freeze (g/* (g/* D D D) (g/* D (g/expt D 2))))
+           (v/freeze (g/* (g/* D D D) (g/* (g/expt D 2) D))))))
+
+  (testing "internal multiplication on right"
+    (is (= '(expt D 4)
+           (v/freeze (g/* D (g/* D D D)))
+           (v/freeze (g/* (g/expt D 2) (g/* D D)))
+           (v/freeze (g/* D (g/* D (g/expt D 2))))
+           (v/freeze (g/* D (g/* (g/expt D 2) D)))
+           (v/freeze (g/* D (g/* D (g/expt D 2))))
+           (v/freeze (g/* D (g/* (g/expt D 2) D)))))))
+
 (deftest custom-getter-tests
   (checking "I == identity" 100 [x gen/any-equatable]
             (is (= x (o/identity x)))

--- a/test/sicmutils/operator_test.cljc
+++ b/test/sicmutils/operator_test.cljc
@@ -104,7 +104,7 @@
   (testing "internal multiplication on both sides"
     (is (= '(expt D 6)
            (v/freeze (g/* (g/* D D D) (g/* D D D)))
-           (v/freeze (g/* (g/* D (g/expt D 2)) (g/* D D D)))
+           (v/freeze (g/* (g/* D (g/expt D 2) D) (g/* D D)))
            (v/freeze (g/* (g/* (g/expt D 2) D) (g/* D D D)))
            (v/freeze (g/* (g/* D D D) (g/* D (g/expt D 2))))
            (v/freeze (g/* (g/* D D D) (g/* (g/expt D 2) D)))
@@ -118,7 +118,12 @@
            (v/freeze (g/* D (g/* D (g/expt D 2))))
            (v/freeze (g/* D (g/* (g/expt D 2) D)))
            (v/freeze (g/* D (g/* D (g/expt D 2))))
-           (v/freeze (g/* D (g/* (g/expt D 2) D)))))))
+           (v/freeze (g/* D (g/* (g/expt D 2) D))))))
+
+  (testing "sums collapse too via the associative rule"
+    (is (= '(+ D (partial 1) (expt D 3))
+           (v/freeze
+            (g/+ D (g/+ (partial 1) (g/* D (g/expt D 2)))))))))
 
 (deftest custom-getter-tests
   (checking "I == identity" 100 [x gen/any-equatable]


### PR DESCRIPTION
This PR adds a simplifier that can properly handle the `name` field for operators.

The scmutils codebase just uses the normal simplifier, which can re-order arguments; this is no good! I think the only simplification we should EVER perform is turning multiplication into exponentiation.

@littleredcomputer what do you think?