### PR TITLE
Bump fraction.js dependency to 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [unreleased]
 
+## 0.19.2
+
+Yet another incremental release, this time to bump the `Fraction.js` dependency.
+The new `cljsjs` dependency has code compatible with advanced compilation.
+
+- #372 bumps the `Fraction.js` dependency to `4.1.1`.
+
 ## 0.19.1
 
 This is an incremental bugfix release to get Clojurescript advanced compilation

--- a/deps.edn
+++ b/deps.edn
@@ -10,4 +10,4 @@
         org.clojure/core.match {:mvn/version "1.0.0"},
         cljsjs/complex {:mvn/version "2.0.11-0"},
         borkdude/sci {:mvn/version "0.2.5"},
-        cljsjs/bigfraction {:mvn/version "4.0.12-0"}}}
+        cljsjs/bigfraction {:mvn/version "4.1.1-0"}}}

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                   :exclusions [org.clojure/clojurescript]]
                  [dm3/stopwatch "0.1.1"]
                  [org.apache.commons/commons-math3 "3.6.1"]
-                 [cljsjs/bigfraction "4.0.12-0"]
+                 [cljsjs/bigfraction "4.1.1-0"]
                  [cljsjs/complex "2.0.11-0"]
                  [cljsjs/odex "2.0.4-0"]
                  [hiccup "1.0.5"]

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -810,7 +810,7 @@
 
 
   (let [pos (gen/fmap inc gen/nat)]
-    (checking "arg-scale, shift" 100
+    (checking "arg-scale, shift" 30
               [term-count (gen/choose 2 10)
                factor pos
                p (gen/fmap p/make (gen/vector pos term-count))]
@@ -1034,7 +1034,7 @@
                      raised)))))
 
 (deftest evaluation-homomorphism-tests
-  (checking "evaluation-homomorphism" 30
+  (checking "evaluation-homomorphism" 20
             [[p q xs] (gen/let [arity (gen/choose 1 6)]
                         (gen/tuple
                          (sg/polynomial :arity arity)


### PR DESCRIPTION
#372 bumps the `Fraction.js` dependency to `4.1.1`.