### PR TITLE
Implement add for sets, add, sub, negate for maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [unreleased]
 
+- #334 adds implementations of `g/add` and the `sicmutils.value.Value` protocol
+  for clojure's Set data structure. Addition is defined as set union, and
+  `(zero-like <set>)` returns the empty set.
+
+- #334 implements `g/add`, `g/negate` and `g/sub` for Clojure's Map data
+  structure. Map addition is defined as a merge using `g/add` on clashing
+  values; `g/sub` is the same, but any values on the right side not on the left
+  side are negated.
+
 ## 0.17.0
 
 > (If you have any questions about how to use any of the following, please ask us

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   values; `g/sub` is the same, but any values on the right side not on the left
   side are negated.
 
+  Maps can also be multiplied with scalars (commutatively) or divided (scalar on
+  the right side only) by scalars. This, plus the commutative group property
+  declared above, mean that Clojure's maps are sparse vector spaces over
+  anything that responds true to `sicmutils.value/scalar?`... currently anything
+  in the numeric tower up to complex, along with symbolic expressions and
+  `Differential` instances.
+
 ## 0.17.0
 
 > (If you have any questions about how to use any of the following, please ask us

--- a/src/sicmutils/collection.cljc
+++ b/src/sicmutils/collection.cljc
@@ -127,6 +127,15 @@
 (defmethod g/sub [::map ::map] [a b]
   (merge-with g/add a (u/map-vals g/negate b)))
 
+(defmethod g/mul [::map ::v/scalar] [m x]
+  (u/map-vals #(g/mul % x) m))
+
+(defmethod g/mul [::v/scalar ::map] [x m]
+  (u/map-vals #(g/mul x %) m))
+
+(defmethod g/div [::map ::v/scalar] [m x]
+  (u/map-vals #(g/div % x) m))
+
 (defmethod g/simplify [::map] [m]
   (u/map-vals g/simplify m))
 

--- a/src/sicmutils/collection.cljc
+++ b/src/sicmutils/collection.cljc
@@ -188,7 +188,7 @@
 
    :cljs
    (do
-     (derive PersistentHashSet ::map)
+     (derive PersistentHashSet ::set)
      (derive PersistentTreeSet ::set)))
 
 (defmethod g/add [::set ::set] [a b]

--- a/src/sicmutils/collection.cljc
+++ b/src/sicmutils/collection.cljc
@@ -20,7 +20,8 @@
 (ns sicmutils.collection
   "This namespace contains implementations of various SICMUtils protocols for
   native Clojure collections."
-  (:require [sicmutils.differential :as d]
+  (:require [clojure.set :as cs]
+            [sicmutils.differential :as d]
             [sicmutils.function :as f]
             [sicmutils.generic :as g]
             [sicmutils.util :as u]
@@ -29,6 +30,7 @@
      (:import (clojure.lang PersistentVector
                             IPersistentVector
                             IPersistentMap
+                            IPersistentSet
                             ISeq
                             LazySeq))))
 
@@ -60,7 +62,7 @@
   ;; look it up), so they can't respond the same way as a structure via
   ;; arity. (the `2` arity takes an additional default value.)
   f/IArity
-  (arity [v] [:between 1 2])
+  (arity [_] [:between 1 2])
 
   ;; Vectors are functors, so they can be perturbed if any of their elements are
   ;; perturbed. [[d/replace-tag]] and [[d/extract-tangent]] pass the buck down
@@ -116,6 +118,15 @@
      (derive PersistentArrayMap ::map)
      (derive PersistentTreeMap ::map)))
 
+(defmethod g/negate [::map] [m]
+  (u/map-vals g/negate m))
+
+(defmethod g/add [::map ::map] [a b]
+  (merge-with g/add a b))
+
+(defmethod g/sub [::map ::map] [a b]
+  (merge-with g/add a (u/map-vals g/negate b)))
+
 (defmethod g/simplify [::map] [m]
   (u/map-vals g/simplify m))
 
@@ -150,9 +161,42 @@
    (kind [m] (:type m (type m)))
 
    f/IArity
-   (arity [m] [:between 1 2])
+   (arity [_] [:between 1 2])
 
    d/IPerturbed
    (perturbed? [m] (boolean (some d/perturbed? (vals m))))
    (replace-tag [m old new] (u/map-vals #(d/replace-tag % old new) m))
    (extract-tangent [m tag] (u/map-vals #(d/extract-tangent % tag) m))))
+
+
+;; ## Sets
+;;
+;; SICMUtils treats Clojure's set data structure as a monoid, with set union as
+;; the addition operation and the empty set as the zero element.
+
+#?(:clj
+   (derive IPersistentSet ::set)
+
+   :cljs
+   (do
+     (derive PersistentHashSet ::map)
+     (derive PersistentTreeSet ::set)))
+
+(defmethod g/add [::set ::set] [a b]
+  (cs/union a b))
+
+(#?@(:clj [do] :cljs [doseq [klass [PersistentHashSet PersistentTreeSet]]])
+ (extend-type #?(:clj IPersistentSet :cljs klass)
+   v/Value
+   (zero? [s] (empty? s))
+   (one? [_] false)
+   (identity? [_] false)
+   (zero-like [_] #{})
+   (one-like [s] (u/unsupported (str "one-like: " s)))
+   (identity-like [s] (u/unsupported (str "identity-like: " s)))
+   (exact? [_] false)
+   (freeze [s] (u/unsupported (str "freeze: " s)))
+   (kind [s] (type s))
+
+   f/IArity
+   (arity [_] [:between 1 2])))


### PR DESCRIPTION
From the CHANGELOG:

- #334 adds implementations of `g/add` and the `sicmutils.value.Value` protocol
  for clojure's Set data structure. Addition is defined as set union, and
  `(zero-like <set>)` returns the empty set.

- #334 implements `g/add`, `g/negate` and `g/sub` for Clojure's Map data
  structure. Map addition is defined as a merge using `g/add` on clashing
  values; `g/sub` is the same, but any values on the right side not on the left
  side are negated.

  Maps can also be multiplied with scalars (commutatively) or divided (scalar on
  the right side only) by scalars. This, plus the commutative group property
  declared above, mean that Clojure's maps are sparse vector spaces over
  anything that responds true to `sicmutils.value/scalar?`... currently anything
  in the numeric tower up to complex, along with symbolic expressions and
  `Differential` instances.