### PR TITLE
Fix simplifier bug with exprs like (sqrt (literal-number 2))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+- #329 fixes a bug where the simplifier couldn't handle expressions like `(sqrt
+  (literal-number 2))`, where literal numbers with no symbols were nested inside
+  of symbolic expressions.
+
 - #326 is a large PR that marks the start of a big push toward full
   implementation of the ideas in "Functional Differential Geometry". Here is the
   full list of changes:

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -29,8 +29,15 @@
             [sicmutils.value :as v]
             #?(:cljs [goog.string :refer [format]])))
 
-(def coefficient second)
-(def exponents first)
+(defn exponents [term]
+  (if term
+    (nth term 0)
+    []))
+
+(defn coefficient [term]
+  (if term
+    (nth term 1)
+    0))
 
 ;; ## Monomials
 ;;
@@ -75,7 +82,7 @@
 
 ;; ## Polynomials
 
-(declare evaluate make-constant poly->str)
+(declare evaluate make-constant poly->str poly:zero poly:one)
 
 (deftype Polynomial [arity xs->c]
   v/Value
@@ -443,9 +450,11 @@
 (defn partial-derivatives
   "The sequence of partial derivatives of p with respect to each
   indeterminate"
-  [^Polynomial p]
-  (for [i (range (.-arity p))]
-    (partial-derivative p i)))
+  [p]
+  (if (v/number? p)
+    [1]
+    (for [i (range (.-arity ^Polynomial p))]
+      (partial-derivative p i))))
 
 ;; ## Canonicalizer
 

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -30,14 +30,10 @@
             #?(:cljs [goog.string :refer [format]])))
 
 (defn exponents [term]
-  (if term
-    (nth term 0)
-    []))
+  (nth term 0 []))
 
 (defn coefficient [term]
-  (if term
-    (nth term 1)
-    0))
+  (nth term 1 0))
 
 ;; ## Monomials
 ;;
@@ -82,7 +78,7 @@
 
 ;; ## Polynomials
 
-(declare evaluate make-constant poly->str poly:zero poly:one)
+(declare evaluate make-constant poly->str)
 
 (deftype Polynomial [arity xs->c]
   v/Value

--- a/src/sicmutils/polynomial/factor.cljc
+++ b/src/sicmutils/polynomial/factor.cljc
@@ -42,7 +42,7 @@
            old-m (v/one-like p)]
       (if (v/one? m)
         (answer tracker h)
-        (let [gg (-> h poly/partial-derivatives gcd-seq)
+        (let [gg    (gcd-seq (poly/partial-derivatives h))
               new-s (g/exact-divide h (gcd h gg))
               new-m (gcd gg new-s)
               facts (g/exact-divide old-s new-s)
@@ -65,11 +65,13 @@
 (defn factor-polynomial-expression
   [simplifier analyzer p]
   (a/expression->
-    analyzer
-    (x/expression-of p)
-    (fn [p v]
-      (map (fn [factor] (simplifier (a/->expression analyzer factor v)))
-           (split p)))))
+   analyzer
+   (x/expression-of p)
+   (fn [p v]
+     (map (fn [factor]
+            (simplifier
+             (a/->expression analyzer factor v)))
+          (split p)))))
 
 (defn- flatten-product
   "Construct a list with all the top-level products in args spliced
@@ -95,9 +97,12 @@
         poly-> (partial a/->expression poly-analyzer)]
     (a/make-analyzer
      (reify a/ICanonicalize
-       (expression-> [_ expr cont v-compare] (a/expression-> poly-analyzer expr cont v-compare))
-       (->expression [_ p vars] (->factors p poly-> vars))
-       (known-operation? [_ o] (a/known-operation? poly-analyzer o)))
+       (expression-> [_ expr cont v-compare]
+         (a/expression-> poly-analyzer expr cont v-compare))
+       (->expression [_ p vars]
+         (->factors p poly-> vars))
+       (known-operation? [_ o]
+         (a/known-operation? poly-analyzer o)))
      (a/monotonic-symbol-generator "-f-"))))
 
 (defn ^:private assume!

--- a/src/sicmutils/simplify.cljc
+++ b/src/sicmutils/simplify.cljc
@@ -142,7 +142,6 @@
        (atan :y :x)
        #(not (simplifies-to-one? `(~'gcd ~(% :x) ~(% :y))))
        (atan (/ :y (gcd :x :y)) (/ :x (gcd :x :y)))
-
        ))
      simplify-and-flatten)))
 
