### PR TITLE
Port curvature.scm, fix operator behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [unreleased]
 
+- #337:
+
+  - adds `sicmutils.calculus.curvature`, with these new functions and many tests
+    from the classic "Gravitation" book:
+
+    `Riemann-curvature`, `Riemann`, `Ricci`, `torsion-vector`, `torsion` and
+    `curvature-components`
+
+  - If you combine `Operator` instances with non-equal `:subtype` fields, the
+    returned operator now keeps the parent subtype (or throws if one is not a
+    subtype of the other).
+
+  - `Operator` instances now ignore any `identity?`-passing operator on the left
+    or right side of operator-operator multiplication. Contexts are still
+    appropriately merged.
+
+  - Similarly, `Operator` addition ignores `zero?` operators on the left or
+    right side, and subtraction ignores `zero?` operators on the right right.
+
+  - form fields now have NO identity operator, since they multiply by wedge, not
+    composition.
+
 - #328 adds many utilities for "Functional Differential Geometry".
 
   - Closes #249; operators now verify compatible contexts on multiplication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,14 @@
 
 - #328 adds many utilities for "Functional Differential Geometry".
 
-  - Closes #249; operators now verify compatible contexts on multiplication
+  - Closes #249; operators now verify compatible contexts on multiplication.
+
   - `Operator` instances can now provides custom `zero?`, `one?`, `identity?`,
     `zero-like`, `one-like` and `identity-like` implementations by setting a
     function of a single (operator-typed) argument to a keyword like `:zero?` in
-    their context.
+    their context. the identity operator returns `true` for `identity?`, and
+    `false` for `one?` so that it isn't stripped by the `g/*` function.
+
   - structures implement the 0-arity case of IFn now.
 
   - vector fields, in `sicmutils.calculus.vector-field`:

--- a/src/sicmutils/calculus/curvature.cljc
+++ b/src/sicmutils/calculus/curvature.cljc
@@ -35,8 +35,8 @@
 
 (defn Riemann-curvature [nabla]
   (fn [u v]
-    (- (o/commutator (nabla u) (nabla v))
-       (nabla (o/commutator u v)))))
+    (g/- (o/commutator (nabla u) (nabla v))
+         (nabla (o/commutator u v)))))
 
 ;; The traditional Riemann tensor R^i_jkl:
 
