### PR TITLE
make-rectangular, make-polar, imag-part, real-part for maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [unreleased]
 
+- #335 implements `g/make-rectangular`, `g/make-polar` `g/real-part` and
+  `g/imag-part` for clojure's Map data structure. Maps are treated as sparse
+  vectors, any missing key on either side of `make-rectangular` or
+  `make-polar`is treated as a 0 (rather than an error because the keys don't
+  match, as in vectors).
+
 - #334 adds implementations of `g/add` and the `sicmutils.value.Value` protocol
   for clojure's Set data structure. Addition is defined as set union, and
   `(zero-like <set>)` returns the empty set.

--- a/src/sicmutils/collection.cljc
+++ b/src/sicmutils/collection.cljc
@@ -136,6 +136,25 @@
 (defmethod g/div [::map ::v/scalar] [m x]
   (u/map-vals #(g/div % x) m))
 
+(defn- combine [f m1 m2 l-default]
+  (letfn [(merge-entry [m e]
+			      (let [k (key e)
+                  v (val e)]
+			        (assoc m k (f (get m k l-default) v))))]
+    (reduce merge-entry m1 (seq m2))))
+
+(defmethod g/make-rectangular [::map ::map] [m1 m2]
+  (combine g/make-rectangular m1 m2 0))
+
+(defmethod g/make-polar [::map ::map] [m1 m2]
+  (combine g/make-polar m1 m2 0))
+
+(defmethod g/real-part [::map] [m]
+  (u/map-vals g/real-part m))
+
+(defmethod g/imag-part [::map] [m]
+  (u/map-vals g/imag-part m))
+
 (defmethod g/simplify [::map] [m]
   (u/map-vals g/simplify m))
 

--- a/test/sicmutils/collection_test.cljc
+++ b/test/sicmutils/collection_test.cljc
@@ -166,7 +166,13 @@
                          (g/make-rectangular m m)))
                 "real-part"))
 
-  (testing "make-rectangular etc for maps"
+  (checking "g/make-rectangular round trip on maps" 100
+            [m (gen/map gen/keyword sg/complex {:max-elements 5})]
+            (is (= m (g/make-rectangular
+                      (g/real-part m)
+                      (g/imag-part m)))))
+
+  (testing "make-rectangular etc for maps, unit"
     (is (v/= {:a (g/make-rectangular 1 2)
               :b 1
               :c (g/make-rectangular 0 1)}

--- a/test/sicmutils/collection_test.cljc
+++ b/test/sicmutils/collection_test.cljc
@@ -23,7 +23,7 @@
             [com.gfredericks.test.chuck.clojure-test :refer [checking]
              #?@(:cljs [:include-macros true])]
             [sicmutils.calculus.derivative :refer [D]]
-            [sicmutils.complex :refer [complex]]
+            [sicmutils.complex :refer [complex I]]
             [sicmutils.collection :as collection]
             [sicmutils.differential :as d]
             [sicmutils.function :as f]
@@ -114,7 +114,7 @@
 
   (checking "map is a sparse vector space over complex" 100
             [m1 (gen/map gen/keyword sg/real {:max-elements 5})
-             m2 (gen/map gen/keyword sg/real  {:max-elements 5})
+             m2 (gen/map gen/keyword sg/real {:max-elements 5})
              x sg/real]
             (is (ish? (u/map-vals #(g/* x %) m1)
                       (g/* x m1))
@@ -133,6 +133,51 @@
                              (g/* x m2))
                       (g/* x (g/add m1 m2)))
                 "multiplication distributes over group addition"))
+
+  (checking "g/make-{rectangular,polar} on maps" 100
+            [m (gen/map gen/keyword sg/real {:max-elements 5})]
+            (is (= m (g/make-rectangular m {}))
+                "make-rectangular with no imaginary parts is identity.")
+
+            (is (ish? (g/* m I)
+                      (g/make-rectangular {} m))
+                "every entry turns turns imaginary!")
+
+            (is (= m (g/make-polar m {}))
+                "make-polar with no angles is identity.")
+
+            (is (ish? (v/zero-like m)
+                      (g/make-polar {} m))
+                "if all angles comes from m, but every radius is 0, then the
+                resulting entries will be zero.")
+
+            (is (= m (g/real-part m))
+                "real-part on all real is id.")
+
+            (is (ish? (v/zero-like m)
+                      (g/imag-part m))
+                "imag-part on all real is zeor-like.")
+
+            (is (ish? m (g/imag-part
+                         (g/make-rectangular m m)))
+                "imag-part recovers all imaginary pieces")
+
+            (is (ish? m (g/real-part
+                         (g/make-rectangular m m)))
+                "real-part"))
+
+  (testing "make-rectangular etc for maps"
+    (is (v/= {:a (g/make-rectangular 1 2)
+              :b 1
+              :c (g/make-rectangular 0 1)}
+             (g/make-rectangular {:a 1 :b 1}
+                                 {:a 2 :c 1})))
+
+    (is (v/= {:a (g/make-polar 1 2)
+              :b 1
+              :c (g/make-polar 0 1)}
+             (g/make-polar {:a 1 :b 1}
+                           {:a 2 :c 1}))))
 
   (testing "Map protocol implementations"
     (checking "f/arity" 100 [m (gen/map gen/keyword sg/any-integral)]


### PR DESCRIPTION
From the CHANGELOG:

- #335 implements `g/make-rectangular`, `g/make-polar` `g/real-part` and
  `g/imag-part` for clojure's Map data structure. Maps are treated as sparse
  vectors, any missing key on either side of `make-rectangular` or
  `make-polar`is treated as a 0 (rather than an error because the keys don't
  match, as in vectors).