@@ -157,38 +156,32 @@
   stabilizes.)"
   [x]
   (-> x
-      rules/canonicalize-partials
-      rules/trig->sincos
-      simplify-and-flatten
-      rules/complex-trig
-      sincos-simplifier
-      sin-sq->cos-sq-simplifier
-      trig-cleanup
-      rules/sincos->trig
-      rules/sqrt-expand
-      simplify-and-flatten
-      rules/sqrt-contract
-      square-root-simplifier
-      clear-square-roots-of-perfect-squares
-      simplify-and-flatten
-      ))
+      (rules/canonicalize-partials)
+      (rules/trig->sincos)
+      (simplify-and-flatten)
+      (rules/complex-trig)
+      (sincos-simplifier)
+      (sin-sq->cos-sq-simplifier)
+      (trig-cleanup)
+      (rules/sincos->trig)
+      (rules/sqrt-expand)
+      (simplify-and-flatten)
+      (rules/sqrt-contract)
+      (square-root-simplifier)
+      (clear-square-roots-of-perfect-squares)
+      (simplify-and-flatten)))
 
 (def simplify-expression
   (simplify-until-stable simplify-expression-1 simplify-and-flatten))
 
-(defn simplify-numerical-expression
-  "Runs the content of the Literal e through the simplifier, but leaves the result
-  in Literal form."
-  [e]
-  (if (x/abstract? e)
-    (x/fmap simplify-expression e)
-    e))
-
-(defn ^:private haz
+(defn- haz
   "Returns a function which checks whether its argument, a set, has a nonempty
   intersection with thing-set."
   [thing-set]
-  #(-> % x/variables-in (set/intersection thing-set) not-empty))
+  (fn [expr]
+    (-> (x/variables-in expr)
+        (set/intersection thing-set)
+        (not-empty))))
 
 (defn only-if
   "returns a function that will apply f to its argument x if (p x), else returns x."

--- a/test/sicmutils/calculus/manifold_test.cljc
+++ b/test/sicmutils/calculus/manifold_test.cljc
@@ -216,16 +216,13 @@
                        (/ 1 (sqrt (+ (expt x 2) (expt y 2) 1))))]
         (rep-roundtrips? S2-gnomonic point rep))
 
-      (comment
-        ;; TODO this is broken until we get the simplifier fine with expressions
-        ;; like `(sqrt 2)`.
-        (is (= '(up (/ (cos theta) (sqrt 2))
-                    (/ (sin theta) (sqrt 2))
-                    (/ 1 (sqrt 2)))
-               (s-freeze
-                (m/manifold-point-representation
-                 ((m/point S2-gnomonic)
-                  (up (g/cos 'theta) (g/sin 'theta))))))))
+      (is (= '(up (/ (cos theta) (sqrt 2))
+                  (/ (sin theta) (sqrt 2))
+                  (/ 1 (sqrt 2)))
+             (s-freeze
+              (m/manifold-point-representation
+               ((m/point m/S2-gnomonic)
+                (up (g/cos 'theta) (g/sin 'theta)))))))
 
       ;; The unit circle on the plane represents the intersection of S2 and z
       ;; = (/ 1 (sqrt 2))

--- a/test/sicmutils/function_test.cljc
+++ b/test/sicmutils/function_test.cljc
@@ -598,8 +598,8 @@
                               (gen/tuple
                                (gen/vector sg/real n)
                                (gen/vector sg/real n)))]
-            (is (== (apply (apply f/arg-scale g/+ factors) args)
-                    (apply g/+ (map g/* factors args)))))
+            (is (ish? (apply (apply f/arg-scale g/+ factors) args)
+                      (apply g/+ (map g/* factors args)))))
 
   (testing "arg-scale unit"
     (is (= 144 ((f/arg-scale g/square 3) 4)))


### PR DESCRIPTION
From the CHANGELOG:

- #329 fixes a bug where the simplifier couldn't handle expressions like `(sqrt
  (literal-number 2))`, where literal numbers with no symbols were nested inside
  of symbolic expressions.