### PR TITLE
flaky test fix for rational functions

### DIFF
--- a/test/sicmutils/rational_function_test.cljc
+++ b/test/sicmutils/rational_function_test.cljc
@@ -219,11 +219,11 @@
 
   (checking "square, cube" test-limit
             [r (sg/rational-function)]
-            (is (= (rf/mul r r)
-                   (rf/square r)))
+            (is (= (rf/square r)
+                   (rf/mul r r)))
 
-            (is (= (rf/mul r (rf/square r))
-                   (rf/cube r)))))
+            (is (= (rf/cube r)
+                   (rf/mul r (rf/square r))))))
 
 (deftest rf-operations
   (let [x+1 (p/make [1 1])


### PR DESCRIPTION
Square and cube don't demote to coefficient; in the contrived generative testing situation, we sometimes make not-totally-reduced RFs, so `rf/mul` drops to coefficient but square and cube don't bother (since usually squaring or cubing wouldn't have that effect).

The solution is to force the RationalFunction instance to the left, since it can handle equality with non-RF instances.