### PR TITLE
Change Euler’s constant to Euler’s number

### DIFF
--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -179,7 +179,7 @@ constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   constant [e](https://en.wikipedia.org/wiki/E_(mathematical_constant)),
   sometimes known as Euler's Number."}
   euler
-  0.57721566490153286)
+  (g/exp 1))
 
 (def ^{:doc "The mathematical
   constant [𝜑](https://en.wikipedia.org/wiki/Golden_ratio), also known as the


### PR DESCRIPTION
The docstring for `euler` describes Euler’s number while the value was the Euler–Mascheroni constant, also known as Euler’s constant. This changes the value to Euler’s number.

Alternatively, one can fix this by adjusting the docstring to describe the Euler–Mascheroni constant. I've created a merge request for that [here](https://github.com/sicmutils/sicmutils/pull/351).

One of the two merge requests should be rejected depending on which solution is preferred.