### PR TITLE
Install make-{polar, rectangular} for structures and matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - #330 adds `g/real-part` and `g/imag-part` implementations for
   `sicmutils.structure.Structure` and `sicmutils.matrix.Matrix` instances. These
-  pass through to the entries in the structure or matrix.
+  pass through to the entries in the structure or matrix. #331 adds similar
+  implementations for `g/make-rectangular` and `g/make-polar`.
 
 - #329 fixes a bug where the simplifier couldn't handle expressions like `(sqrt
   (literal-number 2))`, where literal numbers with no symbols were nested inside

--- a/src/sicmutils/matrix.cljc
+++ b/src/sicmutils/matrix.cljc
@@ -74,7 +74,7 @@
   #?@(:clj
       [Object
        (equals [this that] (m:= this that))
-       (toString [_] (str v))
+       (toString [_] (pr-str v))
 
        Sequential
 
@@ -137,7 +137,7 @@
 
       :cljs
       [Object
-       (toString [_] (str v))
+       (toString [_] (pr-str v))
 
        IPrintWithWriter
        (-pr-writer [x writer _]
@@ -854,6 +854,12 @@
 (defmethod g/simplify [::matrix] [m] (fmap g/simplify m))
 
 (defmethod g/invert [::matrix] [m] (invert m))
+
+(defmethod g/make-rectangular [::matrix ::matrix] [a b]
+  (elementwise g/make-rectangular a b))
+
+(defmethod g/make-polar [::matrix ::matrix] [a b]
+  (elementwise g/make-polar a b))
 
 (defmethod g/real-part [::matrix] [m] (fmap g/real-part m))
 (defmethod g/imag-part [::matrix] [m] (fmap g/imag-part m))

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -103,7 +103,7 @@
        (toString [_] (str "("
                           (orientation orientation->symbol)
                           " "
-                          (join " " (map str v))
+                          (join " " (map pr-str v))
                           ")"))
 
        Sequential
@@ -176,7 +176,8 @@
       :cljs
       [Object
        (toString [_] (str "("
-                          (orientation orientation->symbol) " " (join " " (map str v))
+                          (orientation orientation->symbol)
+                          " " (join " " (map pr-str v))
                           ")"))
 
        IPrintWithWriter
@@ -903,6 +904,22 @@
 
 (defmethod g/abs [::structure] [a]
   (g/sqrt (dot-product a a)))
+
+;; NOTE: `g/make-rectangular` and `g/make-polar` _should_ check that both
+;; dimensions match all the way down, but they currently don't. Use with that in
+;; mind!
+
+(defmethod g/make-rectangular [::up ::up] [a b]
+  (mapr g/make-rectangular a b))
+
+(defmethod g/make-rectangular [::down ::down] [a b]
+  (mapr g/make-rectangular a b))
+
+(defmethod g/make-polar [::up ::up] [a b]
+  (mapr g/make-polar a b))
+
+(defmethod g/make-polar [::down ::down] [a b]
+  (mapr g/make-polar a b))
 
 (defmethod g/real-part [::structure] [m] (mapr g/real-part m))
 (defmethod g/imag-part [::structure] [m] (mapr g/imag-part m))

--- a/test/sicmutils/matrix_test.cljc
+++ b/test/sicmutils/matrix_test.cljc
@@ -617,6 +617,25 @@
                    (g/conjugate
                     (m/by-rows [a b] [c d])))))
 
+  (checking "g/make-rectangular, g/make-polar" 100
+            [a sg/real b sg/real
+             c sg/real d sg/real]
+            (let [M (m/by-rows [a b] [c d])]
+              (is (= (m/fmap #(g/make-rectangular % %) M)
+                     (g/make-rectangular M M)))
+
+              (is (= (m/fmap #(g/make-polar % %) M)
+                     (g/make-polar M M)))))
+
+  (testing "incompatible shapes throw for g/make-*"
+    (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+                 (g/make-rectangular (m/by-rows [1 2 3])
+                                     (m/by-rows [1 2]))))
+
+    (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+                 (g/make-polar (m/by-rows [1 2 3])
+                               (m/by-rows [1 2])))))
+
   (checking "g/real-part, g/imag-part pass through to values" 100
             [a sg/complex b sg/complex
              c sg/complex d sg/complex]
@@ -625,13 +644,26 @@
                      (g/real-part M)))
 
               (is (= (m/fmap g/imag-part M)
-                     (g/imag-part M))))))
+                     (g/imag-part M)))
+
+              (is (= M (g/make-rectangular
+                        (g/real-part M)
+                        (g/imag-part M)))
+                  "g/make-rectangular rebuilds the original matrix from its
+                  parts."))))
 
 (defspec p+q=q+p
   (gen/let [n (gen/choose 1 10)]
     (prop/for-all [p (sg/square-matrix n)
                    q (sg/square-matrix n)]
                   (= (g/+ p q) (g/+ q p)))))
+
+(defspec make-rectangular-imag-real-round-trip
+  (gen/let [n (gen/choose 1 10)]
+    (prop/for-all [M (sg/square-matrix n sg/complex)]
+                  (= M (g/make-rectangular
+                        (g/real-part M)
+                        (g/imag-part M))))))
 
 
 (defspec pq*r=p*qr

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -1086,15 +1086,26 @@
       (is (= (g/sqrt (g/square m))
              (c/complex (g/abs m))))))
 
-  (testing "g/real-part, g/imag-part"
-    (let [struct [#sicm/complex "3+4i"
-                  (s/up #sicm/complex "3+4i")
-                  (s/down #sicm/complex "3+4i")]]
-      (is (= (s/up 3.0 (s/up 3.0) (s/down 3.0))
-             (g/real-part struct)))
+  (testing "g/real-part, g/imag-part, g/make-rectangular, g/make-polar"
+    (let [s3      [3 (s/up 3) (s/down 3)]
+          s4      [4 (s/up 4) (s/down 4)]
+          s-rect  (g/make-rectangular s3 s4)
+          s-polar (g/make-polar s3 s4)]
+      (is (ish? s3 (g/real-part s-rect)))
+      (is (ish? s4 (g/imag-part s-rect)))
 
-      (is (= (s/up 4.0 (s/up 4.0) (s/down 4.0))
-             (g/imag-part struct)))))
+      (is (ish? s3 (s/mapr g/magnitude s-polar))
+          "magnitudes are mirrored back out")
+      (is (ish? s4 (s/mapr (comp #(g/modulo % (* 2 Math/PI))
+                                 g/angle)
+                           s-polar))
+          "angles are mirrored back out, but only equal after we mod by 2pi.")))
+
+  (checking "g/make-rectangular rebuilds the original structure" 100
+            [s (sg/structure sg/complex 3)]
+            (is (= s (g/make-rectangular
+                      (g/real-part s)
+                      (g/imag-part s)))))
 
   (testing "g/conjugate"
     (is (= (s/up 3 4 5) (g/conjugate [3 4 5])))


### PR DESCRIPTION
This PR installs `g/make-rectangular` and `g/make-polar` impls for structures and matrices. This lets us easily build complex matrices and structures from real components.

Closes #194.