### PR TITLE
Add SCI support for new pattern matching library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [unreleased]
 
+- #354 adds SCI support for all macros and functions in the new pattern matching
+  namespaces, and adds these to the namespaces exposed via `sicmutils.env.sci`.
+
 - #349 introduces a new pattern matching system, built out of matcher
   combinators. All of the rules in `sicmutils.simplify.rules` now use the new
   syntax offered by the library. Some notes:

--- a/src/pattern/rule.cljc
+++ b/src/pattern/rule.cljc
@@ -169,7 +169,7 @@
            (or (handler result)
                m/failure)))))))
 
-(defn- compile-rule
+(defn ^:no-doc compile-rule
   "Returns compiled, macro-ready input for [[rule*]] based on the contract
   described by [[rule]]."
   ([p consequent-fn]

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -63,7 +63,11 @@
  right to expose to a user by default. Each value is the sym->var map for the
  corresponding namespace."}
   ns->publics
-  {'sicmutils.complex                          (ns-publics 'sicmutils.complex)
+  {'pattern.consequence                        (ns-publics 'pattern.consequence)
+   'pattern.match                              (ns-publics 'pattern.match)
+   'pattern.rule                               (ns-publics 'pattern.rule)
+   'pattern.syntax                             (ns-publics 'pattern.syntax)
+   'sicmutils.complex                          (ns-publics 'sicmutils.complex)
    'sicmutils.differential                     (ns-publics 'sicmutils.differential)
    'sicmutils.env                              (ns-publics 'sicmutils.env)
    'sicmutils.expression                       (ns-publics 'sicmutils.expression)

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -82,6 +82,7 @@
    'sicmutils.rational-function                (ns-publics 'sicmutils.rational-function)
    'sicmutils.series                           (ns-publics 'sicmutils.series)
    'sicmutils.simplify                         (ns-publics 'sicmutils.simplify)
+   'sicmutils.simplify.rules                   (ns-publics 'sicmutils.simplify.rules)
    'sicmutils.structure                        (ns-publics 'sicmutils.structure)
    'sicmutils.util                             (ns-publics 'sicmutils.util)
    'sicmutils.value                            (ns-publics 'sicmutils.value)

--- a/test/sicmutils/env/sci_test.cljc
+++ b/test/sicmutils/env/sci_test.cljc
@@ -29,6 +29,23 @@
 (defn eval [form]
   (sci/eval-form (sci/fork es/context) form))
 
+(deftest pattern-tests
+  (is (= ['(+ 2 1) "done!"]
+         (eval
+          '(do (require '[pattern.rule :as r :refer [=>]])
+               (let [R (r/ruleset
+                        (+ 10 _) => "done!"
+                        (+ ?a ?b) => (+ ?b ?a))]
+                 [(R '(+ 1 2))
+                  (R (R '(+ 11 10)))])))))
+
+  (is (= '(+ 6)
+         (eval
+          '(do (require '[pattern.rule :as r :refer [=>]])
+               (let [R (r/term-rewriting
+                        (r/rule (+ ?a ?b ??c) => (+ ?b ??c)))]
+                 (R '(+ 1 2 3 4 5 6))))))))
+
 (deftest basic-sci-tests
   (is (= [:at-least 0]
          (eval '(arity


### PR DESCRIPTION
This PR adds SCI support for all macros and functions in the new pattern matching namespaces, and adds these to the namespaces exposed via `sicmutils.env.sci`.

@pangloss, this double-macro-writing thing is a touch annoying, but totally worth it for SCI compatibility. You might take a peek at what I had to do here to get it working for your library!