@@ -65,9 +65,9 @@
 
 (defn torsion-vector [nabla]
   (fn [X Y]
-    (+ ((nabla X) Y)
-       (* -1 ((nabla Y) X))
-       (* -1 (o/commutator X Y)))))
+    (g/+ ((nabla X) Y)
+         (g/* -1 ((nabla Y) X))
+         (g/* -1 (o/commutator X Y)))))
 
 ;; The torsion tensor T^i_jk
 
@@ -78,7 +78,6 @@
       {:arguments [::ff/oneform-field
                    ::vf/vector-field
                    ::vf/vector-field]})))
-
 
 ;; Components of the curvature tensor R^i_{jkl}
 

--- a/src/sicmutils/calculus/curvature.cljc
+++ b/src/sicmutils/calculus/curvature.cljc
@@ -1,0 +1,103 @@
+;;
+;; Copyright © 2021 Sam Ritchie.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
+
+(ns sicmutils.calculus.curvature
+  (:require [sicmutils.calculus.basis :as b]
+            [sicmutils.calculus.coordinate :as cc]
+            [sicmutils.calculus.form-field :as ff]
+            [sicmutils.calculus.manifold :as m]
+            [sicmutils.calculus.vector-field :as vf]
+            [sicmutils.generic :as g]
+            [sicmutils.operator :as o]
+            [sicmutils.structure :as s]
+            [sicmutils.util :as u]
+            [sicmutils.value :as v]))
+
+;; Riemann curvature "tensor" is pretty easy
+
+;; Hawking and Ellis equation 2.18, page 35.
+
+(defn Riemann-curvature [nabla]
+  (fn [u v]
+    (- (o/commutator (nabla u) (nabla v))
+       (nabla (o/commutator u v)))))
+
+;; The traditional Riemann tensor R^i_jkl:
+
+(defn Riemann [nabla]
+  (letfn [(Riemann-tensor [w x u v]
+            (w (((Riemann-curvature nabla) u v) x)))]
+    (with-meta Riemann-tensor
+      {:arguments
+       [::ff/oneform-field
+        ::vf/vector-field
+        ::vf/vector-field
+        ::vf/vector-field]})))
+
+(defn Ricci [nabla basis]
+  (letfn [(Ricci-tensor [u v]
+            (b/contract
+             (fn [ei wi]
+               ((Riemann nabla) wi u ei v))
+             basis))]
+    (with-meta Ricci-tensor
+      {:arguments
+       [::vf/vector-field
+        ::vf/vector-field]})))
+
+;; Hawking and Ellis page 34.
+
+(defn torsion-vector [nabla]
+  (fn [X Y]
+    (+ ((nabla X) Y)
+       (* -1 ((nabla Y) X))
+       (* -1 (o/commutator X Y)))))
+
+;; The torsion tensor T^i_jk
+
+(defn torsion [nabla]
+  (letfn [(the-torsion [w x y]
+            (w ((torsion-vector nabla) x y)))]
+    (with-meta the-torsion
+      {:arguments [::ff/oneform-field
+                   ::vf/vector-field
+                   ::vf/vector-field]})))
+
+
+;; Components of the curvature tensor R^i_{jkl}
+
+(defn curvature-components [nabla coord-sys]
+  (let [d:dxs (vf/coordinate-system->vector-basis coord-sys)
+        dxs   (ff/coordinate-system->oneform-basis coord-sys)
+        point ((m/point coord-sys) (s/up 'x 'y 'z))]
+    ((s/mapr
+      (fn [dx]
+        (s/mapr
+         (fn [d:dx]
+           (s/mapr
+            (fn [d:dy]
+              (s/mapr
+               (fn [d:dz]
+                 (dx (((Riemann-curvature nabla) d:dy d:dz)
+                      d:dx)))
+               d:dxs))
+            d:dxs))
+         d:dxs))
+      dxs)
+     point)))

--- a/src/sicmutils/calculus/form_field.cljc
+++ b/src/sicmutils/calculus/form_field.cljc
@@ -48,15 +48,35 @@
 (derive ::oneform-field ::form-field)
 (derive ::form-field ::o/operator)
 
-(declare ff:zero? ff:zero-like)
+(defn ff:zero
+  "Returns a form field that returns, for any supplied vector field `vf`, a
+  manifold function [[manifold/zero-manifold-function]] that maps every input
+  manifold `point` to the scalar value 0."
+  [vf]
+  m/zero-manifold-function)
+
+(defn get-rank
+  "Returns the rank of the supplied differential form `f`. Functions are treated
+  as differential forms of rank 0.
+
+  Throws for any non differential form supplied."
+  [f]
+  (cond (o/operator? f)
+        (or (:rank (o/context f))
+            (u/illegal
+             (str "operator, but not a differential form: " f)))
+
+        (f/function? f) 0
+        :else (u/illegal
+               (str "not a differential form: " f))))
 
 (defn form-field?
   "Returns true if the supplied `f` is a form field operator, false otherwise."
   [ff]
   (and (o/operator? ff)
-       (-> (o/context ff)
-           (:subtype)
-           (= ::form-field))))
+       (let [subtype (:subtype
+                      (o/context ff))]
+         (isa? subtype ::form-field))))
 
 (defn nform-field?
   "Returns true if the supplied `f` is an [form field of rank
@@ -66,8 +86,7 @@
   real-valued function on the manifold."
   [f n]
   (and (form-field? f)
-       (= n (:rank
-             (o/context f)))))
+       (= n (get-rank f))))
 
 (defn oneform-field?
   "Returns true if the supplied `f` is
@@ -78,6 +97,39 @@
   field to a real-valued function on the manifold."
   [f]
   (nform-field? f 1))
+
+(defn- ff:zero-like
+  "Given some form field `op`, returns a form field with the same context and
+  its procedure replaced by `ff:zero`.
+
+  The returned form field responds `true` to `v/zero?`."
+  [op]
+  {:pre [(form-field? op)]}
+  (o/make-operator ff:zero
+                   'ff:zero
+                   (o/context op)))
+
+(defn- ff:zero?
+  "Returns true if the supplied form field `op` is a form field with a procedure
+  equal to `ff:zero`, false otherwise."
+  [op]
+  (and (form-field? op)
+       (= (o/procedure op) ff:zero)))
+
+(letfn [(one-like [_]
+          (u/unsupported
+           "form fields don't have an identity."))
+        (id-like [_]
+          (u/unsupported
+           "form fields don't have a multiplicative identity."))
+        (identity? [_] false)]
+  (let [defaults {:zero? ff:zero?
+                  :zero-like ff:zero-like
+                  :one-like one-like
+                  :identity? identity?
+                  :identity-like id-like}]
+    (defn- ff-context [m]
+      (merge defaults m))))
 
 (defn ^:no-doc procedure->nform-field
   "Accepts a function `f` and an optional symbolic `name`, and returns an n-form
@@ -95,12 +147,11 @@
      (f)
      (let [args (into [] (repeat n ::vf/vector-field))]
        (o/make-operator f name
-                        {:subtype ::form-field
-                         :zero? ff:zero?
-                         :zero-like ff:zero-like
-                         :arity [:exactly n]
-                         :rank n
-                         :arguments args})))))
+                        (ff-context
+                         {:subtype ::form-field
+                          :arity [:exactly n]
+                          :rank n
+                          :arguments args}))))))
 
 (defn ^:no-doc procedure->oneform-field
   "Accepts a function `f` and an optional symbolic `name`, and returns a one-form
@@ -113,12 +164,11 @@
      (procedure->oneform-field f name)))
   ([f name]
    (o/make-operator f name
-                    {:subtype ::oneform-field
-                     :zero? ff:zero?
-                     :zero-like ff:zero-like
-                     :arity [:exactly 1]
-                     :rank 1
-                     :arguments [::vf/vector-field]})))
+                    (ff-context
+                     {:subtype ::oneform-field
+                      :arity [:exactly 1]
+                      :rank 1
+                      :arguments [::vf/vector-field]}))))
 
 (defn ^:no-doc oneform-field-procedure
   "Takes:
@@ -128,9 +178,7 @@
   - the `coordinate-system`
 
   And returns a procedure (not yet an operator!) that takes a structure of vector fields
-  and produces a new structure of functions of manifold points.
-
-  TODO flesh this out, please!"
+  and produces a new structure of functions of manifold points."
   [components coordinate-system]
   (fn [vf-components]
     (s/mapr (fn [vf]
@@ -188,46 +236,6 @@
                (m/point coordinate-system))))
 
 ;; ### API
-
-(defn ff:zero
-  "Returns a form field that returns, for any supplied vector field `vf`, a
-  manifold function [[manifold/zero-manifold-function]] that maps every input
-  manifold `point` to the scalar value 0."
-  [vf]
-  m/zero-manifold-function)
-
-(defn- ff:zero-like
-  "Given some form field `op`, returns a form field with the same context and
-  its procedure replaced by `ff:zero`.
-
-  The returned form field responds `true` to `v/zero?`."
-  [op]
-  {:pre [(form-field? op)]}
-  (o/make-operator ff:zero
-                   'ff:zero
-                   (o/context op)))
-
-(defn- ff:zero?
-  "Returns true if the supplied form field `op` is a form field with a procedure
-  equal to `ff:zero`, false otherwise."
-  [op]
-  (and (form-field? op)
-       (= (o/procedure op) ff:zero)))
-
-(defn get-rank
-  "Returns the rank of the supplied differential form `f`. Functions are treated
-  as differential forms of rank 0.
-
-  Throws for any non differential form supplied."
-  [f]
-  (cond (o/operator? f)
-        (or (:rank (o/context f))
-            (u/illegal
-             (str "operator, but not a differential form: " f)))
-
-        (f/function? f) 0
-        :else (u/illegal
-               (str "not a differential form: " f))))
 
 (defn literal-oneform-field
   "Given a symbolic name `sym` and a `coordinate-system`, returns a one-form field

--- a/src/sicmutils/calculus/form_field.cljc
+++ b/src/sicmutils/calculus/form_field.cljc
@@ -45,6 +45,7 @@
 ;; real-valued function on the manifold. A one-form field takes a single vector
 ;; field.
 
+(derive ::oneform-field ::form-field)
 (derive ::form-field ::o/operator)
 
 (declare ff:zero? ff:zero-like)
@@ -108,10 +109,16 @@
   `f` should be a function from a vector field to a smooth real-valued function
   `g` of a manifold."
   ([f]
-   (procedure->nform-field
-    f 1 'unnamed-1form-field))
+   (let [name 'unnamed-1form-field]
+     (procedure->oneform-field f name)))
   ([f name]
-   (procedure->nform-field f 1 name)))
+   (o/make-operator f name
+                    {:subtype ::oneform-field
+                     :zero? ff:zero?
+                     :zero-like ff:zero-like
+                     :arity [:exactly 1]
+                     :rank 1
+                     :arguments [::vf/vector-field]})))
 
 (defn ^:no-doc oneform-field-procedure
   "Takes:

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -75,6 +75,7 @@
             [sicmutils.mechanics.rotation]
             [sicmutils.calculus.basis]
             [sicmutils.calculus.covariant]
+            [sicmutils.calculus.curvature]
             [sicmutils.calculus.derivative :as d]
             [sicmutils.calculus.frame]
             [sicmutils.calculus.form-field]
@@ -323,6 +324,9 @@ constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   vector-basis->dual
   make-constant-vector-field
   Jacobian]
+ [sicmutils.calculus.curvature
+  Riemann-curvature Riemann Ricci torsion-vector torsion
+  curvature-components]
  [sicmutils.calculus.map
   basis->basis-over-map
   differential

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -86,6 +86,7 @@
    'sicmutils.calculus.basis                   (ns-publics 'sicmutils.calculus.basis)
    'sicmutils.calculus.coordinate              (ns-publics 'sicmutils.calculus.coordinate)
    'sicmutils.calculus.covariant               (ns-publics 'sicmutils.calculus.covariant)
+   'sicmutils.calculus.curvature               (ns-publics 'sicmutils.calculus.curvature)
    'sicmutils.calculus.derivative              (ns-publics 'sicmutils.calculus.derivative)
    'sicmutils.calculus.form-field              (ns-publics 'sicmutils.calculus.form-field)
    'sicmutils.calculus.frame                   (ns-publics 'sicmutils.calculus.frame)

--- a/src/sicmutils/operator.cljc
+++ b/src/sicmutils/operator.cljc
@@ -225,7 +225,7 @@
     (.-context ^Operator op)
     (u/illegal (str "non-operator supplied: " op))))
 
-(defn- with-context
+(defn ^:no-doc with-context
   "Returns a copy of the supplied operator with `ctx` substituted for its
   context."
   [op ctx]
@@ -268,7 +268,9 @@
   "Merges type context maps of the two operators. Where the maps have keys in
   common, they must agree; disjoint keys become part of the new joint context.
 
-  The exception is the :subtype key, which "
+  The exception is the :subtype key; if the values aren't
+  equal, [[joint-context]] chooses the parent if one derives from the other, or
+  throws if not."
   [o p]
   {:pre [(operator? o)
          (operator? p)]}

--- a/src/sicmutils/operator.cljc
+++ b/src/sicmutils/operator.cljc
@@ -35,14 +35,10 @@
 
 (def ^{:private true
        :doc "Simplifier that acts on associative products and sums, and collects
-  products into exponents. Any operator named `identity` is removed (we can't
-  verify that the operator does in fact _act_ like a proper `identity`.)
-
-  Operator multiplication is NOT associative, so only adjacent products are
-  collected."}
+  products into exponents. Operator multiplication is NOT associative, so only
+  adjacent products are collected."}
   simplify-operator-name
   (rule-simplifier
-   (rules/constant-elimination '* 'identity)
    (rules/associative '+ '*)
    rules/exponent-contract
    (rules/unary-elimination '+ '*)))
@@ -56,10 +52,15 @@
       (z-fn this)
       (= o v/zero-like)))
 
+  ;; NOTE: `one?` is the multiplicative identity; by default, we return false
+  ;; because the system doesn't currently check if the types match for
+  ;; multiplicative identity. So `(* o:identity 5)` would return 5, which is
+  ;; incorrect. (We should get back a new operator that carries the scale-by-5
+  ;; along until the final function resolves.)
   (one? [this]
     (if-let [one-fn (:one? context)]
       (one-fn this)
-      (= o core-identity)))
+      false))
 
   (identity? [this]
     (if-let [id-fn (:identity? context)]
@@ -224,6 +225,17 @@
     (.-context ^Operator op)
     (u/illegal (str "non-operator supplied: " op))))
 
+(defn- with-context
+  "Returns a copy of the supplied operator with `ctx` substituted for its
+  context."
+  [op ctx]
+  (if (operator? op)
+    (let [op ^Operator op]
+      (->Operator (.-o op) (.-arity op) (.-name op)
+                  ctx
+                  (.-m op)))
+    (u/illegal (str "non-operator supplied: " op))))
+
 (defn make-operator
   "Returns an [[Operator]] wrapping the supplied procedure `f` with the name
   `name`.
@@ -254,17 +266,27 @@
 
 (defn- joint-context
   "Merges type context maps of the two operators. Where the maps have keys in
-  common, they must agree; disjoint keys become part of the new joint context."
+  common, they must agree; disjoint keys become part of the new joint context.
+
+  The exception is the :subtype key, which "
   [o p]
   {:pre [(operator? o)
          (operator? p)]}
   (reduce-kv (fn [joint-ctx k v]
                (if-let [cv (k joint-ctx)]
-                 (if (= cv v)
-                   joint-ctx
-                   (u/illegal
-                    (str "incompatible operator context: "
-                         (context o) (context p))))
+                 (cond (= v cv)  joint-ctx
+
+                       (and (= k :subtype) (isa? cv v))
+                       (assoc joint-ctx k v)
+
+                       (and (= k :subtype) (isa? v cv))
+                       joint-ctx
+
+                       :else
+                       (u/illegal
+                        (str "incompatible operator context: "
+                             (context o) (context p)
+                             " at key: " k)))
                  (assoc joint-ctx k v)))
              (context o)
              (context p)))
@@ -333,10 +355,15 @@
   "Subtract one operator from another. Produces an operator which computes the
   difference of applying the supplied operators."
   [o p]
-  (->Operator #(g/sub (apply o %&) (apply p %&))
-              (f/joint-arity [(arity o) (arity p)])
-              `(~'- ~(name o) ~(name p))
-              (joint-context o p)))
+  (let [ctx (joint-context o p)]
+    (if (v/zero? p)
+      (with-context o ctx)
+      (->Operator (fn [& xs]
+                    (g/sub (apply o xs)
+                           (apply p xs)))
+                  (f/joint-arity [(arity o) (arity p)])
+                  `(~'- ~(name o) ~(name p))
+                  ctx))))
 
 (defn- f-o [f o] (combine-f-op g/sub '- f o))
 (defn- o-f [o f] (combine-op-f g/sub '- o f))
@@ -345,10 +372,16 @@
   "Add two operators. Produces an operator which adds the result of applying the
   given operators."
   [o p]
-  (->Operator #(g/add (apply o %&) (apply p %&))
-              (f/joint-arity [(f/arity o) (f/arity p)])
-              `(~'+ ~(name o) ~(name p))
-              (joint-context o p)))
+  (let [ctx (joint-context o p)]
+    (cond (v/zero? o) (with-context p ctx)
+          (v/zero? p) (with-context o ctx)
+          :else
+          (->Operator (fn [& xs]
+                        (g/add (apply o xs)
+                               (apply p xs)))
+                      (f/joint-arity [(f/arity o) (f/arity p)])
+                      `(~'+ ~(name o) ~(name p))
+                      ctx))))
 
 (defn- f+o [f o] (combine-f-op g/add '+ f o))
 (defn- o+f [o f] (combine-op-f g/add '+ o f))
@@ -358,10 +391,14 @@
   ([] identity)
   ([o] o)
   ([o p]
-   (->Operator (f/compose o p)
-               (arity p)
-               `(~'* ~(name o) ~(name p))
-               (joint-context o p))))
+   (let [ctx (joint-context o p)]
+     (cond (v/identity? o) (with-context p ctx)
+           (v/identity? p) (with-context o ctx)
+           :else
+           (->Operator (f/compose o p)
+                       (arity p)
+                       `(~'* ~(name o) ~(name p))
+                       ctx)))))
 
 (defn- f*o
   "Multiply an operator by a non-operator on the left. The non-operator acts on

--- a/test/sicmutils/calculus/curvature_test.cljc
+++ b/test/sicmutils/calculus/curvature_test.cljc
@@ -1,0 +1,743 @@
+;;
+;; Copyright © 2021 Sam Ritchie.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
+
+(ns sicmutils.calculus.curvature-test
+  (:refer-clojure :exclude [+ - * /])
+  (:require [clojure.test :refer [is deftest testing use-fixtures]]
+            [sicmutils.calculus.basis :as b]
+            [sicmutils.calculus.coordinate :refer [let-coordinates]
+             #?@(:cljs [:include-macros true])]
+            [sicmutils.calculus.covariant :as cov]
+            [sicmutils.calculus.curvature :as c]
+            [sicmutils.calculus.manifold :as m]
+            [sicmutils.calculus.map :as cm]
+            [sicmutils.calculus.vector-field :as vf]
+            [sicmutils.abstract.function :as af]
+            [sicmutils.abstract.number :as an]
+            [sicmutils.expression :as x]
+            [sicmutils.function :refer [compose]]
+            [sicmutils.generic :as g :refer [+ - * /]]
+            [sicmutils.operator :as o]
+            [sicmutils.simplify :refer [hermetic-simplify-fixture]]
+            [sicmutils.structure :as s :refer [up down]]
+            [sicmutils.value :as v]))
+
+(use-fixtures :each hermetic-simplify-fixture)
+
+(def simplify
+  (comp v/freeze g/simplify))
+
+(deftest curvature-tests
+  (testing "tests from curvature.scm"
+    ;; General torsion is not too complicated to compute
+    (let-coordinates [[x y] m/R2-rect]
+      (let [R2-rect-basis (b/coordinate-system->basis R2-rect)
+            R2-rect-point ((m/point R2-rect) (up 'x0 'y0))
+
+            Gijk (fn [i j k]
+                   (m/literal-manifold-function
+                    (symbol (str "G↑" i "_" j k))
+                    R2-rect))
+            G (down (down (up (Gijk 0 0 0)
+                              (Gijk 1 0 0))
+                          (up (Gijk 0 1 0)
+                              (Gijk 1 1 0)))
+                    (down (up (Gijk 0 0 1)
+                              (Gijk 1 0 1))
+                          (up (Gijk 0 1 1)
+                              (Gijk 1 1 1))))
+
+            CG (cov/make-Christoffel G R2-rect-basis)
+            CF (cov/Christoffel->Cartan CG)
+
+            v (vf/literal-vector-field 'v R2-rect)
+            w (vf/literal-vector-field 'w R2-rect)
+            f (m/literal-manifold-function 'f R2-rect)
+            present (fn [expr]
+                      (-> (simplify expr)
+                          (x/substitute '(up x0 y0) 'p)))]
+        (is (= '(+ (* -1 (((partial 0) f) p) (v↑0 p) (G↑0_01 p) (w↑1 p))
+                   (* (((partial 0) f) p) (v↑0 p) (w↑1 p) (G↑0_10 p))
+                   (* (((partial 0) f) p) (v↑1 p) (w↑0 p) (G↑0_01 p))
+                   (* -1 (((partial 0) f) p) (v↑1 p) (w↑0 p) (G↑0_10 p))
+                   (* -1 (v↑0 p) (w↑1 p) (((partial 1) f) p) (G↑1_01 p))
+                   (* (v↑0 p) (w↑1 p) (((partial 1) f) p) (G↑1_10 p))
+                   (* (v↑1 p) (w↑0 p) (((partial 1) f) p) (G↑1_01 p))
+                   (* -1 (v↑1 p) (w↑0 p) (((partial 1) f) p) (G↑1_10 p)))
+               (present
+                ((((c/torsion-vector
+                    (cov/covariant-derivative CF)) v w) f)
+                 R2-rect-point))))
+
+        ;; Unfortunately, this says only that the
+        ;; Christoffel symbols are symmetric in the
+        ;; lower two indices iff the torsion is zero.
+        ))
+
+    (let-coordinates [[theta phi] m/S2-spherical]
+      (let [S2-spherical-basis (b/coordinate-system->basis S2-spherical)
+            a-point ((m/point S2-spherical) (up 'theta 'phi))
+            a-function (m/literal-scalar-field 'f S2-spherical)
+
+            ;; the Christoffel symbols (for r=1) (p.341 mtw) are:
+            ;; (the up-down-down Christoffel symbols do not depend on R)
+            G-S2-1 (cov/make-Christoffel
+                    (let [zero m/zero-manifold-function]
+                      (down (down (up zero zero)
+                                  (up zero (/ 1 (g/tan theta))))
+                            (down (up zero (/ 1 (g/tan theta)))
+                                  (up (- (* (g/sin theta)
+                                            (g/cos theta)))
+                                      zero))))
+                    S2-spherical-basis)
+            nabla (cov/covariant-derivative
+                   (cov/Christoffel->Cartan G-S2-1))]
+        (is (= 0 (simplify
+                  (((o/commutator d:dtheta d:dphi) a-function)
+                   a-point))))
+
+        (is (= '(/ (* (((partial 1) f) (up theta phi))
+                      (cos theta))
+                   (sin theta))
+               (simplify
+                ((((nabla d:dtheta) d:dphi)
+                  a-function)
+                 a-point))))
+
+        (is (= '(* -1 (expt (cos theta) 2)
+                   (((partial 0) f) (up theta phi)))
+               (simplify
+                ((((nabla d:dphi) ((nabla d:dtheta) d:dphi))
+                  a-function)
+                 a-point))))
+
+        (doall
+         (for [x [d:dtheta d:dphi]
+               y [d:dtheta d:dphi]]
+           (is (= 0 (simplify
+                     ((((c/torsion-vector nabla) x y)
+                       a-function)
+                      a-point))))))
+
+        (is (= 1 (simplify
+                  (((c/Riemann nabla)
+                    dphi d:dtheta d:dphi d:dtheta)
+                   a-point))))))
+
+    ;; We can work without embedding the sphere in R↑3
+    ;; We need another copy of R2...
+    (let [M (m/make-manifold m/Rn 2)
+          M-rect (m/coordinate-system-at M :rectangular :origin)
+          M-polar (m/coordinate-system-at M :polar-cylindrical :origin)]
+      (let-coordinates [(up theta phi) M-rect]
+        (let [M-basis (b/coordinate-system->basis M-rect)
+              a-point ((m/point M-rect) (up 'theta↑0 'phi↑0))
+              a-function (m/literal-scalar-field 'f M-rect)
+              G-S2-1 (cov/make-Christoffel
+                      (let [zero m/zero-manifold-function]
+                        (down (down
+                               (up zero zero)
+                               (up zero (/ 1 (g/tan theta))))
+                              (down
+                               (up zero (/ 1 (g/tan theta)))
+                               (up (- (* (g/sin theta)
+                                         (g/cos theta)))
+                                   zero))))
+                      M-basis)
+              nabla (cov/covariant-derivative
+                     (cov/Christoffel->Cartan G-S2-1))]
+          (doall
+           (for [x [d:dtheta d:dphi]
+                 y [d:dtheta d:dphi]]
+             (is (= 0 (simplify
+                       ((((c/torsion-vector nabla) x y)
+                         a-function)
+                        a-point))))))
+
+          (is (= 1 (simplify
+                    (((c/Riemann nabla)
+                      dphi d:dtheta d:dphi d:dtheta)
+                     a-point))))
+
+          ;; R↑alpha_{beta gamma delta}
+          ;;
+          (testing "p351 MTW has efficient method for computing curvature (eq
+          14.18)")
+          (letfn [(check! [expected alpha beta gamma delta]
+                    (is (= expected
+                           (simplify
+                            (((c/Riemann nabla)
+                              alpha beta gamma delta)
+                             a-point)))))]
+            (check! 0 dtheta d:dtheta d:dtheta d:dtheta)
+            (check! 0 dtheta d:dtheta d:dtheta d:dphi)
+            (check! 0 dtheta d:dtheta d:dphi d:dtheta)
+            (check! 0 dtheta d:dtheta d:dphi d:dphi)
+            (check! 0 dtheta d:dphi d:dtheta d:dtheta)
+
+            (check! '(expt (sin theta↑0) 2)
+                    dtheta d:dphi d:dtheta d:dphi)
+
+            (check! '(* -1 (expt (sin theta↑0) 2))
+                    dtheta d:dphi d:dphi d:dtheta)
+
+            (check! 0 dtheta d:dphi d:dphi d:dphi)
+            (check! 0 dphi d:dtheta d:dtheta d:dtheta)
+            (check! -1 dphi d:dtheta d:dtheta d:dphi)
+            (check! 1 dphi d:dtheta d:dphi d:dtheta)
+            (check! 0 dphi d:dtheta d:dphi d:dphi)
+            (check! 0 dphi d:dphi d:dtheta d:dtheta)
+            (check! 0 dphi d:dphi d:dtheta d:dphi)
+            (check! 0 dphi d:dphi d:dphi d:dtheta)
+            (check! 0 dphi d:dphi d:dphi d:dphi)))
+        ))
+
+    ;; The Christoffel symbols (for R=1) (p.341 MTW) are:
+    ;; (the up-down-down Christoffel symbols do not depend on R)
+    (let [M (m/make-manifold m/Rn 2)
+          M-rect (m/coordinate-system-at M :rectangular :origin)]
+      (let-coordinates [[t n] m/R2-rect
+                        [theta phi] M-rect]
+        (let [M-basis (b/coordinate-system->basis M-rect)
+              G-S2-1 (cov/make-Christoffel
+                      (let [zero m/zero-manifold-function]
+                        (down (down
+                               (up zero zero)
+                               (up zero (/ 1 (g/tan theta))))
+                              (down
+                               (up zero (/ 1 (g/tan theta)))
+                               (up (- (* (g/sin theta)
+                                         (g/cos theta)))
+                                   zero))))
+                      M-basis)
+
+              f↑theta (af/literal-function 'f↑theta '(-> (UP Real Real) Real))
+              f↑phi (af/literal-function 'f↑phi '(-> (UP Real Real) Real))
+
+              s0 (simplify
+                  (let [mu:N->M (compose (m/point M-rect)
+                                         (up f↑theta f↑phi)
+                                         (m/chart R2-rect))
+                        basis-over-mu (cm/basis->basis-over-map mu:N->M M-basis)
+                        oneform-basis (b/basis->oneform-basis basis-over-mu)
+                        Cartan (cov/Christoffel->Cartan G-S2-1)
+                        nabla (cov/covariant-derivative Cartan mu:N->M)
+                        nablau (nabla d:dt)
+                        d1 (nablau (nablau ((cm/differential mu:N->M) d:dn)))
+                        d2 (((c/Riemann-curvature nabla) d:dn d:dt)
+                            ((cm/differential mu:N->M) d:dt))
+                        deviation (+ d1 d2)]
+                    (s/mapr
+                     (fn [w]
+                       ((w deviation) ((m/point R2-rect)
+                                       (up 'tau 0))))
+                     oneform-basis)))
+
+              s12
+              (x/substitute
+               s0 {'(((* (expt (partial 0) 2) (partial 1)) f↑theta) (up tau 0)) 'xidotdot
+                   '(((* (expt (partial 0) 2) (partial 1)) f↑phi) (up tau 0)) 'etadotdot
+                   '(((expt (partial 0) 2) f↑phi) (up tau 0)) 'phidotdot
+                   '(((expt (partial 0) 2) f↑theta) (up tau 0)) 'thetadotdot
+                   '(((* (partial 0) (partial 1)) f↑phi) (up tau 0)) 'etadot
+                   '(((* (partial 0) (partial 1)) f↑theta) (up tau 0)) 'xidot
+                   '(((partial 1) f↑theta) (up tau 0)) 'xi
+                   '(((partial 1) f↑phi) (up tau 0)) 'eta
+                   '(((partial 0) f↑theta) (up tau 0)) 'thetadot
+                   '(((partial 0) f↑phi) (up tau 0)) 'phidot
+                   '(f↑theta (up tau 0)) 'theta
+                   '(f↑phi (up tau 0)) 'phi})
+
+              ;; Substituting from the geodesic equation (equation of motion) to
+              ;; make make use of the fact that the trajectory is a geodesic.
+              s13
+              (x/substitute s12 'phidotdot '(* -2 thetadot phidot (/ (cos theta) (sin theta))))
+
+              s14
+              (x/substitute s13 'thetadotdot '(* phidot phidot (cos theta) (sin theta)))]
+
+          ;; These geodesic deviation equations are the variational equations
+          ;; driven by the geodesic equation.
+          (is (= '(up (+ (* -2 (expt phidot 2) xi (expt (cos theta) 2))
+                         (* -2 etadot phidot (sin theta) (cos theta))
+                         (* (expt phidot 2) xi)
+                         xidotdot)
+                      (/ (+ (* 2 etadot thetadot (sin theta) (cos theta))
+                            (* 2 phidot xidot (sin theta) (cos theta))
+                            (* etadotdot (expt (sin theta) 2))
+                            (* -2 phidot thetadot xi))
+                         (expt (sin theta) 2)))
+                 (simplify
+                  (an/literal-number s14)))))
+        ))
+    ))
+
+
+(comment
+
+  ;; Testing equation 3 on MTW p272
+  (define s0
+    (simplify
+     (let* ( ;; d:dt and d:dn exist
+            (mu:N->M (compose
+                      (m/point M-rect)
+                      (up f↑theta f↑phi)
+                      (m/chart R2-rect)))
+            (basis-over-mu (cm/basis->basis-over-map mu:N->M M-basis))
+            (oneform-basis (b/basis->oneform-basis basis-over-mu))
+            (Cartan (Christoffel->Cartan G-S2-1))
+            (nabla (cov/covariant-derivative Cartan mu:N->M))
+            (nablau (nabla d:dt))
+            (nablan (nabla d:dn))
+            (deviation (nablan (nablau ((differential mu:N->M) d:dt)))))
+       (s/mapr
+        (fn [w]
+          ((w deviation) ((m/point R2-rect) (up 'tau 0))))
+        oneform-basis))))
+
+  ;; do all substitutions again...
+  (pec s12)
+  ;; ;; Result:
+  (up
+   (+ (* -2 eta phidot thetadot (expt (g/cos theta) 2))
+      (* -2 (expt phidot 2) xi (expt (g/cos theta) 2))
+      (* -1 eta phidotdot (g/cos theta) (g/sin theta))
+      (* -2 etadot phidot (g/cos theta) (g/sin theta))
+      (* (expt phidot 2) xi)
+      xidotdot)
+   (/
+    (+ (* -1 eta (expt phidot 2) (expt (g/cos theta) 2) (g/sin theta))
+       (* -2 phidot thetadot xi (g/sin theta))
+       (* eta thetadotdot (g/cos theta))
+       (* 2 etadot thetadot (g/cos theta))
+       (* 2 phidot xidot (g/cos theta))
+       (* phidotdot xi (g/cos theta))
+       (* etadotdot (g/sin theta)))
+    (g/sin theta)))
+
+
+  (pec s14)
+  ;; ;; Result:
+  (up
+   (+ (* -2 (expt phidot 2) xi (expt (g/cos theta) 2))
+      (* -2 etadot phidot (g/cos theta) (g/sin theta))
+      (* (expt phidot 2) xi)
+      xidotdot)
+   (/
+    (+ (* 2 etadot thetadot (g/cos theta) (g/sin theta))
+       (* 2 phidot xidot (g/cos theta) (g/sin theta))
+       (* etadotdot (expt (g/sin theta) 2))
+       (* -2 phidot thetadot xi))
+    (expt (g/sin theta) 2)))
+
+
+  ;; agrees with Riemann calculation
+  ;;
+  ;; shouldn't this be zero?
+  ;;
+  ;; parallel transport of vector about a loop
+
+  (define-coordinates t the-real-line)
+
+  ;; The coordinates on the unit sphere
+
+  (define-coordinates (up theta phi) S2-spherical)
+
+  (define S2-spherical-basis (coordinate-system->basis S2-spherical))
+
+  ;; The Christoffel symbols (for r=1) (p.341 MTW) are:
+
+  (define G-S2-1
+    (cov/make-Christoffel
+     (let [zero m/zero-manifold-function]
+       (down (down (up zero zero)
+                   (up zero (/ 1 (g/tan theta))))
+             (down (up zero (/ 1 (g/tan theta)))
+                   (up (- (* (g/sin theta) (g/cos theta))) zero))))
+     S2-spherical-basis))
+
+
+  ;; Ordinary Lagrange Equations (= Geodesic Equations)
+
+  (let [U d:dt
+        mu:N->M (compose (m/point S2-spherical)
+                         (up (af/literal-function 'f↑theta)
+                             (af/literal-function 'f↑phi))
+                         (m/chart the-real-line))
+        basis-over-mu (cm/basis->basis-over-map mu:N->M S2-spherical-basis)
+        oneform-basis (b/basis->oneform-basis basis-over-mu)
+        Cartan (Christoffel->Cartan G-S2-1)]
+    (s/mapr
+     (fn [w]
+       ((w (((cov/covariant-derivative Cartan mu:N->M) U)
+            ((differential mu:N->M) U)))
+        ((m/point the-real-line) 'tau)))
+     oneform-basis))
+  ;; ;; Result:
+  (up
+   (+ (((expt D 2) f↑theta) tau)
+      (* -1 (g/cos (f↑theta tau)) (g/sin (f↑theta tau)) (expt ((D f↑phi) tau) 2)))
+   (/ (+ (* (g/sin (f↑theta tau)) (((expt D 2) f↑phi) tau))
+         (* 2 (g/cos (f↑theta tau)) ((D f↑phi) tau) ((D f↑theta) tau)))
+      (g/sin (f↑theta tau))))
+
+
+  ;; Parallel transport of vector W over path mu
+
+  (pec (let ((U d:dt)
+             (mu:N->M (compose (m/point S2-spherical)
+                               (up (af/literal-function 'f↑theta)
+                                   (af/literal-function 'f↑phi))
+                               (m/chart the-real-line))))
+         (let* ((basis-over-mu
+                 (cm/basis->basis-over-map mu:N->M S2-spherical-basis))
+                (oneform-basis (b/basis->oneform-basis basis-over-mu))
+                (vector-basis (basis->vector-basis basis-over-mu))
+                (Cartan (Christoffel->Cartan G-S2-1))
+                (transported-vector-over-map
+                 (basis-components->vector-field
+                  (up (compose (af/literal-function 'w↑0)
+                               (m/chart the-real-line))
+                      (compose (af/literal-function 'w↑1)
+                               (m/chart the-real-line)))
+                  vector-basis)))
+           (s/mapr
+            (fn [w]
+              ((w
+                (((cov/covariant-derivative Cartan mu:N->M) U)
+                 transported-vector-over-map))
+               ((m/point the-real-line) 'tau)))
+            oneform-basis))))
+
+  ;; Result:
+  (up
+   (+ ((D w↑0) tau)
+      (* -1 (g/cos (f↑theta tau)) ((D f↑phi) tau) (w↑1 tau) (g/sin (f↑theta tau))))
+   (/ (+ (* (g/sin (f↑theta tau)) ((D w↑1) tau))
+         (* (g/cos (f↑theta tau)) ((D f↑phi) tau) (w↑0 tau))
+         (* (g/cos (f↑theta tau)) (w↑1 tau) ((D f↑theta) tau)))
+      (g/sin (f↑theta tau))))
+
+
+  ;; was  ...  looks like right hand side
+
+  (up (* (g/sin (theta tau)) (g/cos (theta tau)) (w↑1 tau)
+         ((D phi) tau))
+      (/ (+ (* -1 (w↑0 tau) (g/cos (theta tau)) ((D phi) tau))
+            (* -1 ((D theta) tau) (g/cos (theta tau)) (w↑1 tau)))
+         (g/sin (theta tau))))
+
+
+  ;; To set up for solving for the derivatives, we lift off of the path
+
+  (pec (let ((U d:dt)
+             (mu:N->M (compose (m/point S2-spherical)
+                               (up (af/literal-function 'f↑theta)
+                                   (af/literal-function 'f↑phi))
+                               (m/chart the-real-line))))
+         (let* ((basis-over-mu (cm/basis->basis-over-map mu:N->M S2-spherical-basis))
+                (oneform-basis (b/basis->oneform-basis basis-over-mu))
+                (vector-basis (basis->vector-basis basis-over-mu))
+                (Cartan (Christoffel->Cartan G-S2-1))
+                (transported-vector-over-map
+                 (basis-components->vector-field
+                  (up (compose (osculating-path (up 'tau 'w↑0 'dw↑0/dt))
+                               (m/chart the-real-line))
+                      (compose (osculating-path (up 'tau 'w↑1 'dw↑1/dt))
+                               (m/chart the-real-line)))
+                  vector-basis)))
+           (s/mapr
+            (fn [w]
+              ((w
+                (((cov/covariant-derivative Cartan mu:N->M)
+                  U)
+                 transported-vector-over-map))
+               ((m/point the-real-line) 'tau)))
+            oneform-basis))))
+
+  ;; Result:
+  (up (+ dw↑0:dt
+         (* -1 (g/cos (f↑theta tau)) ((D f↑phi) tau) (g/sin (f↑theta tau)) w↑1))
+      (/ (+ (* (g/sin (f↑theta tau)) dw↑1:dt)
+            (* (g/cos (f↑theta tau)) ((D f↑phi) tau) w↑0)
+            (* (g/cos (f↑theta tau)) ((D f↑theta) tau) w↑1))
+         (g/sin (f↑theta tau))))
+
+
+  ;; Loaded solve by (load "/usr/local/scmutils/src/solve/linreduce")
+  (let [tau 'tau
+        theta (af/literal-function 'f↑theta)
+        phi (af/literal-function 'f↑phi)
+        w↑0 (af/literal-function 'w↑0)
+        w↑1 (af/literal-function 'w↑1)]
+    (solve
+     (fn [v]
+       (let ((dw↑0/dt (ref v 0))
+             (dw↑1/dt (ref v 1)))
+         (up
+          (+ (* -1
+                (w↑1 tau)
+                (g/sin (theta tau))
+                (g/cos (theta tau))
+                ((D phi) tau))
+             dw↑0/dt)
+          (+ (/ (* (w↑0 tau) (g/cos (theta tau)) ((D phi) tau))
+                (g/sin (theta tau)))
+             (/ (* (w↑1 tau) ((D theta) tau) (g/cos (theta tau)))
+                (g/sin (theta tau)))
+             dw↑1/dt))))
+     2 2))
+
+  ;; ;; Result:
+  (up (* (w↑1 tau) (g/sin (f↑theta tau)) (g/cos (f↑theta tau)) ((D f↑phi) tau))
+      (/ (+ (* -1 (w↑1 tau) (g/cos (f↑theta tau)) ((D f↑theta) tau))
+            (* -1 (g/cos (f↑theta tau)) ((D f↑phi) tau) (w↑0 tau)))
+         (g/sin (f↑theta tau))))
+
+
+  (let [U d:dt
+        mu:N->M (compose
+                 (m/point S2-spherical)
+                 (up (af/literal-function 'f↑theta)
+                     (af/literal-function 'f↑phi))
+                 (m/chart the-real-line))]
+    (solve
+     (fn [v]
+       (let [dw↑0:dt (ref v 0)
+             dw↑1:dt (ref v 1)
+             basis-over-mu (cm/basis->basis-over-map mu:N->M S2-spherical-basis)
+             oneform-basis (b/basis->oneform-basis basis-over-mu)
+             vector-basis (b/basis->vector-basis basis-over-mu)
+             Cartan (cov/Christoffel->Cartan G-S2-1)
+             transported-vector-over-map
+             (vf/basis-components->vector-field
+              (up (compose (osculating-path (up 'tau 'w↑0 dw↑0:dt))
+                           (m/chart the-real-line))
+                  (compose (osculating-path (up 'tau 'w↑1 dw↑1:dt))
+                           (m/chart the-real-line)))
+              vector-basis)]
+         (s/mapr
+          (fn [w]
+            ((w
+              (((cov/covariant-derivative Cartan mu:N->M)
+                U)
+               transported-vector-over-map))
+             ((m/point the-real-line) 'tau)))
+          oneform-basis)))
+     (S2-spherical 'dimension)
+     (S2-spherical 'dimension)))
+  ;; ;; Result:
+  (up
+   (* w↑1 (g/cos (f↑theta tau)) (g/sin (f↑theta tau)) ((D f↑phi) tau))
+   (/
+    (+ (* -1 w↑0 (g/cos (f↑theta tau)) ((D f↑phi) tau))
+       (* -1 w↑1 ((D f↑theta) tau) (g/cos (f↑theta tau))))
+    (g/sin (f↑theta tau))))
+
+  ;; Computing parallel transport without the embedding
+  (let-coordinates [t m/the-real-line
+                    [theta phi] M-rect]
+    (let [M-basis (b/coordinate-system->basis M-rect)
+          G-S2-1  (cov/make-Christoffel
+                   (let [zero m/zero-manifold-function]
+                     (down
+                      (down (up zero zero)
+                            (up zero (/ 1 (g/tan theta))))
+                      (down (up zero (/ 1 (g/tan theta)))
+                            (up (- (* (g/sin theta)
+                                      (g/cos theta))) zero))))
+                   M-basis)]
+      ))
+  ;; Parallel transport of vector w over path mu
+
+  (define mu:N->M
+    (compose (m/point M-rect)
+             (up (af/literal-function 'mu↑theta)
+                 (af/literal-function 'mu↑phi))
+             (m/chart the-real-line)))
+
+  (define basis-over-mu
+    (cm/basis->basis-over-map mu:N->M M-basis))
+
+  (define w
+    (basis-components->vector-field
+     (up (compose (af/literal-function 'w↑0)
+                  (m/chart the-real-line))
+         (compose (af/literal-function 'w↑1)
+                  (m/chart the-real-line)))
+     (basis->vector-basis basis-over-mu)))
+
+  (let [Cartan (Christoffel->Cartan G-S2-1)]
+    (s/mapr
+     (fn [omega]
+       ((omega
+         (((cov/covariant-derivative Cartan mu:N->M) d:dt) w))
+        ((m/point the-real-line) 'tau)))
+     (b/basis->oneform-basis basis-over-mu)))
+  ;; ;; Result:
+  (up
+   (+ (* -1 (w↑1 tau) ((D mu↑phi) tau) (g/cos (mu↑theta tau)) (g/sin (mu↑theta tau)))
+      ((D w↑0) tau))
+   (/
+    (+ (* (w↑1 tau) (g/cos (mu↑theta tau)) ((D mu↑theta) tau))
+       (* (w↑0 tau) ((D mu↑phi) tau) (g/cos (mu↑theta tau)))
+       (* ((D w↑1) tau) (g/sin (mu↑theta tau))))
+    (g/sin (mu↑theta tau))))
+
+  ;; These are the equations of the coordinates of a vector being
+  ;; parallel transported along the path defined by f.
+  ;;
+  ;; To integrate these equations of the coordinates of the vector
+  ;; being transported along a path (mu↑theta(tau), mu↑phi(tau)), defined
+  ;; by differential equations we need to make a state space that
+  ;; represents both the path and the coordinates of the vector being
+  ;; transported.  The states are s=(sigma, w)=((theta, phi), (w0, w1))
+  ;; and the differential equations for the path are Dsigma(tau) =
+  ;; b(sigma(tau)).  The differential equations for the coordinates of
+  ;; the vector are driven by this path.
+  ;;
+  ;; To represent these states we make a new manifold with 4
+  ;; coordinates.  The first two coordinates are tha coordinates of the
+  ;; path.  The second two coordinates are the components of the vector
+  ;; to be transported, relative to the coordinate directions in the
+  ;; original manifold.  The right-hand side of the composite
+  ;; differential equation is a vector field on this manifold.
+
+  (define R4 (m/make-manifold m/Rn 4))
+  (define states (m/coordinate-system-at R4 :rectangular :origin))
+  (define-coordinates (up theta phi w0 w1) states)
+
+  (define initial-state-d:dphi
+    ((m/point states) (up 'theta0 'phi0 0 1)))
+  (define initial-state-d:dtheta
+    ((m/point states) (up 'theta0 'phi0 1 0)))
+
+  ;; Assuming that the paths are integral curves of a vector field v,
+  ;; we supply the vector field:
+  (define G (fn [v]
+              (let [alphadot (dtheta v)
+                    betadot (dphi v)]
+                (+ v
+                   (* (compose (* sin cos) theta)
+                      betadot w1 d:dw0)
+                   (* -1
+                      (compose (/ cos sin) theta)
+                      (+ (* w0 betadot)
+                         (* w1 alphadot))
+                      d:dw1)))))
+
+  (define Gu (G d:dtheta))
+  (define Gv (G d:dphi))
+
+  (define (initial-state initial-coords w)
+    (let ((theta0 (ref initial-coords 0))
+          (phi0 (ref initial-coords 1)))
+      (let ((dummy
+             ((m/point states)
+              (up theta0 phi0 'foo 'bar))))
+        ((m/point states)
+         (up theta0 phi0
+             ((dw0 w) dummy)
+             ((dw1 w) dummy))))))
+
+
+  ((dw0 (o/commutator Gu Gv))
+   (initial-state (up 'theta0 'phi0) d:dw1))
+  ;; ;; Result:
+  (* -1 (expt (g/sin theta0) 2))
+
+
+  (is (= 1 (simplify
+            ((dw1 (o/commutator Gu Gv))
+             (initial-state (up 'theta0 'phi0) d:dw0)))))
+                                        ; ; Result:
+  1
+
+  ;; Gee, this gets the right answer.
+
+  ;; To integrate these equations of the coordinates of the vector
+  ;; being transported along a path (mu↑theta(tau), mu↑phi(tau)), defined
+  ;; by differential equations we need to make a state space that
+  ;; represents both the path and the coordinates of the vector being
+  ;; transported.  The states are s=(sigma, w)=((theta, phi), (w0, w1))
+  ;; and the differential equations for the path are Dsigma(tau) =
+  ;; b(sigma(tau)).  The differential equations for the coordinates of
+  ;; the vector are driven by this path.
+
+  ;; To represent these states we make a new manifold with 4
+  ;; coordinates.  The first two coordinates are tha coordinates of the
+  ;; path.  The second two coordinates are the components of the vector
+  ;; to be transported, relative to the coordinate directions in the
+  ;; original manifold.  The right-hand side of the composite
+  ;; differential equation is a vector field on this manifold.
+
+  (define-coordinates (up theta phi) M-rect)
+  (define-coordinates (up Theta Phi w0 w1) states)
+
+  ;; Assuming that the paths are integral curves of a vector field v,
+  ;; we supply the vector field:
+  (define (G v)
+    (let ((alphadot (dTheta v)) (betadot (dPhi v)))
+      (+ v
+         (* (compose (* sin cos) Theta) betadot w1 d:dw0)
+         (* -1
+            (compose (/ cos sin) Theta)
+            (+ (* w0 betadot) (* w1 alphadot))
+            d:dw1))))
+
+  (define Gu (G d:dTheta))
+  (define Gv (G d:dPhi))
+
+  (define (initial-state initial-coords w)
+    (let ((Theta0 (ref initial-coords 0))
+          (Phi0 (ref initial-coords 1)))
+      (let ((m ((m/point M-rect) (up Theta0 Phi0))))
+        ((m/point states)
+         (up Theta0 Phi0
+             ((dtheta w) m) ((dphi w) m))))))
+
+
+  (pec ((dw0 (o/commutator Gu Gv))
+        (initial-state (up 'Theta0 'Phi0) d:dphi)))
+  ;; ;; Result:
+  (* -1 (expt (g/sin Theta0) 2))
+
+
+  (is  (= 1 (simplify
+             ((dw1 (o/commutator Gu Gv))
+              (initial-state (up 'Theta0 'Phi0) d:dtheta)))))
+
+  ;; Gee, this gets the right answer.
+
+
+  ;;----------------------------------------------------------------
+  ;; try to improve this
+  ;;
+  ;; let gamma be the path that we are transporting along
+  ;; gamma(t)->M
+  ;;
+  ;; dgamma(d:dt)(f)(t) is the velocity vector, a vector over the map gamma
+  ;;
+  ;; when gamma is an integral curve of v, then
+  ;; v(f)(gamma(t)) = dgamma(d:dt)(f)(t)
+  ;;
+  ;; let w be an arbitrary vector over the map
+  ;; w(f)(t) = d:dtheta (f)(gamma(t)) a_0(t) + d:dphi (f)(gamma(t)) a_1(t)
+
+  )

--- a/test/sicmutils/calculus/curvature_test.cljc
+++ b/test/sicmutils/calculus/curvature_test.cljc
@@ -175,38 +175,36 @@
                       dphi d:dtheta d:dphi d:dtheta)
                      a-point))))
 
-          ;; R↑alpha_{beta gamma delta}
-          ;;
           (testing "p351 MTW has efficient method for computing curvature (eq
-          14.18)")
-          (letfn [(check! [expected alpha beta gamma delta]
-                    (is (= expected
-                           (simplify
-                            (((c/Riemann nabla)
-                              alpha beta gamma delta)
-                             a-point)))))]
-            (check! 0 dtheta d:dtheta d:dtheta d:dtheta)
-            (check! 0 dtheta d:dtheta d:dtheta d:dphi)
-            (check! 0 dtheta d:dtheta d:dphi d:dtheta)
-            (check! 0 dtheta d:dtheta d:dphi d:dphi)
-            (check! 0 dtheta d:dphi d:dtheta d:dtheta)
+          14.18)"
+            ;; R↑alpha_{beta gamma delta}
+            (letfn [(check! [expected alpha beta gamma delta]
+                      (is (= expected
+                             (simplify
+                              (((c/Riemann nabla)
+                                alpha beta gamma delta)
+                               a-point)))))]
+              (check! 0 dtheta d:dtheta d:dtheta d:dtheta)
+              (check! 0 dtheta d:dtheta d:dtheta d:dphi)
+              (check! 0 dtheta d:dtheta d:dphi d:dtheta)
+              (check! 0 dtheta d:dtheta d:dphi d:dphi)
+              (check! 0 dtheta d:dphi d:dtheta d:dtheta)
 
-            (check! '(expt (sin theta↑0) 2)
-                    dtheta d:dphi d:dtheta d:dphi)
+              (check! '(expt (sin theta↑0) 2)
+                      dtheta d:dphi d:dtheta d:dphi)
 
-            (check! '(* -1 (expt (sin theta↑0) 2))
-                    dtheta d:dphi d:dphi d:dtheta)
+              (check! '(* -1 (expt (sin theta↑0) 2))
+                      dtheta d:dphi d:dphi d:dtheta)
 
-            (check! 0 dtheta d:dphi d:dphi d:dphi)
-            (check! 0 dphi d:dtheta d:dtheta d:dtheta)
-            (check! -1 dphi d:dtheta d:dtheta d:dphi)
-            (check! 1 dphi d:dtheta d:dphi d:dtheta)
-            (check! 0 dphi d:dtheta d:dphi d:dphi)
-            (check! 0 dphi d:dphi d:dtheta d:dtheta)
-            (check! 0 dphi d:dphi d:dtheta d:dphi)
-            (check! 0 dphi d:dphi d:dphi d:dtheta)
-            (check! 0 dphi d:dphi d:dphi d:dphi)))
-        ))
+              (check! 0 dtheta d:dphi d:dphi d:dphi)
+              (check! 0 dphi d:dtheta d:dtheta d:dtheta)
+              (check! -1 dphi d:dtheta d:dtheta d:dphi)
+              (check! 1 dphi d:dtheta d:dphi d:dtheta)
+              (check! 0 dphi d:dtheta d:dphi d:dphi)
+              (check! 0 dphi d:dphi d:dtheta d:dtheta)
+              (check! 0 dphi d:dphi d:dtheta d:dphi)
+              (check! 0 dphi d:dphi d:dphi d:dtheta)
+              (check! 0 dphi d:dphi d:dphi d:dphi))))))
 
     ;; The Christoffel symbols (for R=1) (p.341 MTW) are:
     ;; (the up-down-down Christoffel symbols do not depend on R)
@@ -285,6 +283,7 @@
                          (expt (sin theta) 2)))
                  (simplify
                   (an/literal-number s14)))))
+
         ))
     ))
 
@@ -312,39 +311,39 @@
         oneform-basis))))
 
   ;; do all substitutions again...
-  (pec s12)
+  s12
   ;; ;; Result:
   (up
-   (+ (* -2 eta phidot thetadot (expt (g/cos theta) 2))
-      (* -2 (expt phidot 2) xi (expt (g/cos theta) 2))
-      (* -1 eta phidotdot (g/cos theta) (g/sin theta))
-      (* -2 etadot phidot (g/cos theta) (g/sin theta))
+   (+ (* -2 eta phidot thetadot (expt (cos theta) 2))
+      (* -2 (expt phidot 2) xi (expt (cos theta) 2))
+      (* -1 eta phidotdot (cos theta) (sin theta))
+      (* -2 etadot phidot (cos theta) (sin theta))
       (* (expt phidot 2) xi)
       xidotdot)
    (/
-    (+ (* -1 eta (expt phidot 2) (expt (g/cos theta) 2) (g/sin theta))
-       (* -2 phidot thetadot xi (g/sin theta))
-       (* eta thetadotdot (g/cos theta))
-       (* 2 etadot thetadot (g/cos theta))
-       (* 2 phidot xidot (g/cos theta))
-       (* phidotdot xi (g/cos theta))
-       (* etadotdot (g/sin theta)))
-    (g/sin theta)))
+    (+ (* -1 eta (expt phidot 2) (expt (cos theta) 2) (sin theta))
+       (* -2 phidot thetadot xi (sin theta))
+       (* eta thetadotdot (cos theta))
+       (* 2 etadot thetadot (cos theta))
+       (* 2 phidot xidot (cos theta))
+       (* phidotdot xi (cos theta))
+       (* etadotdot (sin theta)))
+    (sin theta)))
 
 
-  (pec s14)
+  s14
   ;; ;; Result:
   (up
-   (+ (* -2 (expt phidot 2) xi (expt (g/cos theta) 2))
-      (* -2 etadot phidot (g/cos theta) (g/sin theta))
+   (+ (* -2 (expt phidot 2) xi (expt (cos theta) 2))
+      (* -2 etadot phidot (cos theta) (sin theta))
       (* (expt phidot 2) xi)
       xidotdot)
    (/
-    (+ (* 2 etadot thetadot (g/cos theta) (g/sin theta))
-       (* 2 phidot xidot (g/cos theta) (g/sin theta))
-       (* etadotdot (expt (g/sin theta) 2))
+    (+ (* 2 etadot thetadot (cos theta) (sin theta))
+       (* 2 phidot xidot (cos theta) (sin theta))
+       (* etadotdot (expt (sin theta) 2))
        (* -2 phidot thetadot xi))
-    (expt (g/sin theta) 2)))
+    (expt (sin theta) 2)))
 
 
   ;; agrees with Riemann calculation
@@ -392,92 +391,92 @@
   ;; ;; Result:
   (up
    (+ (((expt D 2) f↑theta) tau)
-      (* -1 (g/cos (f↑theta tau)) (g/sin (f↑theta tau)) (expt ((D f↑phi) tau) 2)))
-   (/ (+ (* (g/sin (f↑theta tau)) (((expt D 2) f↑phi) tau))
-         (* 2 (g/cos (f↑theta tau)) ((D f↑phi) tau) ((D f↑theta) tau)))
-      (g/sin (f↑theta tau))))
+      (* -1 (cos (f↑theta tau)) (sin (f↑theta tau)) (expt ((D f↑phi) tau) 2)))
+   (/ (+ (* (sin (f↑theta tau)) (((expt D 2) f↑phi) tau))
+         (* 2 (cos (f↑theta tau)) ((D f↑phi) tau) ((D f↑theta) tau)))
+      (sin (f↑theta tau))))
 
 
   ;; Parallel transport of vector W over path mu
 
-  (pec (let ((U d:dt)
-             (mu:N->M (compose (m/point S2-spherical)
-                               (up (af/literal-function 'f↑theta)
-                                   (af/literal-function 'f↑phi))
-                               (m/chart the-real-line))))
-         (let* ((basis-over-mu
-                 (cm/basis->basis-over-map mu:N->M S2-spherical-basis))
-                (oneform-basis (b/basis->oneform-basis basis-over-mu))
-                (vector-basis (basis->vector-basis basis-over-mu))
-                (Cartan (Christoffel->Cartan G-S2-1))
-                (transported-vector-over-map
-                 (basis-components->vector-field
-                  (up (compose (af/literal-function 'w↑0)
-                               (m/chart the-real-line))
-                      (compose (af/literal-function 'w↑1)
-                               (m/chart the-real-line)))
-                  vector-basis)))
-           (s/mapr
-            (fn [w]
-              ((w
-                (((cov/covariant-derivative Cartan mu:N->M) U)
-                 transported-vector-over-map))
-               ((m/point the-real-line) 'tau)))
-            oneform-basis))))
+  (let ((U d:dt)
+        (mu:N->M (compose (m/point S2-spherical)
+                          (up (af/literal-function 'f↑theta)
+                              (af/literal-function 'f↑phi))
+                          (m/chart the-real-line))))
+    (let* ((basis-over-mu
+            (cm/basis->basis-over-map mu:N->M S2-spherical-basis))
+           (oneform-basis (b/basis->oneform-basis basis-over-mu))
+           (vector-basis (basis->vector-basis basis-over-mu))
+           (Cartan (Christoffel->Cartan G-S2-1))
+           (transported-vector-over-map
+            (basis-components->vector-field
+             (up (compose (af/literal-function 'w↑0)
+                          (m/chart the-real-line))
+                 (compose (af/literal-function 'w↑1)
+                          (m/chart the-real-line)))
+             vector-basis)))
+      (s/mapr
+       (fn [w]
+         ((w
+           (((cov/covariant-derivative Cartan mu:N->M) U)
+            transported-vector-over-map))
+          ((m/point the-real-line) 'tau)))
+       oneform-basis)))
 
   ;; Result:
   (up
    (+ ((D w↑0) tau)
-      (* -1 (g/cos (f↑theta tau)) ((D f↑phi) tau) (w↑1 tau) (g/sin (f↑theta tau))))
-   (/ (+ (* (g/sin (f↑theta tau)) ((D w↑1) tau))
-         (* (g/cos (f↑theta tau)) ((D f↑phi) tau) (w↑0 tau))
-         (* (g/cos (f↑theta tau)) (w↑1 tau) ((D f↑theta) tau)))
-      (g/sin (f↑theta tau))))
+      (* -1 (cos (f↑theta tau)) ((D f↑phi) tau) (w↑1 tau) (sin (f↑theta tau))))
+   (/ (+ (* (sin (f↑theta tau)) ((D w↑1) tau))
+         (* (cos (f↑theta tau)) ((D f↑phi) tau) (w↑0 tau))
+         (* (cos (f↑theta tau)) (w↑1 tau) ((D f↑theta) tau)))
+      (sin (f↑theta tau))))
 
 
   ;; was  ...  looks like right hand side
 
-  (up (* (g/sin (theta tau)) (g/cos (theta tau)) (w↑1 tau)
+  (up (* (sin (theta tau)) (cos (theta tau)) (w↑1 tau)
          ((D phi) tau))
-      (/ (+ (* -1 (w↑0 tau) (g/cos (theta tau)) ((D phi) tau))
-            (* -1 ((D theta) tau) (g/cos (theta tau)) (w↑1 tau)))
-         (g/sin (theta tau))))
+      (/ (+ (* -1 (w↑0 tau) (cos (theta tau)) ((D phi) tau))
+            (* -1 ((D theta) tau) (cos (theta tau)) (w↑1 tau)))
+         (sin (theta tau))))
 
 
   ;; To set up for solving for the derivatives, we lift off of the path
 
-  (pec (let ((U d:dt)
-             (mu:N->M (compose (m/point S2-spherical)
-                               (up (af/literal-function 'f↑theta)
-                                   (af/literal-function 'f↑phi))
-                               (m/chart the-real-line))))
-         (let* ((basis-over-mu (cm/basis->basis-over-map mu:N->M S2-spherical-basis))
-                (oneform-basis (b/basis->oneform-basis basis-over-mu))
-                (vector-basis (basis->vector-basis basis-over-mu))
-                (Cartan (Christoffel->Cartan G-S2-1))
-                (transported-vector-over-map
-                 (basis-components->vector-field
-                  (up (compose (osculating-path (up 'tau 'w↑0 'dw↑0/dt))
-                               (m/chart the-real-line))
-                      (compose (osculating-path (up 'tau 'w↑1 'dw↑1/dt))
-                               (m/chart the-real-line)))
-                  vector-basis)))
-           (s/mapr
-            (fn [w]
-              ((w
-                (((cov/covariant-derivative Cartan mu:N->M)
-                  U)
-                 transported-vector-over-map))
-               ((m/point the-real-line) 'tau)))
-            oneform-basis))))
+  (let ((U d:dt)
+        (mu:N->M (compose (m/point S2-spherical)
+                          (up (af/literal-function 'f↑theta)
+                              (af/literal-function 'f↑phi))
+                          (m/chart the-real-line))))
+    (let* ((basis-over-mu (cm/basis->basis-over-map mu:N->M S2-spherical-basis))
+           (oneform-basis (b/basis->oneform-basis basis-over-mu))
+           (vector-basis (basis->vector-basis basis-over-mu))
+           (Cartan (Christoffel->Cartan G-S2-1))
+           (transported-vector-over-map
+            (basis-components->vector-field
+             (up (compose (osculating-path (up 'tau 'w↑0 'dw↑0/dt))
+                          (m/chart the-real-line))
+                 (compose (osculating-path (up 'tau 'w↑1 'dw↑1/dt))
+                          (m/chart the-real-line)))
+             vector-basis)))
+      (s/mapr
+       (fn [w]
+         ((w
+           (((cov/covariant-derivative Cartan mu:N->M)
+             U)
+            transported-vector-over-map))
+          ((m/point the-real-line) 'tau)))
+       oneform-basis)))
 
   ;; Result:
   (up (+ dw↑0:dt
-         (* -1 (g/cos (f↑theta tau)) ((D f↑phi) tau) (g/sin (f↑theta tau)) w↑1))
-      (/ (+ (* (g/sin (f↑theta tau)) dw↑1:dt)
-            (* (g/cos (f↑theta tau)) ((D f↑phi) tau) w↑0)
-            (* (g/cos (f↑theta tau)) ((D f↑theta) tau) w↑1))
-         (g/sin (f↑theta tau))))
+         (* -1 (cos (f↑theta tau)) ((D f↑phi) tau) (sin (f↑theta tau)) w↑1))
+      (/ (+ (* (sin (f↑theta tau)) dw↑1:dt)
+            (* (cos (f↑theta tau)) ((D f↑phi) tau) w↑0)
+            (* (cos (f↑theta tau)) ((D f↑theta) tau) w↑1))
+         (sin (f↑theta tau))))
 
 
   ;; Loaded solve by (load "/usr/local/scmutils/src/solve/linreduce")
@@ -505,10 +504,10 @@
      2 2))
 
   ;; ;; Result:
-  (up (* (w↑1 tau) (g/sin (f↑theta tau)) (g/cos (f↑theta tau)) ((D f↑phi) tau))
-      (/ (+ (* -1 (w↑1 tau) (g/cos (f↑theta tau)) ((D f↑theta) tau))
-            (* -1 (g/cos (f↑theta tau)) ((D f↑phi) tau) (w↑0 tau)))
-         (g/sin (f↑theta tau))))
+  (up (* (w↑1 tau) (sin (f↑theta tau)) (cos (f↑theta tau)) ((D f↑phi) tau))
+      (/ (+ (* -1 (w↑1 tau) (cos (f↑theta tau)) ((D f↑theta) tau))
+            (* -1 (cos (f↑theta tau)) ((D f↑phi) tau) (w↑0 tau)))
+         (sin (f↑theta tau))))
 
 
   (let [U d:dt
@@ -544,11 +543,11 @@
      (S2-spherical 'dimension)))
   ;; ;; Result:
   (up
-   (* w↑1 (g/cos (f↑theta tau)) (g/sin (f↑theta tau)) ((D f↑phi) tau))
+   (* w↑1 (cos (f↑theta tau)) (sin (f↑theta tau)) ((D f↑phi) tau))
    (/
-    (+ (* -1 w↑0 (g/cos (f↑theta tau)) ((D f↑phi) tau))
-       (* -1 w↑1 ((D f↑theta) tau) (g/cos (f↑theta tau))))
-    (g/sin (f↑theta tau))))
+    (+ (* -1 w↑0 (cos (f↑theta tau)) ((D f↑phi) tau))
+       (* -1 w↑1 ((D f↑theta) tau) (cos (f↑theta tau))))
+    (sin (f↑theta tau))))
 
   ;; Computing parallel transport without the embedding
   (let-coordinates [t m/the-real-line
@@ -592,13 +591,13 @@
      (b/basis->oneform-basis basis-over-mu)))
   ;; ;; Result:
   (up
-   (+ (* -1 (w↑1 tau) ((D mu↑phi) tau) (g/cos (mu↑theta tau)) (g/sin (mu↑theta tau)))
+   (+ (* -1 (w↑1 tau) ((D mu↑phi) tau) (cos (mu↑theta tau)) (sin (mu↑theta tau)))
       ((D w↑0) tau))
    (/
-    (+ (* (w↑1 tau) (g/cos (mu↑theta tau)) ((D mu↑theta) tau))
-       (* (w↑0 tau) ((D mu↑phi) tau) (g/cos (mu↑theta tau)))
-       (* ((D w↑1) tau) (g/sin (mu↑theta tau))))
-    (g/sin (mu↑theta tau))))
+    (+ (* (w↑1 tau) (cos (mu↑theta tau)) ((D mu↑theta) tau))
+       (* (w↑0 tau) ((D mu↑phi) tau) (cos (mu↑theta tau)))
+       (* ((D w↑1) tau) (sin (mu↑theta tau))))
+    (sin (mu↑theta tau))))
 
   ;; These are the equations of the coordinates of a vector being
   ;; parallel transported along the path defined by f.
@@ -660,7 +659,7 @@
   ((dw0 (o/commutator Gu Gv))
    (initial-state (up 'theta0 'phi0) d:dw1))
   ;; ;; Result:
-  (* -1 (expt (g/sin theta0) 2))
+  (* -1 (expt (sin theta0) 2))
 
 
   (is (= 1 (simplify
@@ -713,10 +712,10 @@
              ((dtheta w) m) ((dphi w) m))))))
 
 
-  (pec ((dw0 (o/commutator Gu Gv))
-        (initial-state (up 'Theta0 'Phi0) d:dphi)))
+  ((dw0 (o/commutator Gu Gv))
+   (initial-state (up 'Theta0 'Phi0) d:dphi))
   ;; ;; Result:
-  (* -1 (expt (g/sin Theta0) 2))
+  (* -1 (expt (sin Theta0) 2))
 
 
   (is  (= 1 (simplify

--- a/test/sicmutils/calculus/vector_field_test.cljc
+++ b/test/sicmutils/calculus/vector_field_test.cljc
@@ -42,12 +42,17 @@
   (comp v/freeze g/simplify))
 
 (deftest vector-field-tests
-  (testing "v/zero-like"
+  (testing "v/zero-like, v/one-like, v/identity-like"
     (let [vf (vf/literal-vector-field 'b R2-rect)]
       (is (v/zero? (v/zero-like vf)))
       (is (vf/vector-field? (v/zero-like vf)))
       (is (= 'vf:zero (v/freeze
-                       (v/zero-like vf))))))
+                       (v/zero-like vf))))
+
+      (testing "the returned identity keeps its context and `::vf/vector-field`
+       status."
+        (is (vf/vector-field? (v/one-like vf)))
+        (is (vf/vector-field? (v/identity-like vf))))))
 
   (testing "with-coordinate-prototype"
     (let [A R2-rect

--- a/test/sicmutils/collection_test.cljc
+++ b/test/sicmutils/collection_test.cljc
@@ -22,6 +22,7 @@
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]
              #?@(:cljs [:include-macros true])]
+            [same :refer [ish?]]
             [sicmutils.calculus.derivative :refer [D]]
             [sicmutils.complex :refer [complex I]]
             [sicmutils.collection :as collection]

--- a/test/sicmutils/fdg/ch7_test.cljc
+++ b/test/sicmutils/fdg/ch7_test.cljc
@@ -87,24 +87,28 @@
            R3-rect-point ((point R3-rect) (up 'x0 'y0 'z0))]
        (is (= :sicmutils.calculus.vector-field/vector-field (v/kind V)))
        (is (= :sicmutils.operator/operator (v/kind (e/Lie-derivative V))))
-       (is (= :sicmutils.calculus.form-field/form-field (v/kind theta)))
+       (is (= :sicmutils.calculus.form-field/oneform-field (v/kind theta)))
        (is (= 1 (:rank (o/context theta))))
        (is (= 2 (:rank (o/context omega))))
+
        #_(is (e/= 'a
                   (simplify (((d ((e/Lie-derivative V) theta))
                               X Y)
                              R3-rect-point))))
+
        #_(is (e/= 'a
                   (simplify ((((e/Lie-derivative V) (d theta))
                               X Y)
                              R3-rect-point))))
+
        ;; if you look at the LH and RH of the subtraction, you will observe that
        ;; this is nontrivial :)
        (is (zero?
-            (simplify (((- ((e/Lie-derivative V) (d theta))
-                           (d ((e/Lie-derivative V) theta)))
-                        X Y)
-                       R3-rect-point))))
+            (simplify
+             (((- ((e/Lie-derivative V) (d theta))
+                  (d ((e/Lie-derivative V) theta)))
+               X Y)
+              R3-rect-point))))
        (is (zero?
             (simplify (((- ((e/Lie-derivative V) (d omega))
                            (d ((e/Lie-derivative V) omega)))

--- a/test/sicmutils/operator_test.cljc
+++ b/test/sicmutils/operator_test.cljc
@@ -59,7 +59,7 @@
 
     (testing "one? zero? identity? return true appropriately"
       (is (v/zero? (v/zero-like x2)))
-      (is (v/one? (v/one-like x2)))
+      (is (not (v/one? (v/one-like x2))))
       (is (v/identity? (v/identity-like x2))))
 
     (testing "v/numerical?"
@@ -360,23 +360,59 @@
           q (o/make-operator identity 'q {:subtype ::x :color :blue})
           r (o/make-operator identity 'r {:subtype ::x :color :green})]
       (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
-                   (g/add o p)))
+                   (g/+ o p)))
 
       (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
-                   (g/mul o p)))
+                   (g/* o p)))
 
       (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
-                   (g/add q r)))
+                   (g/+ q r)))
 
       (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
-                   (g/add q p)))
+                   (g/+ q p)))
 
       (is (= 2 (((+ o o) inc) 0)))
       (is (= 1 (((* o o) inc) 0)))
       (is (= {:subtype ::x} (o/context (+ o o))))
       (is (= {:subtype ::y} (o/context (* p p))))
       (is (= {:subtype ::x :color :blue}
-             (o/context (+ q o)))))))
+             (o/context (+ q o))))))
+
+  (testing "subtypes combine by choosing the parent"
+    (derive ::cake ::o/operator)
+    (derive ::face ::cake)
+    (let [o (o/make-operator identity 'o {:subtype ::cake})
+          p (o/make-operator identity 'p {:subtype ::face})]
+      (is (= {:subtype ::cake}
+             (o/context (+ o p))
+             (o/context (+ p o))))
+
+      (is (= {:subtype ::cake}
+             (o/context (- o p))
+             (o/context (- p o))))
+
+      (is (= {:subtype ::cake}
+             (o/context (* o p))
+             (o/context (* p o))))))
+
+  (testing "*, -, + between operators simplifies"
+    (is (= (o/procedure D)
+           (o/procedure (* o/identity D))
+           (o/procedure (* D o/identity)))
+        "* ignores identity")
+
+    (is (= (o/procedure D)
+           (o/procedure (+ D (v/zero-like D)))
+           (o/procedure (+ (v/zero-like D) D)))
+        "+ ignores zeros")
+
+    (is (= (o/procedure D)
+           (o/procedure (- D (v/zero-like D))))
+        "- ignores zeros on right")
+
+    (is (not= (o/procedure D)
+              (o/procedure (- (v/zero-like D) D)))
+        "- does NOT ignore zero on left")))
 
     ;;; more testing to come as we implement multivariate literal functions that
     ;;; rely on operations on structures....

--- a/test/sicmutils/runner.cljs
+++ b/test/sicmutils/runner.cljs
@@ -10,6 +10,7 @@
             sicmutils.calculus.basis-test
             sicmutils.calculus.coordinate-test
             sicmutils.calculus.covariant-test
+            sicmutils.calculus.curvature-test
             sicmutils.calculus.derivative-test
             sicmutils.calculus.form-field-test
             sicmutils.calculus.manifold-test
@@ -111,6 +112,7 @@
            'sicmutils.calculus.basis-test
            'sicmutils.calculus.coordinate-test
            'sicmutils.calculus.covariant-test
+           'sicmutils.calculus.curvature-test
            'sicmutils.calculus.derivative-test
            'sicmutils.calculus.form-field-test
            'sicmutils.calculus.manifold-test


### PR DESCRIPTION
From the CHANGELOG:

- #337:

  - adds `sicmutils.calculus.curvature`, with these new functions and many tests
    from the classic "Gravitation" book:

    `Riemann-curvature`, `Riemann`, `Ricci`, `torsion-vector`, `torsion` and
    `curvature-components`

  - If you combine `Operator` instances with non-equal `:subtype` fields, the
    returned operator now keeps the parent subtype (or throws if one is not a
    subtype of the other).

  - `Operator` instances now ignore any `identity?`-passing operator on the left
    or right side of operator-operator multiplication. Contexts are still
    appropriately merged.

  - Similarly, `Operator` addition ignores `zero?` operators on the left or
    right side, and subtraction ignores `zero?` operators on the right right.

  - form fields now have NO identity operator, since they multiply by wedge, not
    composition.