### PR TITLE
add real-part, imag-part implementations for structures, matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+- #330 adds `g/real-part` and `g/imag-part` implementations for
+  `sicmutils.structure.Structure` and `sicmutils.matrix.Matrix` instances. These
+  pass through to the entries in the structure or matrix.
+
 - #329 fixes a bug where the simplifier couldn't handle expressions like `(sqrt
   (literal-number 2))`, where literal numbers with no symbols were nested inside
   of symbolic expressions.

--- a/src/sicmutils/matrix.cljc
+++ b/src/sicmutils/matrix.cljc
@@ -855,8 +855,9 @@
 
 (defmethod g/invert [::matrix] [m] (invert m))
 
-(defmethod g/conjugate [::matrix] [m]
-  (fmap g/conjugate m))
+(defmethod g/real-part [::matrix] [m] (fmap g/real-part m))
+(defmethod g/imag-part [::matrix] [m] (fmap g/imag-part m))
+(defmethod g/conjugate [::matrix] [m]  (fmap g/conjugate m))
 
 (defmethod g/transpose [::matrix] [m] (transpose m))
 (defmethod g/trace [::square-matrix] [m] (trace m))

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -904,8 +904,9 @@
 (defmethod g/abs [::structure] [a]
   (g/sqrt (dot-product a a)))
 
-(defmethod g/conjugate [::structure] [a]
-  (mapr g/conjugate a))
+(defmethod g/real-part [::structure] [m] (mapr g/real-part m))
+(defmethod g/imag-part [::structure] [m] (mapr g/imag-part m))
+(defmethod g/conjugate [::structure] [a] (mapr g/conjugate a))
 
 (defmethod g/transpose [::structure] [a] (transpose a))
 (defmethod g/dimension [::structure] [a] (dimension a))

--- a/test/sicmutils/matrix_test.cljc
+++ b/test/sicmutils/matrix_test.cljc
@@ -615,7 +615,17 @@
                               [(g/conjugate c)
                                (g/conjugate d)])
                    (g/conjugate
-                    (m/by-rows [a b] [c d]))))))
+                    (m/by-rows [a b] [c d])))))
+
+  (checking "g/real-part, g/imag-part pass through to values" 100
+            [a sg/complex b sg/complex
+             c sg/complex d sg/complex]
+            (let [M (m/by-rows [a b] [c d])]
+              (is (= (m/fmap g/real-part M)
+                     (g/real-part M)))
+
+              (is (= (m/fmap g/imag-part M)
+                     (g/imag-part M))))))
 
 (defspec p+q=q+p
   (gen/let [n (gen/choose 1 10)]

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -1086,6 +1086,16 @@
       (is (= (g/sqrt (g/square m))
              (c/complex (g/abs m))))))
 
+  (testing "g/real-part, g/imag-part"
+    (let [struct [#sicm/complex "3+4i"
+                  (s/up #sicm/complex "3+4i")
+                  (s/down #sicm/complex "3+4i")]]
+      (is (= (s/up 3.0 (s/up 3.0) (s/down 3.0))
+             (g/real-part struct)))
+
+      (is (= (s/up 4.0 (s/up 4.0) (s/down 4.0))
+             (g/imag-part struct)))))
+
   (testing "g/conjugate"
     (is (= (s/up 3 4 5) (g/conjugate [3 4 5])))
     (is (= (s/up #sicm/complex "3-4i")


### PR DESCRIPTION
From the CHANGELOG:

- #330 adds `g/real-part` and `g/imag-part` implementations for
  `sicmutils.structure.Structure` and `sicmutils.matrix.Matrix` instances. These
  pass through to the entries in the structure or matrix.