### PR TITLE
Change docstring of Euler–Mascheroni constant

### DIFF
--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -175,9 +175,9 @@
 constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   -pi (g/- Math/PI))
 
-(def ^{:doc "The mathematical
-  constant [e](https://en.wikipedia.org/wiki/E_(mathematical_constant)),
-  sometimes known as Euler's Number."}
+(def ^{:doc "The mathematical constant known as the [Euler–Mascheroni
+  constant](https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant) and
+  sometimes as Euler's constant."}
   euler
   0.57721566490153286)
 

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -175,10 +175,16 @@
 constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   -pi (g/- Math/PI))
 
+(def ^{:doc "The mathematical
+  constant [e](https://en.wikipedia.org/wiki/E_(mathematical_constant)),
+  sometimes known as Euler's Number."}
+  euler
+  (Math/exp 1))
+
 (def ^{:doc "The mathematical constant known as the [Euler–Mascheroni
   constant](https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant) and
   sometimes as Euler's constant."}
-  euler
+  euler-gamma
   0.57721566490153286)
 
 (def ^{:doc "The mathematical


### PR DESCRIPTION
The docstring for the Euler–Mascheroni constant was describing Euler’s number instead of the Euler–Mascheroni constant.

Alternatively, one can fix this by adjusting the number to be Euler's number. I've created a merge request for that [here](https://github.com/sicmutils/sicmutils/pull/352).

One of the two merge requests should be rejected depending on which solution is preferred.