### PR TITLE
Change default down-tuple rendering style to horizontal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [unreleased]
 
+- #321 changes the default `TeX` rendering style for `down` tuples back to
+  horizontal, undoing #283. @kloimhardt made a solid case that because `down`
+  tuples represent row vectors, it's not helpful for building knowledge and
+  intuition to only distinguish these with differently-shaped braces.
+  Intuition-builders win!
+
 - #319: adds
 
   - symbolic boolean implementations for `sym:=`, `sym:and`, `sym:or` and

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -394,8 +394,9 @@
 
 (def ^{:dynamic true
        :doc "If true, [[->TeX]] will render down tuples as vertical matrices
-  with square braces. Defaults to true."}
-  *TeX-vertical-down-tuples* true)
+  with square braces. Defaults to false."}
+  *TeX-vertical-down-tuples*
+  false)
 
 (def ^{:dynamic true
        :doc "If true, [[->TeX]] will render symbols with more than 1 character

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -131,20 +131,20 @@
           (down (up 1 2) (up 3 4)))))
 
   (testing "customizable down tuple rendering in TeX"
-    (is (= (str "\\begin{bmatrix}\\"
-                "displaystyle{1} \\cr \\cr "
-                "\\displaystyle{2} \\cr \\cr "
-                "\\displaystyle{3}"
+    (is (= (str "\\begin{bmatrix}"
+                "\\displaystyle{1}&\\displaystyle{2}&\\displaystyle{3}"
                 "\\end{bmatrix}")
            (->TeX (down 1 2 3)))
-        "Downs render vertically by default")
+        "Downs render horizontally by default")
 
-    (binding [r/*TeX-vertical-down-tuples* false]
-      (is (= (str "\\begin{bmatrix}"
-                  "\\displaystyle{1}&\\displaystyle{2}&\\displaystyle{3}"
+    (binding [r/*TeX-vertical-down-tuples* true]
+      (is (= (str "\\begin{bmatrix}\\"
+                  "displaystyle{1} \\cr \\cr "
+                  "\\displaystyle{2} \\cr \\cr "
+                  "\\displaystyle{3}"
                   "\\end{bmatrix}")
              (->TeX (down 1 2 3)))
-          "bind the dynamic variable falsey to get horz down tuples."))))
+          "bind the dynamic variable truthy to get vertical down tuples."))))
 
 (deftest variable-sub-super-scripts
   (testing "infix"


### PR DESCRIPTION
cc @kloimhardt , @littleredcomputer ...

From @kloimhardt :

> I just discovered that in sicmutils 0.16.0 the TeX representation of a (down ...) tuple is a column in square brackets. Not a row anymore. Is it possible to make that column visualization optional via setting some global variable (and set the default to the old row setting)? I think covectors should be displayed as rows whenever visually possible.

> Rationale: One main advantage of sicmutils over Mathematica is, that the distinction between covector and (contravariant) vector is built in at the core. I think most of the hardship in understanding Analytical Mechanics (and books like Arnold) stem from the fact that students grow up with just one type of vector and the corresponding easy to use vector products (inner product and cross product). But on the long run, those easy rules for multiplying vectors do harm. In the usual linear algebra courses, the only hint that there are two types of vectors (dual vector spaces) is the rule for matrix multiplication. This rule is often explained and memorized visually: tilt the vector to the right of the matrix and overlay it onto the rows of the matrix and multiply the numbers, do this for every row.

> I hereby argue that having two column vectors side by side makes one think of the old and wrong inner product, even if the left column is square bracketed. I think it is very important to not allow some student of sicmutils to mentally think of the easy,old,wrong inner product when he is really doing a matrix multiplication, the only door they know to enter dual spaces.
Of course, for some seasoned pro who works with expressions containing dozens of terms, this visual rule is not necessary anymore. But I think even a local setting in the actual code to break the row after each term would be acceptable for a pro.

From the CHANGELOG:

- #321 changes the default `TeX` rendering style for `down` tuples back to
  horizontal, undoing #283. @kloimhardt made a solid case that because `down`
  tuples represent row vectors, it's not helpful for building knowledge and
  intuition to only distinguish these with differently-shaped braces.
  Intuition-builders win!