### PR TITLE
Add ch7, covariant tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 - #379 fixes typos in a couple of the equations in `richardson.cljc`, closing
   #377. Thanks to @leifp for the report.
 
+- new PR:
+
+  - approximate equality of up, down implemented. Note trickiness.
+
+  - bugfix in `Cartan->Cartan-over-map` so that the book works now.
+
+  - new tests ported over!
+
+  - Added remaining code forms for chapter 7 in `ch7_test.cljc`
+
 ## 0.19.2
 
 Yet another incremental release, this time to bump the `Fraction.js` dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
   - Added remaining code forms for chapter 7 in `ch7_test.cljc`
 
+  - TODO tests for symbol equality in `ish?`
+
 ## 0.19.2
 
 Yet another incremental release, this time to bump the `Fraction.js` dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,42 @@
 - #379 fixes typos in a couple of the equations in `richardson.cljc`, closing
   #377. Thanks to @leifp for the report.
 
-- new PR:
+- Features, tests and bugfixes from #381:
 
-  - approximate equality of up, down implemented. Note trickiness.
+  - `sicmutils.calculus.coordinate/generate` moves to
+    `sicmutils.calculus.manifold/c:generate`; this supports a bugfix where
+    1-dimensional manifolds like `R1-rect`, aka `the-real-line`, return a
+    coordinate prototype of a single element like `t` instead of a structure
+    with a single entry, like `(up t)`. Thanks to @phasetr for the bug report
+    that led to this fix, and @gjs for finding and fixing the bug.
 
-  - bugfix in `Cartan->Cartan-over-map` so that the book works now.
+  - `same.ish/Approximate` implemented for `sicmutils.structure/Structure`,
+    allowing `ish?` comparison of `up` and `down` structures with approximate
+    entries. Require `sicmutils.generator` for this feature. (NOTE: because
+    protocols are implemented for the LEFT argument, `(ish? <vector> (down
+    ...))` will still return true if the values are approximately equal, even
+    though a `<vector>` is technically an `up` and should NOT equal a `down`. Do
+    an explicit conversion to `up` using `sicmutils.structure/vector->up` if
+    this distinction is important.)
 
-  - new tests ported over!
+  - `same.ish/Approximate` now defers to `sicmutils.value/=` for equality
+    between `Symbol` and other types. This lets `ish?` handle equality between
+    symbols like `'x` and literal expressions that happen to wrap a single
+    symbol.
 
-  - Added remaining code forms for chapter 7 in `ch7_test.cljc`
+  - `Cartan->Cartan-over-map` now does NOT compose `(differential map)` with its
+    internal Cartan forms. This fixed a bug in a code listing in section 7.3 of
+    FDG.
 
-  - TODO tests for symbol equality in `ish?`
+  - Section 7.3 of FDG implemented as tests in `sicmutils.fdg.ch7-test`.
 
-  - properly return a single coordinate for any 1-dimensional coordinate prototype.
+  - Many new tests and explorations ported over from `covariant-derivative.scm`.
+    These live in `sicmutils.calculus.covariant-test`.
+
+  - timeout exceptions resulting from full GCD are now caught in tests using
+    `sicmutils.simplify/hermetic-simplify-fixture`. Previously, setting a low
+    timeout where simplification failed would catch and move on in normal work,
+    but fail in tests where fixtures were applied.
 
 ## 0.19.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
   - TODO tests for symbol equality in `ish?`
 
+  - properly return a single coordinate for any 1-dimensional coordinate prototype.
+
 ## 0.19.2
 
 Yet another incremental release, this time to bump the `Fraction.js` dependency.

--- a/src/sicmutils/calculus/basis.cljc
+++ b/src/sicmutils/calculus/basis.cljc
@@ -20,7 +20,6 @@
 (ns sicmutils.calculus.basis
   (:require [sicmutils.generic :as g]
             [sicmutils.structure :as s]
-            [sicmutils.calculus.coordinate :as coord]
             [sicmutils.calculus.manifold :as m]
             [sicmutils.calculus.form-field :as ff]
             [sicmutils.calculus.vector-field :as vf]
@@ -103,7 +102,7 @@
                  (-> (s/mapr #(% coords) vector-basis-coefficient-functions)
                      (invert)
                      (transpose))))
-        oneform-basis-coefficient-functions (coord/generate
+        oneform-basis-coefficient-functions (m/c:generate
                                              (:dimension
                                               (m/manifold coordinate-system))
                                              ::s/up

--- a/src/sicmutils/calculus/coordinate.cljc
+++ b/src/sicmutils/calculus/coordinate.cljc
@@ -151,15 +151,3 @@
   [coordinate-prototype coordinate-system & body]
   `(let-coordinates [~coordinate-prototype ~coordinate-system]
      ~@body))
-
-(defn generate
-  "Generates a coordinate structure of the supplied dimension `n`, and
-  `orientation` using the supplied function `f` for entries. See the very
-  similar [[sicmutils.structure/generate]] for more details.
-
-  NOTE from GJS: this is a kludge introduced only to allow a coordinate of
-  dimension 1 to automatically unwrap itself."
-  [n orientation f]
-  (if (= n 1)
-    (f 0)
-    (s/generate n orientation f)))

--- a/src/sicmutils/calculus/covariant.cljc
+++ b/src/sicmutils/calculus/covariant.cljc
@@ -222,11 +222,9 @@
 (defn Cartan->Cartan-over-map [Cartan map]
   (let [basis (cm/basis->basis-over-map
                map (Cartan->basis Cartan))
-        Cartan-forms
-        (s/mapr (cm/form-field->form-field-over-map map)
-                (Cartan->forms Cartan))]
-    (make-Cartan (f/compose Cartan-forms (cm/differential map))
-                 basis)))
+        forms (s/mapr (cm/form-field->form-field-over-map map)
+                      (Cartan->forms Cartan))]
+    (make-Cartan forms basis)))
 
 ;; ### Covariant Vector Definition
 
@@ -393,8 +391,12 @@
   ([Cartan]
    (covariant-derivative-ordinary Cartan))
   ([Cartan map]
-   (covariant-derivative-ordinary
-    (Cartan->Cartan-over-map Cartan map))))
+   (let [mapped (Cartan->Cartan-over-map Cartan map)]
+     (covariant-derivative-ordinary
+      (make-Cartan (f/compose (Cartan->forms mapped)
+                              (cm/differential map))
+                   (Cartan->basis mapped)
+                   )))))
 
 (defn covariant-differential [Cartan]
   (fn [V]

--- a/src/sicmutils/calculus/covariant.cljc
+++ b/src/sicmutils/calculus/covariant.cljc
@@ -395,8 +395,7 @@
      (covariant-derivative-ordinary
       (make-Cartan (f/compose (Cartan->forms mapped)
                               (cm/differential map))
-                   (Cartan->basis mapped)
-                   )))))
+                   (Cartan->basis mapped))))))
 
 (defn covariant-differential [Cartan]
   (fn [V]
@@ -425,7 +424,7 @@
                      (manifold/manifold source-coordsys)))]}
         (let [e (vf/coordinate-system->vector-basis source-coordsys)]
           (((((covariant-derivative Cartan-on-target gamma)
-              e);; d/dt
+              e) ;; d/dt
              vector-over-gamma)
             (manifold/chart target-coordsys))
            source-m))))))

--- a/src/sicmutils/calculus/manifold.cljc
+++ b/src/sicmutils/calculus/manifold.cljc
@@ -53,7 +53,9 @@
 ;;
 ;; - `manifold` and `patch` should be protocols, so that manifolds, patches and
 ;;   coordinate systems can report their manifold, and patches and coordinate
-;;   systems can report their patch. `point` can report its manifold too.
+;;   systems can report their patch. `point` can report its manifold too. Once
+;;   this change is made, `transfer-point` should use the `manifold` protocol to
+;;   simplify its implementation.
 ;;
 ;; - `patch`, `manifold` and `point` should be defrecords, so that they can
 ;;   implement the protocols above in different ways. We can also implement
@@ -387,10 +389,11 @@
   manifold `embedded` and transfers the point to the supplied `embedding`
   manifold.
 
-  TODO note that you can supply either a manifold or a coordinate system
-  attached to some manifold.
+  The embedding dimension must be the same for both manifolds.
 
-  The embedding dimension must be the same for both manifolds."
+  NOTE that `embedded` and `embedding` can be either manifolds, or instances
+  of [[ICoordinateSystem]]. In the latter case `embedded` and `embedding` will
+  bind to the manifold associated with the supplied [[ICoordinateSystem]]."
   [embedded embedding]
   (let [embedded-m (if (coordinate-system? embedded)
                      (manifold embedded)
@@ -398,8 +401,8 @@
         embedding-m (if (coordinate-system? embedding)
                       (manifold embedding)
                       embedding)]
-    (assert (= (:embedding-dimension embedded)
-	             (:embedding-dimension embedding)))
+    (assert (= (:embedding-dimension embedded-m)
+	             (:embedding-dimension embedding-m)))
     (fn [point]
       (assert (= embedded-m (point->manifold point)))
       (make-manifold-point

--- a/src/sicmutils/calculus/manifold.cljc
+++ b/src/sicmutils/calculus/manifold.cljc
@@ -387,15 +387,24 @@
   manifold `embedded` and transfers the point to the supplied `embedding`
   manifold.
 
+  TODO note that you can supply either a manifold or a coordinate system
+  attached to some manifold.
+
   The embedding dimension must be the same for both manifolds."
   [embedded embedding]
-  {:pre [(= (:embedding-dimension embedded)
-	          (:embedding-dimension embedding))]}
-  (fn [point]
-    (assert (= embedded (point->manifold point)))
-    (make-manifold-point
-	   (manifold-point-representation point)
-	   (manifold embedding))))
+  (let [embedded-m (if (coordinate-system? embedded)
+                     (manifold embedded)
+                     embedded)
+        embedding-m (if (coordinate-system? embedding)
+                      (manifold embedding)
+                      embedding)]
+    (assert (= (:embedding-dimension embedded)
+	             (:embedding-dimension embedding)))
+    (fn [point]
+      (assert (= embedded-m (point->manifold point)))
+      (make-manifold-point
+	     (manifold-point-representation point)
+	     embedding-m))))
 
 (defn corresponding-velocities
   "Takes a coordinate representation `coords` of a manifold point with all

--- a/src/sicmutils/calculus/manifold.cljc
+++ b/src/sicmutils/calculus/manifold.cljc
@@ -455,12 +455,24 @@ codebase compatibility."}
 ;;
 ;; This section defines many instances of [[ICoordinateSystem]].
 
+(defn c:generate
+  "Generates a coordinate structure of the supplied dimension `n`, and
+  `orientation` using the supplied function `f` for entries. See the very
+  similar [[sicmutils.structure/generate]] for more details.
+
+  NOTE from GJS: this is a kludge introduced only to allow a coordinate of
+  dimension 1 to automatically unwrap itself."
+  [n orientation f]
+  (if (= n 1)
+    (f 0)
+    (s/generate n orientation f)))
+
 (defn- default-coordinate-prototype
   "Takes a `manifold` and returns a [[sicmutils.structure/up]] instance of the
   same dimension as `manifold`, with symbolic entries in each position. "
   [manifold]
   (let [k (:dimension manifold)]
-    (s/generate
+    (c:generate
      k ::s/up (fn [i] (symbol (str "x" i))))))
 
 (defn- ->Rectangular

--- a/src/sicmutils/simplify.cljc
+++ b/src/sicmutils/simplify.cljc
@@ -72,10 +72,12 @@
   "Returns the result of executing the supplied `thunk` in an environment where
   the [[*rf-simplify*]] and [[*poly-simplify*]] are not memoized."
   [thunk]
-  (binding [*rf-simplify* (a/expression-simplifier
-                           (rational-function-analyzer))
-            *poly-simplify* (a/expression-simplifier
-                             (poly-analyzer))]
+  (binding [*rf-simplify* (unless-timeout
+                           (a/expression-simplifier
+                            (rational-function-analyzer)))
+            *poly-simplify* (unless-timeout
+                             (a/expression-simplifier
+                              (poly-analyzer)))]
     (thunk)))
 
 (defn- simplify-and-flatten [expr]

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -372,4 +372,917 @@
         Y (literal-vector-field 'Y S2-spherical)
         m ((point S2-spherical) (up 'theta 'phi))]
     (declare-argument-types! g (list vector-field? vector-field?))
-    (is (= 0 (((((covariant-derivative C) V) g) X Y) m)))))
+    (is (= 0 (((((covariant-derivative C) V) g) X Y) m))))
+
+
+  #|
+;;; Fun with Christoffel symbols.
+
+  (install-coordinates R2-rect (up 'x 'y))
+
+  (define R2-rect-basis
+    (coordinate-system->basis R2-rect))
+  (define R2-rect-point
+    ((R2-rect '->point) (up 'x0 'y0)))
+
+  (define (Gijk i j k)
+    (literal-manifold-function
+     (string->symbol
+      (string-append "G^"
+                     (number->string i)
+                     "_"
+                     (number->string j)
+                     (number->string k)))
+     R2-rect))
+
+  (define G
+    (down (down (up (Gijk 0 0 0)
+                    (Gijk 1 0 0))
+                (up (Gijk 0 1 0)
+                    (Gijk 1 1 0)))
+          (down (up (Gijk 0 0 1)
+                    (Gijk 1 0 1))
+                (up (Gijk 0 1 1)
+                    (Gijk 1 1 1)))))
+
+  (clear-arguments)
+  (suppress-arguments '((up x0 y0)))
+
+  (pec (G R2-rect-point))
+  #| Result:
+  (down (down (up G^0_00 G^1_00) (up G^0_10 G^1_10))
+        (down (up G^0_01 G^1_01) (up G^0_11 G^1_11)))
+  |#
+
+  (define CG (make-Christoffel G R2-rect-basis))
+
+  (define CF (Christoffel->Cartan CG))
+
+  (pec (((Cartan->forms CF) (literal-vector-field 'X R2-rect))
+        R2-rect-point))
+  #| Result:
+  (down (up (+ (* G^0_01 X^1) (* G^0_00 X^0))
+            (+ (* G^1_01 X^1) (* G^1_00 X^0)))
+        (up (+ (* G^0_11 X^1) (* G^0_10 X^0))
+            (+ (* G^1_11 X^1) (* G^1_10 X^0))))
+  |#
+  
+  (pec ((Christoffel->symbols
+         (Cartan->Christoffel (Christoffel->Cartan CG)))
+        R2-rect-point))
+  #| Result:
+  (down (down (up G^0_00 G^1_00) (up G^0_10 G^1_10))
+        (down (up G^0_01 G^1_01) (up G^0_11 G^1_11)))
+  |#
+
+  ;; Transformation of Cartan to polar leaves covariant derivative
+  ;; invariant.
+
+  (pec (((((- (covariant-derivative CF)
+              (covariant-derivative
+               (Cartan-transform CF (R2-polar 'coordinate-basis))))
+           (literal-vector-field 'A R2-rect))
+          (literal-vector-field 'B R2-polar))
+         (literal-scalar-field 'f R2-polar))
+        R2-rect-point))
+
+  #| Result:
+  0
+  |#
+
+  ;; Example from the text:
+
+  (define-coordinates (up x y) R2-rect)
+  (define-coordinates (up r theta) R2-polar)
+
+  (define v (literal-vector-field 'v R2-rect))
+  (define w (literal-vector-field 'w R2-rect))
+  (define f (literal-manifold-function 'f R2-rect))
+
+  (define R2-rect-basis (coordinate-system->basis R2-rect))
+  (define R2-polar-basis (coordinate-system->basis R2-polar))
+
+  (define R2-rect-Christoffel
+    (make-Christoffel
+     (let ((zero (lambda (m) 0)))
+       (down (down (up zero zero)
+                   (up zero zero))
+             (down (up zero zero)
+                   (up zero zero))))
+     R2-rect-basis))
+
+  (define R2-rect-Cartan
+    (Christoffel->Cartan R2-rect-Christoffel))
+
+
+  (define R2-polar-Christoffel
+    (make-Christoffel
+     (let ((zero (lambda (m) 0)))
+       (down (down (up zero zero)
+                   (up zero (/ 1 r)))
+             (down (up zero (/ 1 r))
+                   (up (* -1 r) zero))))
+     R2-polar-basis))
+
+  (define R2-polar-Cartan
+    (Christoffel->Cartan R2-polar-Christoffel))
+
+
+  (pec
+   (((((- (covariant-derivative R2-rect-Cartan)
+          (covariant-derivative R2-polar-Cartan))
+       v)
+      w)
+     f)
+    (typical-point R2-rect)))
+  #| Result:
+  0
+  |#
+
+  (pec
+   (((((- (covariant-derivative R2-polar-Cartan)
+          (covariant-derivative
+           (Cartan-transform R2-polar-Cartan R2-rect-basis)))
+       v)
+      w)
+     f)
+    R2-rect-point))
+  #| Result:
+  0
+  |#
+
+  (define X (literal-vector-field 'X R2-rect))
+
+  (define V (literal-vector-field 'V R2-rect))
+
+  (pec (((((covariant-derivative CF) X) V)
+         (literal-manifold-function 'F R2-rect))
+        R2-rect-point))
+  #| Result:
+  (+ (* G^0_00 V^0 ((partial 0) F) X^0)
+     (* G^1_00 V^0 ((partial 1) F) X^0)
+     (* G^0_10 ((partial 0) F) V^1 X^0)
+     (* G^1_10 ((partial 1) F) V^1 X^0)
+     (* G^0_01 V^0 ((partial 0) F) X^1)
+     (* G^1_01 V^0 ((partial 1) F) X^1)
+     (* G^0_11 ((partial 0) F) V^1 X^1)
+     (* G^1_11 ((partial 1) F) V^1 X^1)
+     (* ((partial 0) F) ((partial 0) V^0) X^0)
+     (* ((partial 0) F) ((partial 1) V^0) X^1)
+     (* ((partial 1) F) ((partial 0) V^1) X^0)
+     (* ((partial 1) F) ((partial 1) V^1) X^1))
+  |#
+
+  |#
+  
+  #|
+  (define-coordinates (up x y) R2-rect)
+  (define rect-basis (coordinate-system->basis R2-rect))
+
+  (define-coordinates (up r theta) R2-polar)
+  (define polar-basis (coordinate-system->basis R2-polar))
+
+  (define rect-chi (R2-rect '->coords))
+  (define rect-chi-inverse (R2-rect '->point))
+  (define polar-chi (R2-polar '->coords))
+  (define polar-chi-inverse (R2-polar '->point))
+  (define m2 (rect-chi-inverse (up 'x0 'y0)))
+
+  (define rect-Christoffel
+    (make-Christoffel
+     (let ((zero (lambda (m) 0)))
+       (down (down (up zero zero)
+                   (up zero zero))
+             (down (up zero zero)
+                   (up zero zero))))
+     rect-basis))
+
+  (define polar-Christoffel
+    (make-Christoffel
+     (let ((zero (lambda (m) 0)))
+       (down (down (up zero zero)
+                   (up zero (/ 1 r)))
+             (down (up zero (/ 1 r))
+                   (up (* -1 r) zero))))
+     polar-basis))
+
+  (define rect-Cartan
+    (Christoffel->Cartan rect-Christoffel))
+
+  (define polar-Cartan
+    (Christoffel->Cartan polar-Christoffel))
+
+  (define J (- (* x d/dy) (* y d/dx)))
+
+  (define f (literal-scalar-field 'f R2-rect))
+
+  (pec
+   (((((covariant-derivative rect-Cartan)
+       d/dx)
+      J)
+     f)
+    m2))
+  #| Result:
+  ((partial 1) f)
+  |#
+;;; Note: arg-suppressor is in force from above.
+
+  (pec
+   (((((covariant-derivative polar-Cartan)
+       d/dx)
+      J)
+     f)
+    m2))
+  #| Result:
+  ((partial 1) f)
+  |#
+  |#
+  
+  #|
+;;; More generally, can show independence here
+
+  (define v (literal-vector-field 'v R2-rect))
+  (define w (literal-vector-field 'w R2-rect))
+
+  (pec
+   (((((- (covariant-derivative rect-Cartan)
+          (covariant-derivative polar-Cartan))
+       v)
+      w)
+     f)
+    m2))
+  #| Result:
+  0
+  |#
+
+  (define v (literal-vector-field 'v R2-polar))
+  (define w (literal-vector-field 'w R2-polar))
+
+  (pec
+   (((((- (covariant-derivative rect-Cartan)
+          (covariant-derivative polar-Cartan))
+       v)
+      w)
+     f)
+    m2))
+  #| Result:
+  0
+  |#
+
+  |#
+
+  (testing "after cartan-over-map"
+    #|
+    (define M (make-manifold S^2-type 2 3))
+    (define spherical
+      (coordinate-system-at 'spherical 'north-pole M))
+    (define-coordinates (up theta phi) spherical)
+    (define-coordinates t the-real-line)
+    (define spherical-basis (coordinate-system->basis spherical))
+
+    (define G-S2-1
+      (make-Christoffel
+       (let ((zero  (lambda (point) 0)))
+         (down (down (up zero zero)
+                     (up zero (/ 1 (tan theta))))
+               (down (up zero (/ 1 (tan theta)))
+                     (up (- (* (sin theta) (cos theta))) zero))))
+       spherical-basis))
+
+
+    (define gamma:N->M
+      (compose (spherical '->point)
+               (up (literal-function 'alpha)
+                   (literal-function 'beta))
+               (the-real-line '->coords)))
+
+    (define basis-over-gamma
+      (basis->basis-over-map gamma:N->M spherical-basis))
+
+    (define w
+      (basis-components->vector-field
+       (up (compose (literal-function 'w0)
+                    (the-real-line '->coords))
+           (compose (literal-function 'w1)
+                    (the-real-line '->coords)))
+       (basis->vector-basis basis-over-gamma)))
+
+    (define sphere-Cartan (Christoffel->Cartan G-S2-1))
+
+    (pec
+     (s:map/r
+      (lambda (omega)
+              ((omega
+                (((covariant-derivative sphere-Cartan gamma:N->M)
+                  d/dt)
+                 w))
+               ((the-real-line '->point) 'tau)))
+      (basis->1form-basis basis-over-gamma)))
+    #| Result:
+    (up
+     (+ (* -1 (sin (alpha tau)) ((D beta) tau) (w1 tau) (cos (alpha tau)))
+        ((D w0) tau))
+     (+ (/ (* (w0 tau) ((D beta) tau) (cos (alpha tau))) (sin (alpha tau)))
+        (/ (* (w1 tau) ((D alpha) tau) (cos (alpha tau))) (sin (alpha tau)))
+        ((D w1) tau)))
+    |#
+    )
+
+  (testing "geodesic-equations"
+    (pec
+     (s:map/r
+      (lambda (omega)
+              ((omega
+                (((covariant-derivative sphere-Cartan gamma:N->M)
+                  d/dt)
+                 ((differential gamma:N->M) d/dt)))
+               ((the-real-line '->point) 't)))
+      (basis->1form-basis basis-over-gamma)))
+
+    #| Result:
+    (up
+     (+ (* -1 (sin (alpha t)) (expt ((D beta) t) 2) (cos (alpha t)))
+        (((expt D 2) alpha) t))
+     (+ (/ (* 2 ((D beta) t) (cos (alpha t)) ((D alpha) t)) (sin (alpha t)))
+        (((expt D 2) beta) t)))
+    |#
+    |#
+    ;;; Geodesic equation
+
+    (define-coordinates (up x y) R2-rect)
+
+    (define (Gijk i j k)
+      (literal-manifold-function
+       (string->symbol
+        (string-append "G^"
+                       (number->string i)
+                       "_"
+                       (number->string j)
+                       (number->string k)))
+       R2-rect))
+
+    (define G
+      (down (down (up (Gijk 0 0 0)
+                      (Gijk 1 0 0))
+                  (up (Gijk 0 1 0)
+                      (Gijk 1 1 0)))
+            (down (up (Gijk 0 0 1)
+                      (Gijk 1 0 1))
+                  (up (Gijk 0 1 1)
+                      (Gijk 1 1 1)))))
+
+
+    (define CG
+      (make-Christoffel G (coordinate-system->basis R2-rect)))
+
+    (define gamma:N->M
+      (compose (R2-rect '->point)
+               (up (literal-function 'alpha)
+                   (literal-function 'beta))
+               (the-real-line '->coords)))
+
+    (define basis-over-gamma
+      (basis->basis-over-map gamma:N->M
+                             (coordinate-system->basis R2-rect)))
+
+    (define u
+      (basis-components->vector-field
+       (up (compose (literal-function 'u0)
+                    (the-real-line '->coords))
+           (compose (literal-function 'u1)
+                    (the-real-line '->coords)))
+       (basis->vector-basis basis-over-gamma)))
+
+
+    (pec
+     (s:map/r
+      (lambda (omega)
+              ((omega
+                (((covariant-derivative (Christoffel->Cartan CG) gamma:N->M)
+                  d/dt)
+                 u))
+               ((the-real-line '->point) 't)))
+      (basis->1form-basis basis-over-gamma)))
+    #| Result:
+    (up
+     (+ (* ((D alpha) t) (u0 t) (G^0_00 (up (alpha t) (beta t))))
+        (* ((D alpha) t) (u1 t) (G^0_10 (up (alpha t) (beta t))))
+        (* ((D beta) t) (u0 t) (G^0_01 (up (alpha t) (beta t))))
+        (* ((D beta) t) (u1 t) (G^0_11 (up (alpha t) (beta t))))
+        ((D u0) t))
+     (+ (* ((D alpha) t) (u0 t) (G^1_00 (up (alpha t) (beta t))))
+        (* ((D alpha) t) (u1 t) (G^1_10 (up (alpha t) (beta t))))
+        (* ((D beta) t) (u0 t) (G^1_01 (up (alpha t) (beta t))))
+        (* ((D beta) t) (u1 t) (G^1_11 (up (alpha t) (beta t))))
+        ((D u1) t)))
+    |#
+
+    (pec
+     (s:map/r
+      (lambda (omega)
+              ((omega
+                (((covariant-derivative (Christoffel->Cartan CG) gamma:N->M)
+                  d/dt)
+                 ((differential gamma:N->M) d/dt)))
+               ((the-real-line '->point) 't)))
+      (basis->1form-basis basis-over-gamma)))
+    #| Result:
+    (up
+     (+ (* (expt ((D alpha) t) 2) (G^0_00 (up (alpha t) (beta t))))
+        (* ((D alpha) t) ((D beta) t) (G^0_01 (up (alpha t) (beta t))))
+        (* ((D alpha) t) ((D beta) t) (G^0_10 (up (alpha t) (beta t))))
+        (* (expt ((D beta) t) 2) (G^0_11 (up (alpha t) (beta t))))
+        (((expt D 2) alpha) t))
+     (+ (* (expt ((D alpha) t) 2) (G^1_00 (up (alpha t) (beta t))))
+        (* ((D alpha) t) ((D beta) t) (G^1_01 (up (alpha t) (beta t))))
+        (* ((D alpha) t) ((D beta) t) (G^1_10 (up (alpha t) (beta t))))
+        (* (expt ((D beta) t) 2) (G^1_11 (up (alpha t) (beta t))))
+        (((expt D 2) beta) t)))
+    |#
+
+
+    #|
+;;;; Geodesic Equations = Lagrange Equations
+
+;;; Here I restrict everything to the unit sphere.
+;;; The coordinates on the unit sphere
+
+    (define-coordinates t R1-rect)
+    (define-coordinates (up theta phi) S2-spherical)
+
+    (define 2-sphere-basis (coordinate-system->basis S2-spherical))
+
+;;; The Christoffel symbols (for r=1) (p.341 MTW) are:
+
+    (define G-S2-1
+      (make-Christoffel
+       (let ((zero  (lambda (point) 0)))
+         (down (down (up zero zero)
+                     (up zero (/ 1 (tan theta))))
+               (down (up zero (/ 1 (tan theta)))
+                     (up (- (* (sin theta) (cos theta))) zero))))
+       2-sphere-basis))
+
+    (pec (let ((mu:N->M (compose (S2-spherical '->point)
+                                 (up (literal-function 'mu-theta)
+                                     (literal-function 'mu-phi))
+                                 (R1-rect '->coords)))
+               (Cartan (Christoffel->Cartan G-S2-1)))
+           (s:map/r
+            (lambda (w)
+                    ((w
+                      (((covariant-derivative Cartan mu:N->M) d/dt)
+                       ((differential mu:N->M) d/dt)))
+                     ((R1-rect '->point) 'tau)))
+            (basis->1form-basis
+             (basis->basis-over-map mu:N->M
+                                    (Cartan->basis Cartan))))))
+    #| Result:
+    (up (+ (* -1
+              (expt ((D mu-phi) tau) 2)
+              (cos (mu-theta tau))
+              (sin (mu-theta tau)))
+           (((expt D 2) mu-theta) tau))
+        (+ (/ (* 2 ((D mu-phi) tau)
+                 (cos (mu-theta tau))
+                 ((D mu-theta) tau))
+              (sin (mu-theta tau)))
+           (((expt D 2) mu-phi) tau)))
+    |#
+    
+;;; We can get the geodesic equations as ordinary Lagrange
+;;; equations of a free particle constrained to the surface
+;;; of the sphere:
+
+    (define ((Lfree m) s)
+      (let ((t (time s))
+            (q (coordinate s))
+            (v (velocity s)))
+        (* 1/2 m (square v))))
+
+    #|
+;;; F is really the embedding map, from the coordinates on the sphere
+;;; to the 3-space coordinates in the embedding manifold.
+
+;;; This hides the assumption that the R3 manifold is the same one as
+;;; the embedding manifold.
+
+    (define F
+      (compose (R3-rect '->coords)
+               (S2-spherical '->point)
+               coordinate))
+
+;;; Actually (9 June 2009--GJS) this no longer works, because R3-rect
+;;; does not accept an S2-spherical point as in the same manifold.
+
+;;; Fixed by explicit transfer of a point -- see manifold.scm
+    |#
+
+
+    (define F
+      (compose (R3-rect '->coords)
+               (transfer-point S2-spherical R3-rect)
+               (S2-spherical '->point)
+               coordinate))
+
+    (define Lsphere
+      (compose (Lfree 1) (F->C F)))
+
+    (pec (((Lagrange-equations Lsphere)
+           (up (literal-function 'theta)
+               (literal-function 'phi)))
+          't))
+    #| Result:
+    (down
+     (+ (((expt D 2) theta) t)
+        (* -1 (cos (theta t)) (sin (theta t)) (expt ((D phi) t) 2)))
+     (+ (* (expt (sin (theta t)) 2) (((expt D 2) phi) t))
+        (* 2 (cos (theta t)) (sin (theta t)) ((D phi) t) ((D theta) t))))
+    |#
+
+
+;;; Note these are DOWN while the geodesic equations are UP.  This is
+;;; due to the fact that the geodesic equations are raised by the
+;;; metric, which is diagonal, here R=1, and cancels an instance
+;;; of(expt (sin theta) 2).
+
+;;; Also see p.345 MTW for computing Christoffel symbols from Lagrange
+;;; equations.
+    |#
+    
+    #|
+;;; Exercise on computation of Christoffel symbols.
+
+    (install-coordinates R3-rect (up 'x 'y 'z))
+    (define R3-rect-point ((R3-rect '->point) (up 'x0 'y0 'z0)))
+
+    (install-coordinates R3-cyl (up 'r 'theta 'zeta))
+    (define R3-cyl-point ((R3-cyl '->point) (up 'r0 'theta0 'z0)))
+
+    (define mpr (R3-rect '->coords))
+
+    (pec (((* d/dr d/dr) mpr) R3-rect-point))
+    #| Result:
+    (up 0 0 0)
+    |#
+;;; So \Gamma^r_{rr} = 0, \Gamma^\theta_{rr} = 0
+
+    (pec (((* d/dtheta d/dr) mpr) R3-rect-point))
+    #| Result:
+    (up (/ (* -1 y0) (sqrt (+ (expt x0 2) (expt y0 2))))
+        (/ x0 (sqrt (+ (expt x0 2) (expt y0 2))))
+        0)
+    |#
+;;; by hand = -sint d/dx + cost d/dy = 1/r d/dtheta
+;;; Indeed.
+
+    (pec (((* d/dtheta d/dr) mpr) R3-cyl-point))
+    #| Result:
+    (up (* -1 (sin theta0)) (cos theta0) 0)
+    |#
+;;; So \Gamma^r_{r\theta} = 0, \Gamma^\theta_{r\theta} = 1/r
+
+    (pec (((* d/dr d/dtheta) mpr) R3-rect-point))
+    #| Result:
+    (up (/ (* -1 y0) (sqrt (+ (expt x0 2) (expt y0 2))))
+        (/ x0 (sqrt (+ (expt x0 2) (expt y0 2))))
+        0)
+    |#
+;;; by hand = -sint d/dx + cost d/dy = 1/r d/dtheta
+
+    (pec (((* d/dr d/dtheta) mpr) R3-cyl-point))
+    #| Result:
+    (up (* -1 (sin theta0)) (cos theta0) 0)
+    |#
+;;; So \Gammar_{\theta r} = 0, \Gamma\theta_{\theta r} = 1/r
+
+    (pec (((* d/dtheta d/dtheta) mpr) R3-rect-point))
+    #| Result:
+    (up (* -1 x0) (* -1 y0) 0)
+    |#
+;;; by hand = -r cost d/dx - r sint d/dy = -r d/dr
+
+    (pec (((* d/dtheta d/dtheta) mpr) R3-cyl-point))
+    #| Result:
+    (up (* -1 r0 (cos theta0)) (* -1 r0 (sin theta0)) 0)
+    |#
+;;; So \Gammar_{\theta \theta} = -r, \Gamma\theta_{\theta \theta} = 0
+
+;;; These are correct Christoffel symbols...
+    |#
+    
+    #|
+;;; Computation of Covariant derivatives by difference quotient.
+;;; CD below is parallel in definition to the Lie Derivative.
+;;; Does not seem to depend on a derivative of basis vectors, in fact
+;;; the derivative of the basis vectors is multiplied by zero in the
+;;; product rule output.
+
+    (define (Gijk i j k)
+      (literal-manifold-function
+       (string->symbol
+        (string-append "G^"
+                       (number->string i)
+                       "_"
+                       (number->string j)
+                       (number->string k)))
+       R2-rect))
+
+    (define G
+      (down (down (up (Gijk 0 0 0)
+                      (Gijk 1 0 0))
+                  (up (Gijk 0 1 0)
+                      (Gijk 1 1 0)))
+            (down (up (Gijk 0 0 1)
+                      (Gijk 1 0 1))
+                  (up (Gijk 0 1 1)
+                      (Gijk 1 1 1)))))
+
+    (define X (literal-vector-field 'X R2-rect))
+
+    (define Y (literal-vector-field 'Y R2-rect))
+
+    (define q_0 (up 'q_x 'q_y))
+
+    (define m_0
+      ((R2-rect '->point) q_0))
+
+    (define F (literal-manifold-function 'F R2-rect))
+
+
+    (define (((((CD CF chart) v) u) F) m)
+
+      (define (Sigma state) (ref state 0))
+      (define (U state) (ref state 1))
+      (define (sigma-u sigma u) (up sigma u))
+
+      (define chi (chart '->coords))
+      (define chi^-1 (chart '->point))
+
+      ;; ((gamma m) delta) is the point on gamma advanced by delta.
+
+      (define ((gamma m) delta)
+        (chi^-1 (+ (chi m) (* delta ((v chi) m)))))
+
+      (let ((basis (Cartan->basis CF)))
+        (let ((vector-basis (basis->vector-basis basis))
+              (1form-basis (basis->1form-basis basis)))
+          (let ((u^i (1form-basis u)))
+            (let ((initial-state
+                   (sigma-u (chi m) (u^i m))))
+
+              (define (bs state)
+                (let ((sigma (Sigma state)))
+                  (let ((m_0 (chi^-1 sigma)))
+                    (up ((v chi) m_0)
+                        (* -1
+                           (((Cartan->forms CF) v) m_0)
+                           (u^i m_0))))))
+
+              (define (vs fs)
+                (* (D fs) bs))
+
+              ;; First-order approximation to A
+
+              (define (Au delta)
+                (+ (U initial-state)
+                   (* delta ((vs U) initial-state))))
+
+              (define (g delta)
+                (let ((advanced-m ((gamma m) delta)))
+                  (* (- (u^i advanced-m) (Au delta))
+                     ((vector-basis F) advanced-m))))
+
+              ((D g) 0))))))
+
+;;; A bit simpler, but lacking in motivation?
+
+    (define (((((CD CF chart) v) u) F) m)
+
+      (define (Sigma state) (ref state 0))
+      (define (U state) (ref state 1))
+      (define (sigma-u sigma u) (up sigma u))
+
+      (define chi (chart '->coords))
+      (define chi^-1 (chart '->point))
+
+      ;; ((gamma m) delta) is the point on gamma advanced by delta.
+
+      (define ((gamma m) delta)
+        (chi^-1 (+ (chi m) (* delta ((v chi) m)))))
+
+      (let ((basis (Cartan->basis CF)))
+        (let ((vector-basis (basis->vector-basis basis))
+              (1form-basis (basis->1form-basis basis)))
+          (let ((u^i (1form-basis u)))
+            (let ((initial-state
+                   (sigma-u (chi m) (u^i m))))
+
+              ;; First-order approximation to A
+
+              (define (Au delta)
+                (- (u^i m)
+                   (* delta
+                      (((Cartan->forms CF) v) m)
+                      (u^i m))))
+
+              (define (g delta)
+                (let ((advanced-m ((gamma m) delta)))
+                  (* (- (u^i advanced-m) (Au delta))
+                     ((vector-basis F) advanced-m))))
+
+              ((D g) 0))))))
+
+    (let ((CF (Christoffel->Cartan
+               (make-Christoffel G
+                                 (coordinate-system->basis R2-rect)))))
+      (pe (- (((((CD CF R2-rect) X) Y) F) m_0)
+             (((((covariant-derivative CF) X) Y) F) m_0))))
+    0
+
+    (let ((CF (Christoffel->Cartan
+               (make-Christoffel G
+                                 (coordinate-system->basis R2-polar)))))
+      (pe (- (((((CD CF R2-rect) X) Y) F) m_0)
+             (((((covariant-derivative CF) X) Y) F) m_0))))
+    0
+
+    (let ((CF (Christoffel->Cartan
+               (make-Christoffel G
+                                 (coordinate-system->basis R2-rect)))))
+      (pe (- (((((CD CF R2-polar) X) Y) F) m_0)
+             (((((covariant-derivative CF) X) Y) F) m_0))))
+    0
+
+    (let ((CF (Christoffel->Cartan
+               (make-Christoffel G
+                                 (coordinate-system->basis R2-polar)))))
+      (pe (- (((((CD CF R2-polar) X) Y) F) m_0)
+             (((((covariant-derivative CF) X) Y) F) m_0))))
+    0
+                                        ;Too slow...                            ; ; ; ; ; ; ; ; ; ; ; ; ; ;
+    |#
+    
+    #|
+;;; Testing on forms.
+
+    (define (Gijk i j k)
+      (literal-manifold-function
+       (string->symbol
+        (string-append "G^"
+                       (number->string i)
+                       "_"
+                       (number->string j)
+                       (number->string k)))
+       R2-rect))
+
+    (define G
+      (down (down (up (Gijk 0 0 0)
+                      (Gijk 1 0 0))
+                  (up (Gijk 0 1 0)
+                      (Gijk 1 1 0)))
+            (down (up (Gijk 0 0 1)
+                      (Gijk 1 0 1))
+                  (up (Gijk 0 1 1)
+                      (Gijk 1 1 1)))))
+
+    (define X (literal-vector-field 'X R2-rect))
+
+    (define Y (literal-vector-field 'Y R2-rect))
+
+    (define omega (literal-1form-field 'omega R2-rect))
+
+    (define q_0 (up 'q_x 'q_y))
+
+    (define m_0
+      ((R2-rect '->point) q_0))
+
+    (define F (literal-manifold-function 'F R2-rect))
+
+    (let* ((CF (Christoffel->Cartan
+                (make-Christoffel G
+                                  (coordinate-system->basis R2-rect))))
+           (D_x ((covariant-derivative CF) X)))
+      (pe (- (+ (((D_x omega) Y) m_0)
+                ((omega (D_x Y)) m_0))
+             ((D_x (omega Y)) m_0))))
+    0
+
+
+    (define tau (literal-1form-field 'tau R2-rect))
+
+    (define Z (literal-vector-field 'Z R2-rect))
+
+    (let* ((CF (Christoffel->Cartan
+                (make-Christoffel G
+                                  (coordinate-system->basis R2-rect))))
+           (D_x ((covariant-derivative CF) X)))
+      (pe (- (((D_x (wedge omega tau)) Y Z) m_0)
+             (+ (((wedge omega (D_x tau)) Y Z) m_0)
+                (((wedge (D_x omega) tau) Y Z) m_0)))))
+    0
+
+    (let* ((CF (Christoffel->Cartan
+                (make-Christoffel G
+                                  (coordinate-system->basis R2-polar))))
+           (D_x ((covariant-derivative CF) X)))
+      (pe (- (((D_x (wedge omega tau)) Y Z) m_0)
+             (+ (((wedge omega (D_x tau)) Y Z) m_0)
+                (((wedge (D_x omega) tau) Y Z) m_0)))))
+    0
+    |#
+
+    ;; Next, tests, for the actual functions:
+    #|
+    (((geodesic-equation the-real-line R2-rect (literal-Cartan 'G R2-rect))
+      (literal-manifold-map 'gamma the-real-line R2-rect))
+     ((point the-real-line) 't))
+    #|
+    (up
+     (+ (* (expt ((D gamma0) t) 2) (G_00^0 (up (gamma0 t) (gamma1 t))))
+        (* ((D gamma0) t) ((D gamma1) t) (G_10^0 (up (gamma0 t) (gamma1 t))))
+        (* ((D gamma0) t) ((D gamma1) t) (G_01^0 (up (gamma0 t) (gamma1 t))))
+        (* (expt ((D gamma1) t) 2) (G_11^0 (up (gamma0 t) (gamma1 t))))
+        (((expt D 2) gamma0) t))
+     (+ (* (expt ((D gamma0) t) 2) (G_00^1 (up (gamma0 t) (gamma1 t))))
+        (* ((D gamma0) t) ((D gamma1) t) (G_10^1 (up (gamma0 t) (gamma1 t))))
+        (* ((D gamma0) t) ((D gamma1) t) (G_01^1 (up (gamma0 t) (gamma1 t))))
+        (* (expt ((D gamma1) t) 2) (G_11^1 (up (gamma0 t) (gamma1 t))))
+        (((expt D 2) gamma1) t)))
+    |#
+
+
+    (let ((C (literal-Cartan 'G R2-rect)))
+      (- (((geodesic-equation the-real-line R2-rect C)
+           (literal-manifold-map 'gamma the-real-line R2-rect))
+          ((point the-real-line) 't))
+         (((geodesic-equation the-real-line R2-rect (symmetrize-Cartan C))
+           (literal-manifold-map 'gamma the-real-line R2-rect))
+          ((point the-real-line) 't))))
+    #|
+    (up 0 0)
+    |#
+    |#
+
+
+    )
+
+  (testing "parallel-transport-equation"
+
+    #|
+    (define M (make-manifold S^2-type 2 3))
+    (define S2-spherical
+      (coordinate-system-at 'spherical 'north-pole M))
+    (define-coordinates (up theta phi) S2-spherical)
+    (define S2-basis
+      (coordinate-system->basis S2-spherical))
+
+    (define G-S2-1
+      (make-Christoffel
+       (let ((zero  (lambda (point) 0)))
+         (down (down (up zero zero)
+                     (up zero (/ 1 (tan theta))))
+               (down (up zero (/ 1 (tan theta)))
+                     (up (- (* (sin theta)
+                               (cos theta)))
+                         zero))))
+       S2-basis))
+
+    (define gamma
+      (compose (point S2-spherical)
+               (up (literal-function 'alpha)
+                   (literal-function 'beta))
+               (chart the-real-line)))
+
+
+    (define basis-over-gamma
+      (basis->basis-over-map gamma S2-basis))
+
+
+    (define u
+      (basis-components->vector-field
+       (up (compose (literal-function 'u^0)
+                    (chart the-real-line))
+           (compose (literal-function 'u^1)
+                    (chart the-real-line)))
+       (basis->vector-basis basis-over-gamma)))
+
+    (define sphere-Cartan
+      (Christoffel->Cartan G-S2-1))
+
+    ((((parallel-transport-equation
+        the-real-line S2-spherical sphere-Cartan)
+       gamma)
+      u)
+     ((point the-real-line) 't))
+
+    #|
+    (up
+     (+ (* -1 (sin (alpha t)) ((D beta) t) (u^1 t) (cos (alpha t))) ((D u^0) t))
+     (+ (/ (* (u^0 t) ((D beta) t) (cos (alpha t))) (sin (alpha t)))
+        (/ (* (u^1 t) ((D alpha) t) (cos (alpha t))) (sin (alpha t)))
+        ((D u^1) t)))
+    |#
+    |#
+
+    ))

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -443,14 +443,12 @@
 
         ;; Transformation of Cartan to polar leaves covariant derivative
         ;; invariant.
-        #_
         (is (zero?
              (simplify
               (((((- (cov/covariant-derivative CF)
                      (cov/covariant-derivative
                       (cov/Cartan-transform
-                       ;; TODO we need to get this working!!
-                       CF (R2-polar 'coordinate-basis))))
+                       CF (b/coordinate-system->basis R2-polar))))
                   (vf/literal-vector-field 'A R2-rect))
                  (vf/literal-vector-field 'B R2-polar))
                 (man/literal-scalar-field 'f R2-polar))

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -21,15 +21,19 @@
   (:refer-clojure :exclude [+ - * /  partial])
   (:require [clojure.test :refer [is deftest testing use-fixtures]]
             [sicmutils.calculus.basis :as b]
+            [sicmutils.calculus.connection :as conn]
             [sicmutils.calculus.coordinate :as c
              :refer [let-coordinates]
              #?@(:cljs [:include-macros true])]
             [sicmutils.calculus.covariant :as cov]
             [sicmutils.calculus.derivative :refer [D]]
             [sicmutils.calculus.form-field :as ff]
+            [sicmutils.calculus.indexed :as ci]
             [sicmutils.calculus.manifold :as man
-             :refer [R2-rect R3-rect R3-cyl]]
+             :refer [R2-polar R2-rect R3-rect R3-cyl R4-rect
+                     point chart]]
             [sicmutils.calculus.map :as cm]
+            [sicmutils.calculus.metric :refer [S2-metric]]
             [sicmutils.calculus.vector-field :as vf]
             [sicmutils.expression :as x]
             [sicmutils.function :as f]
@@ -47,8 +51,8 @@
   (testing "Lie derivative."
     (let-coordinates [[x y z]        R3-rect
                       [r theta zeta] R3-cyl]
-      (let [R3-rect-point ((man/point R3-rect) (up 'x0 'y0 'z0))
-            R3-cyl-point ((man/point R3-cyl) (up 'r0 'theta0 'zeta0))
+      (let [R3-rect-point ((point R3-rect) (up 'x0 'y0 'z0))
+            R3-cyl-point ((point R3-cyl) (up 'r0 'theta0 'zeta0))
 
             w (ff/literal-oneform-field 'w R3-rect)
             u (ff/literal-oneform-field 'u R3-rect)
@@ -94,11 +98,11 @@
         (is (= 0 (simplify
                   ((- ((ff/d ((g/Lie-derivative X) w)) Y Z)
                       (((g/Lie-derivative X) (ff/d w)) Y Z))
-                   ((man/point R3-rect)
+                   ((point R3-rect)
                     (up 'x↑0 'y↑0 'z↑0))))))))
 
     (let-coordinates [[x y] R2-rect]
-      (let [R2-rect-point ((man/point R2-rect) (up 'x0 'y0))
+      (let [R2-rect-point ((point R2-rect) (up 'x0 'y0))
             X (vf/literal-vector-field 'X R2-rect)
             Y (vf/literal-vector-field 'Y R2-rect)
 
@@ -156,7 +160,7 @@
             Y (vf/literal-vector-field 'Y R2-rect)
 
             q_0 (up 'q_x 'q_y)
-            m ((man/point R2-rect) q_0)
+            m ((point R2-rect) q_0)
             f (man/literal-manifold-function 'f R2-rect)
 
             e_0 (vf/literal-vector-field 'e_0 R2-rect)
@@ -179,18 +183,18 @@
 
             q_0 (up 'q_x 'q_y)
 
-            m_0 ((man/point R2-rect) q_0)
+            m_0 ((point R2-rect) q_0)
 
             q (fn [coords]
                 (fn [t]
                   (+ coords
-                     (* t ((X (man/chart R2-rect))
-                           ((man/point R2-rect) coords))))))
+                     (* t ((X (chart R2-rect))
+                           ((point R2-rect) coords))))))
 
             gamma (fn [initial-point]
                     (f/compose
-                     (man/point R2-rect)
-                     (q ((man/chart R2-rect) initial-point))))
+                     (point R2-rect)
+                     (q ((chart R2-rect) initial-point))))
 
             phiX (fn [t]
                    (fn [point]
@@ -199,8 +203,7 @@
             result-via-Lie ((((g/Lie-derivative X) Y) f) m_0)
             present (fn [expr]
                       (-> (simplify expr)
-                          (x/substitute '(up q_x q_y) 'p)))
-            ]
+                          (x/substitute '(up q_x q_y) 'p)))]
         (is (= '(+ (* -1 (Y↑0 p) (((partial 0) f) p) (((partial 0) X↑0) p))
                    (* -1 (Y↑0 p) (((partial 1) f) p) (((partial 0) X↑1) p))
                    (* (((partial 0) f) p) (((partial 0) Y↑0) p) (X↑0 p))
@@ -242,7 +245,7 @@
                             m_0)))
                       0))))))
 
-      (let [m ((man/point R2-rect) (up 'x 'y))
+      (let [m ((point R2-rect) (up 'x 'y))
             V (vf/literal-vector-field 'V R2-rect)
             Y (vf/literal-vector-field 'Y R2-rect)
             f (man/literal-manifold-function 'f R2-rect)
@@ -282,7 +285,7 @@
 (deftest interior-product-tests
   (testing "Claim: L_x omega = i_x d omega + d i_x omega (Cartan Homotopy Formula)"
     (let-coordinates [[x y z] R3-rect]
-      (let [R3-rect-point ((man/point R3-rect) (up 'x0 'y0 'z0))
+      (let [R3-rect-point ((point R3-rect) (up 'x0 'y0 'z0))
 
             X (vf/literal-vector-field 'X R3-rect)
             Y (vf/literal-vector-field 'Y R3-rect)
@@ -319,379 +322,353 @@
                      R3-rect-point)))))))))
 
 
-#_
 (deftest new-tests
   ;; Structured objects, such as tensors, take vector fields and oneform
   ;; fields as arguments.
   ;;
   ;; oneform fields can act as (0,1) tensor fields if arguments are declared:
-
-  (let [omega (literal-oneform-field 'omega R4-rect)]
-    (declare-argument-types! omega (list vector-field?))
-    (let [m (typical-point R4-rect)
-          X (literal-vector-field 'X R4-rect)
-          Tomega (indexed->typed
-                  (typed->indexed omega
-                                  (coordinate-system->basis R4-rect))
-                  (coordinate-system->basis R4-rect))
-          V (literal-vector-field 'V R4-rect)
-          C (literal-Cartan 'G R4-rect)]
-      (is (= 0 (- (((((covariant-derivative C) X) omega) V) m)
-                  (((((covariant-derivative C) X) Tomega) V) m))))))
+  (let [omega (-> (ff/literal-oneform-field 'omega R4-rect)
+                  (ci/with-argument-types [::vf/vector-field]))
+        m (man/typical-point R4-rect)
+        X (vf/literal-vector-field 'X R4-rect)
+        Tomega (-> omega
+                   (ci/typed->indexed (b/coordinate-system->basis R4-rect))
+                   (ci/indexed->typed (b/coordinate-system->basis R4-rect)))
+        V (vf/literal-vector-field 'V R4-rect)
+        C (conn/literal-Cartan 'G R4-rect)]
+    (is (zero?
+         (simplify
+          (- (((((cov/covariant-derivative C) X) omega) V) m)
+             (((((cov/covariant-derivative C) X) Tomega) V) m))))))
 
   ;; So to test the operation on a vector field we must construct a
   ;; (1,0) tensor field that behaves like a vector field, but acts on
   ;; oneform fields rather than manifold functions.
-
-  (let [basis (coordinate-system->basis R4-rect)
-        V (literal-vector-field 'V R4-rect)
-        TV (fn [oneform] (oneform V))]
-    (declare-argument-types! TV (list oneform-field?))
-    (let [m (typical-point R4-rect)
-          X (literal-vector-field 'X R4-rect)
-          omega (literal-oneform-field 'omega R4-rect)
-          C (literal-Cartan 'G R4-rect)]
-      (is (= 0 (- ((omega V) m) ((TV omega) m))))))
-
-  ;; So TV is the tensor field that acts as the vector field V.
-  (let [basis (coordinate-system->basis R4-rect)
-        V (literal-vector-field 'V R4-rect)
-        TV (fn (oneform) (oneform V))]
-    (declare-argument-types! TV (list oneform-field?))
-    (let [m (typical-point R4-rect)
-          X (literal-vector-field 'X R4-rect)
-          omega (literal-oneform-field 'omega R4-rect)
-          C (literal-Cartan 'G R4-rect)]
-      (is (= 0 (- ((omega (((covariant-derivative C) X) V)) m)
-                  (((((covariant-derivative C) X) TV) omega) m))))))
-
-  (let [g S2-metric
-        G (metric->Christoffel-2 g (coordinate-system->basis S2-spherical))
-        C (Christoffel->Cartan G)
-        V (literal-vector-field 'V S2-spherical)
-        X (literal-vector-field 'X S2-spherical)
-        Y (literal-vector-field 'Y S2-spherical)
-        m ((point S2-spherical) (up 'theta 'phi))]
-    (declare-argument-types! g (list vector-field? vector-field?))
-    (is (= 0 (((((covariant-derivative C) V) g) X Y) m))))
-
-
-
-  ;; Fun with Christoffel symbols.
-
-  (install-coordinates R2-rect (up 'x 'y))
-
-  (define R2-rect-basis
-    (coordinate-system->basis R2-rect))
-  (define R2-rect-point
-    ((R2-rect '->point) (up 'x0 'y0)))
-
-  (define (Gijk i j k)
-    (literal-manifold-function
-     (string->symbol
-      (string-append "G↑"
-                     (number->string i)
-                     "_"
-                     (number->string j)
-                     (number->string k)))
-     R2-rect))
-
-  (define G
-    (down (down (up (Gijk 0 0 0)
-                    (Gijk 1 0 0))
-                (up (Gijk 0 1 0)
-                    (Gijk 1 1 0)))
-          (down (up (Gijk 0 0 1)
-                    (Gijk 1 0 1))
-                (up (Gijk 0 1 1)
-                    (Gijk 1 1 1)))))
-
-  (clear-arguments)
-  (suppress-arguments '((up x0 y0)))
-
-  (pec (G R2-rect-point))
-  ;; Result:
-  '(down (down (up G↑0_00 G↑1_00) (up G↑0_10 G↑1_10))
-         (down (up G↑0_01 G↑1_01) (up G↑0_11 G↑1_11)))
-
-
-  (define CG (make-Christoffel G R2-rect-basis))
-
-  (define CF (Christoffel->Cartan CG))
-
-  (pec (((Cartan->forms CF) (literal-vector-field 'X R2-rect))
-        R2-rect-point))
-  ;; Result:
-  (down (up (+ (* G↑0_01 X↑1) (* G↑0_00 X↑0))
-            (+ (* G↑1_01 X↑1) (* G↑1_00 X↑0)))
-        (up (+ (* G↑0_11 X↑1) (* G↑0_10 X↑0))
-            (+ (* G↑1_11 X↑1) (* G↑1_10 X↑0))))
-
-  (pec ((Christoffel->symbols
-         (Cartan->Christoffel (Christoffel->Cartan CG)))
-        R2-rect-point))
-  ;; Result:
-  (down (down (up G↑0_00 G↑1_00) (up G↑0_10 G↑1_10))
-        (down (up G↑0_01 G↑1_01) (up G↑0_11 G↑1_11)))
-
-
-  ;; Transformation of Cartan to polar leaves covariant derivative
-  ;; invariant.
-
-  (pec (((((- (covariant-derivative CF)
-              (covariant-derivative
-               (Cartan-transform CF (R2-polar 'coordinate-basis))))
-           (literal-vector-field 'A R2-rect))
-          (literal-vector-field 'B R2-polar))
-         (literal-scalar-field 'f R2-polar))
-        R2-rect-point))
-
-  ;; Result:
-  0
-
-
-  ;; Example from the text:
-
-  (define-coordinates (up x y) R2-rect)
-  (define-coordinates (up r theta) R2-polar)
-
-  (define v (literal-vector-field 'v R2-rect))
-  (define w (literal-vector-field 'w R2-rect))
-  (define f (literal-manifold-function 'f R2-rect))
-
-  (define R2-rect-basis (coordinate-system->basis R2-rect))
-  (define R2-polar-basis (coordinate-system->basis R2-polar))
-
-  (define R2-rect-Christoffel
-    (make-Christoffel
-     (let ((zero (fn (m) 0)))
-       (down (down (up zero zero)
-                   (up zero zero))
-             (down (up zero zero)
-                   (up zero zero))))
-     R2-rect-basis))
-
-  (define R2-rect-Cartan
-    (Christoffel->Cartan R2-rect-Christoffel))
-
-
-  (define R2-polar-Christoffel
-    (make-Christoffel
-     (let ((zero (fn (m) 0)))
-       (down (down (up zero zero)
-                   (up zero (/ 1 r)))
-             (down (up zero (/ 1 r))
-                   (up (* -1 r) zero))))
-     R2-polar-basis))
-
-  (define R2-polar-Cartan
-    (Christoffel->Cartan R2-polar-Christoffel))
-
-
-  (pec
-   (((((- (covariant-derivative R2-rect-Cartan)
-          (covariant-derivative R2-polar-Cartan))
-       v)
-      w)
-     f)
-    (typical-point R2-rect)))
-  ;; Result:
-  0
-
-
-  (pec
-   (((((- (covariant-derivative R2-polar-Cartan)
-          (covariant-derivative
-           (Cartan-transform R2-polar-Cartan R2-rect-basis)))
-       v)
-      w)
-     f)
-    R2-rect-point))
-  ;; Result:
-  0
-
-
-  (define X (literal-vector-field 'X R2-rect))
-
-  (define V (literal-vector-field 'V R2-rect))
-
-  (pec (((((covariant-derivative CF) X) V)
-         (literal-manifold-function 'F R2-rect))
-        R2-rect-point))
-  ;; Result:
-  (+ (* G↑0_00 V↑0 ((partial 0) F) X↑0)
-     (* G↑1_00 V↑0 ((partial 1) F) X↑0)
-     (* G↑0_10 ((partial 0) F) V↑1 X↑0)
-     (* G↑1_10 ((partial 1) F) V↑1 X↑0)
-     (* G↑0_01 V↑0 ((partial 0) F) X↑1)
-     (* G↑1_01 V↑0 ((partial 1) F) X↑1)
-     (* G↑0_11 ((partial 0) F) V↑1 X↑1)
-     (* G↑1_11 ((partial 1) F) V↑1 X↑1)
-     (* ((partial 0) F) ((partial 0) V↑0) X↑0)
-     (* ((partial 0) F) ((partial 1) V↑0) X↑1)
-     (* ((partial 1) F) ((partial 0) V↑1) X↑0)
-     (* ((partial 1) F) ((partial 1) V↑1) X↑1))
-
-
-
-
-  (define-coordinates (up x y) R2-rect)
-  (define rect-basis (coordinate-system->basis R2-rect))
-
-  (define-coordinates (up r theta) R2-polar)
-  (define polar-basis (coordinate-system->basis R2-polar))
-
-  (define rect-chi (R2-rect '->coords))
-  (define rect-chi-inverse (R2-rect '->point))
-  (define polar-chi (R2-polar '->coords))
-  (define polar-chi-inverse (R2-polar '->point))
-  (define m2 (rect-chi-inverse (up 'x0 'y0)))
-
-  (define rect-Christoffel
-    (make-Christoffel
-     (let ((zero (fn (m) 0)))
-       (down (down (up zero zero)
-                   (up zero zero))
-             (down (up zero zero)
-                   (up zero zero))))
-     rect-basis))
-
-  (define polar-Christoffel
-    (make-Christoffel
-     (let ((zero (fn (m) 0)))
-       (down (down (up zero zero)
-                   (up zero (/ 1 r)))
-             (down (up zero (/ 1 r))
-                   (up (* -1 r) zero))))
-     polar-basis))
-
-  (define rect-Cartan
-    (Christoffel->Cartan rect-Christoffel))
-
-  (define polar-Cartan
-    (Christoffel->Cartan polar-Christoffel))
-
-  (define J (- (* x d/dy) (* y d/dx)))
-
-  (define f (literal-scalar-field 'f R2-rect))
-
-  (pec
-   (((((covariant-derivative rect-Cartan)
-       d/dx)
-      J)
-     f)
-    m2))
-  ;; Result:
-  ((partial 1) f)
-
-  ;; Note: arg-suppressor is in force from above.
-
-  (pec
-   (((((covariant-derivative polar-Cartan)
-       d/dx)
-      J)
-     f)
-    m2))
-  ;; Result:
-  ((partial 1) f)
-
-
-
-  ;; More generally, can show independence here
-
-  (define v (literal-vector-field 'v R2-rect))
-  (define w (literal-vector-field 'w R2-rect))
-
-  (pec
-   (((((- (covariant-derivative rect-Cartan)
-          (covariant-derivative polar-Cartan))
-       v)
-      w)
-     f)
-    m2))
-  ;; Result:
-  0
-
-
-  (define v (literal-vector-field 'v R2-polar))
-  (define w (literal-vector-field 'w R2-polar))
-
-  (pec
-   (((((- (covariant-derivative rect-Cartan)
-          (covariant-derivative polar-Cartan))
-       v)
-      w)
-     f)
-    m2))
-  ;; Result:
-  0
-
-
-
-
-  (testing "after cartan-over-map"
-
-    (define M (make-manifold S↑2-type 2 3))
-    (define spherical
-      (coordinate-system-at 'spherical 'north-pole M))
-    (define-coordinates (up theta phi) spherical)
-    (define-coordinates t the-real-line)
-    (define spherical-basis (coordinate-system->basis spherical))
-
-    (define G-S2-1
-      (make-Christoffel
-       (let ((zero  (fn (point) 0)))
+  (let [basis (b/coordinate-system->basis R4-rect)
+        V (vf/literal-vector-field 'V R4-rect)
+        TV (-> (fn [oneform] (oneform V))
+               (ci/with-argument-types [::ff/oneform-field]))
+        m (man/typical-point R4-rect)
+        X (vf/literal-vector-field 'X R4-rect)
+        omega (ff/literal-oneform-field 'omega R4-rect)
+        C (conn/literal-Cartan 'G R4-rect)]
+    (is (zero?
+         (simplify
+          (- ((omega V) m) ((TV omega) m)))))
+
+    ;; So TV is the tensor field that acts as the vector field V.
+    (is (zero?
+         (simplify
+          (- ((omega (((cov/covariant-derivative C) X) V)) m)
+             (((((cov/covariant-derivative C) X) TV) omega) m))))))
+
+  (let [g (ci/with-argument-types
+            S2-metric [::vf/vector-field
+                       ::vf/vector-field])
+        G (conn/metric->Christoffel-2
+           g
+           (b/coordinate-system->basis man/S2-spherical))
+        C (cov/Christoffel->Cartan G)
+        V (vf/literal-vector-field 'V man/S2-spherical)
+        X (vf/literal-vector-field 'X man/S2-spherical)
+        Y (vf/literal-vector-field 'Y man/S2-spherical)
+        m ((point man/S2-spherical) (up 'theta 'phi))]
+
+    (is (v/zero?
+         (simplify
+          (((((cov/covariant-derivative C) V) g) X Y) m)))))
+
+  (testing "Fun with Christoffel symbols."
+    (let-coordinates [[x y] R2-rect]
+      (let [R2-rect-basis (b/coordinate-system->basis R2-rect)
+            R2-rect-point ((point R2-rect) (up 'x0 'y0))
+            Gijk (fn [i j k]
+                   (man/literal-manifold-function
+                    (symbol
+                     (str "G↑" i "_" j k))
+                    R2-rect))
+            G (down (down (up (Gijk 0 0 0)
+                              (Gijk 1 0 0))
+                          (up (Gijk 0 1 0)
+                              (Gijk 1 1 0)))
+                    (down (up (Gijk 0 0 1)
+                              (Gijk 1 0 1))
+                          (up (Gijk 0 1 1)
+                              (Gijk 1 1 1))))
+            present (fn [expr]
+                      (-> (simplify expr)
+                          (x/substitute '(up x0 y0) 'p)))]
+        (is (= '(down (down (up (G↑0_00 p) (G↑1_00 p))
+                            (up (G↑0_10 p) (G↑1_10 p)))
+                      (down (up (G↑0_01 p) (G↑1_01 p))
+                            (up (G↑0_11 p) (G↑1_11 p))))
+               (v/freeze
+                (present
+                 (G R2-rect-point)))))
+
+        (let [CG (cov/make-Christoffel G R2-rect-basis)
+              CF (cov/Christoffel->Cartan CG)]
+          (is (= '(down
+                   (up (+ (* (G↑0_00 p) (X↑0 p)) (* (G↑0_01 p) (X↑1 p)))
+                       (+ (* (G↑1_00 p) (X↑0 p)) (* (G↑1_01 p) (X↑1 p))))
+                   (up (+ (* (G↑0_10 p) (X↑0 p)) (* (G↑0_11 p) (X↑1 p)))
+                       (+ (* (G↑1_10 p) (X↑0 p)) (* (G↑1_11 p) (X↑1 p)))))
+                 (v/freeze
+                  (present
+                   (((cov/Cartan->forms CF) (vf/literal-vector-field 'X R2-rect))
+                    R2-rect-point)))))
+
+          (is (= '(down
+                   (down (up (G↑0_00 p) (G↑1_00 p))
+                         (up (G↑0_10 p) (G↑1_10 p)))
+                   (down (up (G↑0_01 p) (G↑1_01 p))
+                         (up (G↑0_11 p) (G↑1_11 p))))
+                 (v/freeze
+                  (present
+                   ((cov/Christoffel->symbols
+                     (cov/Cartan->Christoffel (cov/Christoffel->Cartan CG)))
+                    R2-rect-point)))))
+
+          ;; Transformation of Cartan to polar leaves covariant derivative
+          ;; invariant.
+          #_
+          (is (zero?
+               (simplify
+                (((((- (cov/covariant-derivative CF)
+                       (cov/covariant-derivative
+                        (cov/Cartan-transform
+                         ;; TODO we need to get this working!!
+                         CF (R2-polar 'coordinate-basis))))
+                    (vf/literal-vector-field 'A R2-rect))
+                   (vf/literal-vector-field 'B R2-polar))
+                  (man/literal-scalar-field 'f R2-polar))
+                 R2-rect-point)))))))))
+
+(deftest more-new-tests
+  (testing "Example from the text:"
+    (let-coordinates [[x y] R2-rect
+                      [r theta] R2-polar]
+      (let [v (vf/literal-vector-field 'v R2-rect)
+            w (vf/literal-vector-field 'w R2-rect)
+            f (man/literal-manifold-function 'f R2-rect)
+            R2-rect-point ((point R2-rect) (up 'x0 'y0))
+            R2-rect-basis (b/coordinate-system->basis R2-rect)
+            R2-polar-basis (b/coordinate-system->basis R2-polar)
+            R2-rect-Christoffel
+            (cov/make-Christoffel
+             (let [zero man/zero-manifold-function]
+               (down (down (up zero zero)
+                           (up zero zero))
+                     (down (up zero zero)
+                           (up zero zero))))
+             R2-rect-basis)
+            R2-rect-Cartan (cov/Christoffel->Cartan R2-rect-Christoffel)
+            R2-polar-Christoffel (cov/make-Christoffel
+                                  (let [zero man/zero-manifold-function]
+                                    (down (down (up zero zero)
+                                                (up zero (/ 1 r)))
+                                          (down (up zero (/ 1 r))
+                                                (up (* -1 r) zero))))
+                                  R2-polar-basis)
+            R2-polar-Cartan (cov/Christoffel->Cartan R2-polar-Christoffel)]
+        (is (zero?
+             (simplify
+              (((((- (cov/covariant-derivative R2-rect-Cartan)
+                     (cov/covariant-derivative R2-polar-Cartan))
+                  v)
+                 w)
+                f)
+               (man/typical-point R2-rect)))))
+
+        (is (zero?
+             (simplify
+              (((((- (cov/covariant-derivative R2-polar-Cartan)
+                     (cov/covariant-derivative
+                      (cov/Cartan-transform R2-polar-Cartan R2-rect-basis)))
+                  v)
+                 w)
+                f)
+               R2-rect-point)))))))
+
+  #_
+  (comment
+    (define X (vf/literal-vector-field 'X R2-rect))
+
+    (define V (vf/literal-vector-field 'V R2-rect))
+
+    (pec (((((cov/covariant-derivative CF) X) V)
+           (man/literal-manifold-function 'F R2-rect))
+          R2-rect-point))
+    ;; Result:
+    (+ (* G↑0_00 V↑0 ((partial 0) F) X↑0)
+       (* G↑1_00 V↑0 ((partial 1) F) X↑0)
+       (* G↑0_10 ((partial 0) F) V↑1 X↑0)
+       (* G↑1_10 ((partial 1) F) V↑1 X↑0)
+       (* G↑0_01 V↑0 ((partial 0) F) X↑1)
+       (* G↑1_01 V↑0 ((partial 1) F) X↑1)
+       (* G↑0_11 ((partial 0) F) V↑1 X↑1)
+       (* G↑1_11 ((partial 1) F) V↑1 X↑1)
+       (* ((partial 0) F) ((partial 0) V↑0) X↑0)
+       (* ((partial 0) F) ((partial 1) V↑0) X↑1)
+       (* ((partial 1) F) ((partial 0) V↑1) X↑0)
+       (* ((partial 1) F) ((partial 1) V↑1) X↑1))
+
+
+    (define-coordinates (up x y) R2-rect)
+    (define rect-basis (b/coordinate-system->basis R2-rect))
+
+    (define-coordinates (up r theta) R2-polar)
+    (define polar-basis (b/coordinate-system->basis R2-polar))
+
+    (define rect-chi (R2-rect '->coords))
+    (define rect-chi-inverse (R2-rect '->point))
+    (define polar-chi (R2-polar '->coords))
+    (define polar-chi-inverse (R2-polar '->point))
+    (define m2 (rect-chi-inverse (up 'x0 'y0)))
+
+    (define rect-Christoffel
+      (cov/make-Christoffel
+       (let ((zero (fn (m) 0)))
          (down (down (up zero zero)
-                     (up zero (/ 1 (tan theta))))
-               (down (up zero (/ 1 (tan theta)))
-                     (up (- (* (sin theta) (cos theta))) zero))))
-       spherical-basis))
+                     (up zero zero))
+               (down (up zero zero)
+                     (up zero zero))))
+       rect-basis))
 
+    (define polar-Christoffel
+      (cov/make-Christoffel
+       (let ((zero (fn (m) 0)))
+         (down (down (up zero zero)
+                     (up zero (/ 1 r)))
+               (down (up zero (/ 1 r))
+                     (up (* -1 r) zero))))
+       polar-basis))
 
-    (define gamma:N->M
-      (compose (spherical '->point)
-               (up (literal-function 'alpha)
-                   (literal-function 'beta))
-               (the-real-line '->coords)))
+    (define rect-Cartan
+      (cov/Christoffel->Cartan rect-Christoffel))
 
-    (define basis-over-gamma
-      (basis->basis-over-map gamma:N->M spherical-basis))
+    (define polar-Cartan
+      (cov/Christoffel->Cartan polar-Christoffel))
 
-    (define w
-      (basis-components->vector-field
-       (up (compose (literal-function 'w0)
-                    (the-real-line '->coords))
-           (compose (literal-function 'w1)
-                    (the-real-line '->coords)))
-       (basis->vector-basis basis-over-gamma)))
+    (define J (- (* x d/dy) (* y d/dx)))
 
-    (define sphere-Cartan (Christoffel->Cartan G-S2-1))
+    (define f (man/literal-scalar-field 'f R2-rect))
 
     (pec
-     (s:map/r
-      (fn (omega)
-        ((omega
-          (((covariant-derivative sphere-Cartan gamma:N->M)
-            d/dt)
-           w))
-         ((the-real-line '->point) 'tau)))
-      (basis->oneform-basis basis-over-gamma)))
+     (((((cov/covariant-derivative rect-Cartan)
+         d/dx)
+        J)
+       f)
+      m2))
     ;; Result:
-    (up
-     (+ (* -1 (sin (alpha tau)) ((D beta) tau) (w1 tau) (cos (alpha tau)))
-        ((D w0) tau))
-     (+ (/ (* (w0 tau) ((D beta) tau) (cos (alpha tau))) (sin (alpha tau)))
-        (/ (* (w1 tau) ((D alpha) tau) (cos (alpha tau))) (sin (alpha tau)))
-        ((D w1) tau)))
+    ((partial 1) f)
 
-    )
+    ;; Note: arg-suppressor is in force from above.
 
+    (pec
+     (((((cov/covariant-derivative polar-Cartan)
+         d/dx)
+        J)
+       f)
+      m2))
+    ;; Result:
+    ((partial 1) f)
+
+
+
+    ;; More generally, can show independence here
+
+    (define v (vf/literal-vector-field 'v R2-rect))
+    (define w (vf/literal-vector-field 'w R2-rect))
+
+    (pec
+     (((((- (cov/covariant-derivative rect-Cartan)
+            (cov/covariant-derivative polar-Cartan))
+         v)
+        w)
+       f)
+      m2))
+    ;; Result:
+    0
+
+
+    (define v (vf/literal-vector-field 'v R2-polar))
+    (define w (vf/literal-vector-field 'w R2-polar))
+
+    (pec
+     (((((- (cov/covariant-derivative rect-Cartan)
+            (cov/covariant-derivative polar-Cartan))
+         v)
+        w)
+       f)
+      m2))
+    ;; Result:
+    0
+
+
+    (testing "after cartan-over-map"
+
+      (define M (make-manifold S↑2-type 2 3))
+      (define spherical
+        (coordinate-system-at 'spherical 'north-pole M))
+      (define-coordinates (up theta phi) spherical)
+      (define-coordinates t the-real-line)
+      (define spherical-basis (b/coordinate-system->basis spherical))
+
+      (define G-S2-1
+        (cov/make-Christoffel
+         (let ((zero  (fn (point) 0)))
+           (down (down (up zero zero)
+                       (up zero (/ 1 (tan theta))))
+                 (down (up zero (/ 1 (tan theta)))
+                       (up (- (* (sin theta) (cos theta))) zero))))
+         spherical-basis))
+
+
+      (define gamma:N->M
+        (compose (spherical '->point)
+                 (up (literal-function 'alpha)
+                     (literal-function 'beta))
+                 (the-real-line '->coords)))
+
+      (define basis-over-gamma
+        (basis->basis-over-map gamma:N->M spherical-basis))
+
+      (define w
+        (basis-components->vector-field
+         (up (compose (literal-function 'w0)
+                      (the-real-line '->coords))
+             (compose (literal-function 'w1)
+                      (the-real-line '->coords)))
+         (basis->vector-basis basis-over-gamma)))
+
+      (define sphere-Cartan (cov/Christoffel->Cartan G-S2-1))
+
+      (pec
+       (s:map/r
+        (fn (omega)
+          ((omega
+            (((cov/covariant-derivative sphere-Cartan gamma:N->M)
+              d/dt)
+             w))
+           ((the-real-line '->point) 'tau)))
+        (basis->oneform-basis basis-over-gamma)))
+      ;; Result:
+      (up
+       (+ (* -1 (sin (alpha tau)) ((D beta) tau) (w1 tau) (cos (alpha tau)))
+          ((D w0) tau))
+       (+ (/ (* (w0 tau) ((D beta) tau) (cos (alpha tau))) (sin (alpha tau)))
+          (/ (* (w1 tau) ((D alpha) tau) (cos (alpha tau))) (sin (alpha tau)))
+          ((D w1) tau))))))
+
+#_
+(deftest geodesic-equations
   (testing "geodesic-equations"
     (pec
      (s:map/r
       (fn (omega)
         ((omega
-          (((covariant-derivative sphere-Cartan gamma:N->M)
+          (((cov/covariant-derivative sphere-Cartan gamma:N->M)
             d/dt)
            ((differential gamma:N->M) d/dt)))
          ((the-real-line '->point) 't)))
@@ -710,7 +687,7 @@
     (define-coordinates (up x y) R2-rect)
 
     (define (Gijk i j k)
-      (literal-manifold-function
+      (man/literal-manifold-function
        (string->symbol
         (string-append "G↑"
                        (number->string i)
@@ -729,9 +706,8 @@
                   (up (Gijk 0 1 1)
                       (Gijk 1 1 1)))))
 
-
     (define CG
-      (make-Christoffel G (coordinate-system->basis R2-rect)))
+      (cov/make-Christoffel G (b/coordinate-system->basis R2-rect)))
 
     (define gamma:N->M
       (compose (R2-rect '->point)
@@ -741,7 +717,7 @@
 
     (define basis-over-gamma
       (basis->basis-over-map gamma:N->M
-                             (coordinate-system->basis R2-rect)))
+                             (b/coordinate-system->basis R2-rect)))
 
     (define u
       (basis-components->vector-field
@@ -756,7 +732,7 @@
      (s:map/r
       (fn (omega)
         ((omega
-          (((covariant-derivative (Christoffel->Cartan CG) gamma:N->M)
+          (((cov/covariant-derivative (cov/Christoffel->Cartan CG) gamma:N->M)
             d/dt)
            u))
          ((the-real-line '->point) 't)))
@@ -779,7 +755,7 @@
      (s:map/r
       (fn (omega)
         ((omega
-          (((covariant-derivative (Christoffel->Cartan CG) gamma:N->M)
+          (((cov/covariant-derivative (cov/Christoffel->Cartan CG) gamma:N->M)
             d/dt)
            ((differential gamma:N->M) d/dt)))
          ((the-real-line '->point) 't)))
@@ -798,22 +774,20 @@
         (((expt D 2) beta) t)))
 
 
-
-
-;;; Geodesic Equations = Lagrange Equations
-
+    ;; Geodesic Equations = Lagrange Equations
+    ;;
     ;; Here I restrict everything to the unit sphere.
     ;; The coordinates on the unit sphere
 
     (define-coordinates t R1-rect)
     (define-coordinates (up theta phi) S2-spherical)
 
-    (define two-sphere-basis (coordinate-system->basis S2-spherical))
+    (define two-sphere-basis (b/coordinate-system->basis S2-spherical))
 
     ;; The Christoffel symbols (for r=1) (p.341 MTW) are:
 
     (define G-S2-1
-      (make-Christoffel
+      (cov/make-Christoffel
        (let ((zero  (fn (point) 0)))
          (down (down (up zero zero)
                      (up zero (/ 1 (tan theta))))
@@ -825,11 +799,11 @@
                                  (up (literal-function 'mu-theta)
                                      (literal-function 'mu-phi))
                                  (R1-rect '->coords)))
-               (Cartan (Christoffel->Cartan G-S2-1)))
+               (Cartan (cov/Christoffel->Cartan G-S2-1)))
            (s:map/r
             (fn (w)
               ((w
-                (((covariant-derivative Cartan mu:N->M) d/dt)
+                (((cov/covariant-derivative Cartan mu:N->M) d/dt)
                  ((differential mu:N->M) d/dt)))
                ((R1-rect '->point) 'tau)))
             (basis->oneform-basis
@@ -972,9 +946,8 @@
     ;; Does not seem to depend on a derivative of basis vectors, in fact
     ;; the derivative of the basis vectors is multiplied by zero in the
     ;; product rule output.
-
     (define (Gijk i j k)
-      (literal-manifold-function
+      (man/literal-manifold-function
        (string->symbol
         (string-append "G↑"
                        (number->string i)
@@ -993,16 +966,16 @@
                   (up (Gijk 0 1 1)
                       (Gijk 1 1 1)))))
 
-    (define X (literal-vector-field 'X R2-rect))
+    (define X (vf/literal-vector-field 'X R2-rect))
 
-    (define Y (literal-vector-field 'Y R2-rect))
+    (define Y (vf/literal-vector-field 'Y R2-rect))
 
     (define q_0 (up 'q_x 'q_y))
 
     (define m_0
       ((R2-rect '->point) q_0))
 
-    (define F (literal-manifold-function 'F R2-rect))
+    (define F (man/literal-manifold-function 'F R2-rect))
 
 
     (define (((((CD CF chart) v) u) F) m)
@@ -1031,7 +1004,7 @@
                   (let ((m_0 (chi↑-1 sigma)))
                     (up ((v chi) m_0)
                         (* -1
-                           (((Cartan->forms CF) v) m_0)
+                           (((cov/Cartan->forms CF) v) m_0)
                            (u↑i m_0))))))
 
               (define (vs fs)
@@ -1078,7 +1051,7 @@
               (define (Au delta)
                 (- (u↑i m)
                    (* delta
-                      (((Cartan->forms CF) v) m)
+                      (((cov/Cartan->forms CF) v) m)
                       (u↑i m))))
 
               (define (g delta)
@@ -1088,40 +1061,40 @@
 
               ((D g) 0))))))
 
-    (let ((CF (Christoffel->Cartan
-               (make-Christoffel G
-                                 (coordinate-system->basis R2-rect)))))
+    (let ((CF (cov/Christoffel->Cartan
+               (cov/make-Christoffel G
+                                     (b/coordinate-system->basis R2-rect)))))
       (pe (- (((((CD CF R2-rect) X) Y) F) m_0)
-             (((((covariant-derivative CF) X) Y) F) m_0))))
+             (((((cov/covariant-derivative CF) X) Y) F) m_0))))
     0
 
-    (let ((CF (Christoffel->Cartan
-               (make-Christoffel G
-                                 (coordinate-system->basis R2-polar)))))
+    (let ((CF (cov/Christoffel->Cartan
+               (cov/make-Christoffel G
+                                     (b/coordinate-system->basis R2-polar)))))
       (pe (- (((((CD CF R2-rect) X) Y) F) m_0)
-             (((((covariant-derivative CF) X) Y) F) m_0))))
+             (((((cov/covariant-derivative CF) X) Y) F) m_0))))
     0
 
-    (let ((CF (Christoffel->Cartan
-               (make-Christoffel G
-                                 (coordinate-system->basis R2-rect)))))
+    (let ((CF (cov/Christoffel->Cartan
+               (cov/make-Christoffel G
+                                     (b/coordinate-system->basis R2-rect)))))
       (pe (- (((((CD CF R2-polar) X) Y) F) m_0)
-             (((((covariant-derivative CF) X) Y) F) m_0))))
+             (((((cov/covariant-derivative CF) X) Y) F) m_0))))
     0
 
-    (let ((CF (Christoffel->Cartan
-               (make-Christoffel G
-                                 (coordinate-system->basis R2-polar)))))
+    (let ((CF (cov/Christoffel->Cartan
+               (cov/make-Christoffel G
+                                     (b/coordinate-system->basis R2-polar)))))
       (pe (- (((((CD CF R2-polar) X) Y) F) m_0)
-             (((((covariant-derivative CF) X) Y) F) m_0))))
+             (((((cov/covariant-derivative CF) X) Y) F) m_0))))
     0
-                                        ;Too slow...                            ; ; ; ; ; ; ; ; ; ; ; ; ; ;
+    ;; Too slow...
 
 
     ;; Testing on forms.
 
     (define (Gijk i j k)
-      (literal-manifold-function
+      (man/literal-manifold-function
        (string->symbol
         (string-append "G↑"
                        (number->string i)
@@ -1140,46 +1113,46 @@
                   (up (Gijk 0 1 1)
                       (Gijk 1 1 1)))))
 
-    (define X (literal-vector-field 'X R2-rect))
+    (define X (vf/literal-vector-field 'X R2-rect))
 
-    (define Y (literal-vector-field 'Y R2-rect))
+    (define Y (vf/literal-vector-field 'Y R2-rect))
 
-    (define omega (literal-oneform-field 'omega R2-rect))
+    (define omega (ff/literal-oneform-field 'omega R2-rect))
 
     (define q_0 (up 'q_x 'q_y))
 
     (define m_0
       ((R2-rect '->point) q_0))
 
-    (define F (literal-manifold-function 'F R2-rect))
+    (define F (man/literal-manifold-function 'F R2-rect))
 
-    (let* ((CF (Christoffel->Cartan
-                (make-Christoffel G
-                                  (coordinate-system->basis R2-rect))))
-           (D_x ((covariant-derivative CF) X)))
+    (let* ((CF (cov/Christoffel->Cartan
+                (cov/make-Christoffel G
+                                      (b/coordinate-system->basis R2-rect))))
+           (D_x ((cov/covariant-derivative CF) X)))
       (pe (- (+ (((D_x omega) Y) m_0)
                 ((omega (D_x Y)) m_0))
              ((D_x (omega Y)) m_0))))
     0
 
 
-    (define tau (literal-oneform-field 'tau R2-rect))
+    (define tau (ff/literal-oneform-field 'tau R2-rect))
 
-    (define Z (literal-vector-field 'Z R2-rect))
+    (define Z (vf/literal-vector-field 'Z R2-rect))
 
-    (let* ((CF (Christoffel->Cartan
-                (make-Christoffel G
-                                  (coordinate-system->basis R2-rect))))
-           (D_x ((covariant-derivative CF) X)))
+    (let* ((CF (cov/Christoffel->Cartan
+                (cov/make-Christoffel G
+                                      (b/coordinate-system->basis R2-rect))))
+           (D_x ((cov/covariant-derivative CF) X)))
       (pe (- (((D_x (wedge omega tau)) Y Z) m_0)
              (+ (((wedge omega (D_x tau)) Y Z) m_0)
                 (((wedge (D_x omega) tau) Y Z) m_0)))))
     0
 
-    (let* ((CF (Christoffel->Cartan
-                (make-Christoffel G
-                                  (coordinate-system->basis R2-polar))))
-           (D_x ((covariant-derivative CF) X)))
+    (let* ((CF (cov/Christoffel->Cartan
+                (cov/make-Christoffel G
+                                      (b/coordinate-system->basis R2-polar))))
+           (D_x ((cov/covariant-derivative CF) X)))
       (pe (- (((D_x (wedge omega tau)) Y Z) m_0)
              (+ (((wedge omega (D_x tau)) Y Z) m_0)
                 (((wedge (D_x omega) tau) Y Z) m_0)))))
@@ -1188,7 +1161,7 @@
 
     ;; Next, tests, for the actual functions:
 
-    (((geodesic-equation the-real-line R2-rect (literal-Cartan 'G R2-rect))
+    (((geodesic-equation the-real-line R2-rect (conn/literal-Cartan 'G R2-rect))
       (literal-manifold-map 'gamma the-real-line R2-rect))
      ((point the-real-line) 't))
 
@@ -1206,7 +1179,7 @@
 
 
 
-    (let ((C (literal-Cartan 'G R2-rect)))
+    (let ((C (conn/literal-Cartan 'G R2-rect)))
       (- (((geodesic-equation the-real-line R2-rect C)
            (literal-manifold-map 'gamma the-real-line R2-rect))
           ((point the-real-line) 't))
@@ -1214,25 +1187,18 @@
            (literal-manifold-map 'gamma the-real-line R2-rect))
           ((point the-real-line) 't))))
 
-    (up 0 0)
+    (up 0 0)))
 
-
-
-
-    )
-
-  (testing "parallel-transport-equation"
-
-
+#_(deftest parallel-transport-equation
     (define M (make-manifold S↑2-type 2 3))
     (define S2-spherical
       (coordinate-system-at 'spherical 'north-pole M))
     (define-coordinates (up theta phi) S2-spherical)
     (define S2-basis
-      (coordinate-system->basis S2-spherical))
+      (b/coordinate-system->basis S2-spherical))
 
     (define G-S2-1
-      (make-Christoffel
+      (cov/make-Christoffel
        (let ((zero  (fn (point) 0)))
          (down (down (up zero zero)
                      (up zero (/ 1 (tan theta))))
@@ -1262,7 +1228,7 @@
        (basis->vector-basis basis-over-gamma)))
 
     (define sphere-Cartan
-      (Christoffel->Cartan G-S2-1))
+      (cov/Christoffel->Cartan G-S2-1))
 
     ((((parallel-transport-equation
         the-real-line S2-spherical sphere-Cartan)
@@ -1275,5 +1241,4 @@
      (+ (* -1 (sin (alpha t)) ((D beta) t) (u↑1 t) (cos (alpha t))) ((D u↑0) t))
      (+ (/ (* (u↑0 t) ((D beta) t) (cos (alpha t))) (sin (alpha t)))
         (/ (* (u↑1 t) ((D alpha) t) (cos (alpha t))) (sin (alpha t)))
-        ((D u↑1) t)))
-    ))
+        ((D u↑1) t))))

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -343,7 +343,6 @@
 
 (def R2-rect-point ((point R2-rect) (up 'x0 'y0)))
 (def R2-rect-basis (b/coordinate-system->basis R2-rect))
-(def R2-rect-point ((point R2-rect) (up 'x0 'y0)))
 (def R2-polar-basis (b/coordinate-system->basis R2-polar))
 
 (defn present
@@ -645,7 +644,7 @@
                      ((point the-real-line) 't)))
                   (b/basis->oneform-basis basis-over-gamma))))))))))
 
-(deftest geodesic-equation-tests
+(deftest geodesic-equation-tests-a
   (testing "geodesic equations"
     (let-coordinates [[x y] R2-rect
                       t the-real-line]
@@ -892,46 +891,7 @@
                                    ((vector-basis F) advanced-m))))]
                       ((D g) 0))))))))))))
 
-;; A bit simpler, but lacking in motivation?
-
-#_
-(define (((((CD CF chart) v) u) F) m)
-
-  (define (Sigma state) (ref state 0))
-  (define (U state) (ref state 1))
-  (define (sigma-u sigma u) (up sigma u))
-
-  (define chi (chart '->coords))
-  (define chi↑-1 (chart '->point))
-
-  ;; ((gamma m) delta) is the point on gamma advanced by delta.
-
-  (define ((gamma m) delta)
-    (chi↑-1 (+ (chi m) (* delta ((v chi) m)))))
-
-  (let ((basis (Cartan->basis CF)))
-    (let ((vector-basis (b/basis->vector-basis basis))
-          (oneform-basis (b/basis->oneform-basis basis)))
-      (let ((u↑i (oneform-basis u)))
-        (let ((initial-state
-               (sigma-u (chi m) (u↑i m))))
-
-          ;; First-order approximation to A
-
-          (define (Au delta)
-            (- (u↑i m)
-               (* delta
-                  (((cov/Cartan->forms CF) v) m)
-                  (u↑i m))))
-
-          (define (g delta)
-            (let ((advanced-m ((gamma m) delta)))
-              (* (- (u↑i advanced-m) (Au delta))
-                 ((vector-basis F) advanced-m))))
-
-          ((D g) 0))))))
-
-(deftest geodesic-equation-tests
+(deftest geodesic-equation-tests-b
   (let [X (vf/literal-vector-field 'X R2-rect)
         Y (vf/literal-vector-field 'Y R2-rect)
         F (man/literal-manifold-function 'F R2-rect)
@@ -956,7 +916,8 @@
           (- (((((CD CF-rect R2-polar) X) Y) F) m_0)
              (((((cov/covariant-derivative CF-rect) X) Y) F) m_0)))))
 
-    ;; Too slow... it works if we bump the timeout, but this is not fast.
+    ;; TODO: Too slow... it works if we bump the timeout, but this is not fast.
+    #_
     (binding [pg/*poly-gcd-time-limit* [5 :seconds]]
       (is (zero?
            (simplify
@@ -981,11 +942,15 @@
                  (+ (((ff/wedge omega (D_x-rect tau)) Y Z) m_0)
                     (((ff/wedge (D_x-rect omega) tau) Y Z) m_0))))))
 
-        (is (zero?
-             (simplify
-              (- (((D_x-polar (ff/wedge omega tau)) Y Z) m_0)
-                 (+ (((ff/wedge omega (D_x-polar tau)) Y Z) m_0)
-                    (((ff/wedge (D_x-polar omega) tau) Y Z) m_0)))))))))
+        (testing "TODO: investigate if there is some setting that will prevent
+        GCD from running without me having to add this manually. The test passes
+        without the super slow GCD."
+          (binding [pg/*poly-gcd-time-limit* [0 :seconds]]
+            (is (zero?
+                 (simplify
+                  (- (((D_x-polar (ff/wedge omega tau)) Y Z) m_0)
+                     (+ (((ff/wedge omega (D_x-polar tau)) Y Z) m_0)
+                        (((ff/wedge (D_x-polar omega) tau) Y Z) m_0)))))))))))
 
   ;; Next, tests, for the actual functions:
   (is (= '(up

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -303,27 +303,28 @@
                       (ff/d ((cov/interior-product X) omega)))))]
         (is (= 0 (simplify
                   ((- (((g/Lie-derivative X) omega) Y Z)
-	                    (((L1 X) omega) Y Z))
+                      (((L1 X) omega) Y Z))
                    R3-rect-point))))
 
         (let [omega (ff/literal-oneform-field 'omega R3-rect)]
           (is (= 0 (simplify
                     ((- (((g/Lie-derivative X) omega) Y)
-	                      (((L1 X) omega) Y))
-	                   R3-rect-point)))))
+                        (((L1 X) omega) Y))
+                     R3-rect-point)))))
 
         (let [omega (* alpha (ff/wedge dx dy dz))]
           (is (= 0 (simplify
                     ((- (((g/Lie-derivative X) omega) Y Z W)
-	                      (((L1 X) omega) Y Z W))
-	                   R3-rect-point)))))))))
+                        (((L1 X) omega) Y Z W))
+                     R3-rect-point)))))))))
 
 
+#_
 (deftest new-tests
-  ;; Structured objects, such as tensors, take vector fields and 1form
+  ;; Structured objects, such as tensors, take vector fields and oneform
   ;; fields as arguments.
   ;;
-  ;; 1form fields can act as (0,1) tensor fields if arguments are declared:
+  ;; oneform fields can act as (0,1) tensor fields if arguments are declared:
 
   (let [omega (literal-oneform-field 'omega R4-rect)]
     (declare-argument-types! omega (list vector-field?))
@@ -340,26 +341,26 @@
 
   ;; So to test the operation on a vector field we must construct a
   ;; (1,0) tensor field that behaves like a vector field, but acts on
-  ;; 1form fields rather than manifold functions.
+  ;; oneform fields rather than manifold functions.
 
   (let [basis (coordinate-system->basis R4-rect)
         V (literal-vector-field 'V R4-rect)
-        TV (lambda (1form) (1form V))]
+        TV (fn [oneform] (oneform V))]
     (declare-argument-types! TV (list oneform-field?))
     (let [m (typical-point R4-rect)
           X (literal-vector-field 'X R4-rect)
-          omega (literal-1form-field 'omega R4-rect)
+          omega (literal-oneform-field 'omega R4-rect)
           C (literal-Cartan 'G R4-rect)]
       (is (= 0 (- ((omega V) m) ((TV omega) m))))))
 
   ;; So TV is the tensor field that acts as the vector field V.
   (let [basis (coordinate-system->basis R4-rect)
         V (literal-vector-field 'V R4-rect)
-        TV (lambda (1form) (1form V))]
-    (declare-argument-types! TV (list 1form-field?))
+        TV (fn (oneform) (oneform V))]
+    (declare-argument-types! TV (list oneform-field?))
     (let [m (typical-point R4-rect)
           X (literal-vector-field 'X R4-rect)
-          omega (literal-1form-field 'omega R4-rect)
+          omega (literal-oneform-field 'omega R4-rect)
           C (literal-Cartan 'G R4-rect)]
       (is (= 0 (- ((omega (((covariant-derivative C) X) V)) m)
                   (((((covariant-derivative C) X) TV) omega) m))))))
@@ -375,8 +376,8 @@
     (is (= 0 (((((covariant-derivative C) V) g) X Y) m))))
 
 
-  #|
-;;; Fun with Christoffel symbols.
+
+  ;; Fun with Christoffel symbols.
 
   (install-coordinates R2-rect (up 'x 'y))
 
@@ -388,7 +389,7 @@
   (define (Gijk i j k)
     (literal-manifold-function
      (string->symbol
-      (string-append "G^"
+      (string-append "G↑"
                      (number->string i)
                      "_"
                      (number->string j)
@@ -409,10 +410,10 @@
   (suppress-arguments '((up x0 y0)))
 
   (pec (G R2-rect-point))
-  #| Result:
-  (down (down (up G^0_00 G^1_00) (up G^0_10 G^1_10))
-        (down (up G^0_01 G^1_01) (up G^0_11 G^1_11)))
-  |#
+  ;; Result:
+  '(down (down (up G↑0_00 G↑1_00) (up G↑0_10 G↑1_10))
+         (down (up G↑0_01 G↑1_01) (up G↑0_11 G↑1_11)))
+
 
   (define CG (make-Christoffel G R2-rect-basis))
 
@@ -420,20 +421,19 @@
 
   (pec (((Cartan->forms CF) (literal-vector-field 'X R2-rect))
         R2-rect-point))
-  #| Result:
-  (down (up (+ (* G^0_01 X^1) (* G^0_00 X^0))
-            (+ (* G^1_01 X^1) (* G^1_00 X^0)))
-        (up (+ (* G^0_11 X^1) (* G^0_10 X^0))
-            (+ (* G^1_11 X^1) (* G^1_10 X^0))))
-  |#
-  
+  ;; Result:
+  (down (up (+ (* G↑0_01 X↑1) (* G↑0_00 X↑0))
+            (+ (* G↑1_01 X↑1) (* G↑1_00 X↑0)))
+        (up (+ (* G↑0_11 X↑1) (* G↑0_10 X↑0))
+            (+ (* G↑1_11 X↑1) (* G↑1_10 X↑0))))
+
   (pec ((Christoffel->symbols
          (Cartan->Christoffel (Christoffel->Cartan CG)))
         R2-rect-point))
-  #| Result:
-  (down (down (up G^0_00 G^1_00) (up G^0_10 G^1_10))
-        (down (up G^0_01 G^1_01) (up G^0_11 G^1_11)))
-  |#
+  ;; Result:
+  (down (down (up G↑0_00 G↑1_00) (up G↑0_10 G↑1_10))
+        (down (up G↑0_01 G↑1_01) (up G↑0_11 G↑1_11)))
+
 
   ;; Transformation of Cartan to polar leaves covariant derivative
   ;; invariant.
@@ -446,9 +446,9 @@
          (literal-scalar-field 'f R2-polar))
         R2-rect-point))
 
-  #| Result:
+  ;; Result:
   0
-  |#
+
 
   ;; Example from the text:
 
@@ -464,7 +464,7 @@
 
   (define R2-rect-Christoffel
     (make-Christoffel
-     (let ((zero (lambda (m) 0)))
+     (let ((zero (fn (m) 0)))
        (down (down (up zero zero)
                    (up zero zero))
              (down (up zero zero)
@@ -477,7 +477,7 @@
 
   (define R2-polar-Christoffel
     (make-Christoffel
-     (let ((zero (lambda (m) 0)))
+     (let ((zero (fn (m) 0)))
        (down (down (up zero zero)
                    (up zero (/ 1 r)))
              (down (up zero (/ 1 r))
@@ -495,9 +495,9 @@
       w)
      f)
     (typical-point R2-rect)))
-  #| Result:
+  ;; Result:
   0
-  |#
+
 
   (pec
    (((((- (covariant-derivative R2-polar-Cartan)
@@ -507,9 +507,9 @@
       w)
      f)
     R2-rect-point))
-  #| Result:
+  ;; Result:
   0
-  |#
+
 
   (define X (literal-vector-field 'X R2-rect))
 
@@ -518,24 +518,23 @@
   (pec (((((covariant-derivative CF) X) V)
          (literal-manifold-function 'F R2-rect))
         R2-rect-point))
-  #| Result:
-  (+ (* G^0_00 V^0 ((partial 0) F) X^0)
-     (* G^1_00 V^0 ((partial 1) F) X^0)
-     (* G^0_10 ((partial 0) F) V^1 X^0)
-     (* G^1_10 ((partial 1) F) V^1 X^0)
-     (* G^0_01 V^0 ((partial 0) F) X^1)
-     (* G^1_01 V^0 ((partial 1) F) X^1)
-     (* G^0_11 ((partial 0) F) V^1 X^1)
-     (* G^1_11 ((partial 1) F) V^1 X^1)
-     (* ((partial 0) F) ((partial 0) V^0) X^0)
-     (* ((partial 0) F) ((partial 1) V^0) X^1)
-     (* ((partial 1) F) ((partial 0) V^1) X^0)
-     (* ((partial 1) F) ((partial 1) V^1) X^1))
-  |#
+  ;; Result:
+  (+ (* G↑0_00 V↑0 ((partial 0) F) X↑0)
+     (* G↑1_00 V↑0 ((partial 1) F) X↑0)
+     (* G↑0_10 ((partial 0) F) V↑1 X↑0)
+     (* G↑1_10 ((partial 1) F) V↑1 X↑0)
+     (* G↑0_01 V↑0 ((partial 0) F) X↑1)
+     (* G↑1_01 V↑0 ((partial 1) F) X↑1)
+     (* G↑0_11 ((partial 0) F) V↑1 X↑1)
+     (* G↑1_11 ((partial 1) F) V↑1 X↑1)
+     (* ((partial 0) F) ((partial 0) V↑0) X↑0)
+     (* ((partial 0) F) ((partial 1) V↑0) X↑1)
+     (* ((partial 1) F) ((partial 0) V↑1) X↑0)
+     (* ((partial 1) F) ((partial 1) V↑1) X↑1))
 
-  |#
-  
-  #|
+
+
+
   (define-coordinates (up x y) R2-rect)
   (define rect-basis (coordinate-system->basis R2-rect))
 
@@ -550,7 +549,7 @@
 
   (define rect-Christoffel
     (make-Christoffel
-     (let ((zero (lambda (m) 0)))
+     (let ((zero (fn (m) 0)))
        (down (down (up zero zero)
                    (up zero zero))
              (down (up zero zero)
@@ -559,7 +558,7 @@
 
   (define polar-Christoffel
     (make-Christoffel
-     (let ((zero (lambda (m) 0)))
+     (let ((zero (fn (m) 0)))
        (down (down (up zero zero)
                    (up zero (/ 1 r)))
              (down (up zero (/ 1 r))
@@ -582,10 +581,10 @@
       J)
      f)
     m2))
-  #| Result:
+  ;; Result:
   ((partial 1) f)
-  |#
-;;; Note: arg-suppressor is in force from above.
+
+  ;; Note: arg-suppressor is in force from above.
 
   (pec
    (((((covariant-derivative polar-Cartan)
@@ -593,13 +592,12 @@
       J)
      f)
     m2))
-  #| Result:
+  ;; Result:
   ((partial 1) f)
-  |#
-  |#
-  
-  #|
-;;; More generally, can show independence here
+
+
+
+  ;; More generally, can show independence here
 
   (define v (literal-vector-field 'v R2-rect))
   (define w (literal-vector-field 'w R2-rect))
@@ -611,9 +609,9 @@
       w)
      f)
     m2))
-  #| Result:
+  ;; Result:
   0
-  |#
+
 
   (define v (literal-vector-field 'v R2-polar))
   (define w (literal-vector-field 'w R2-polar))
@@ -625,15 +623,15 @@
       w)
      f)
     m2))
-  #| Result:
+  ;; Result:
   0
-  |#
 
-  |#
+
+
 
   (testing "after cartan-over-map"
-    #|
-    (define M (make-manifold S^2-type 2 3))
+
+    (define M (make-manifold S↑2-type 2 3))
     (define spherical
       (coordinate-system-at 'spherical 'north-pole M))
     (define-coordinates (up theta phi) spherical)
@@ -642,7 +640,7 @@
 
     (define G-S2-1
       (make-Christoffel
-       (let ((zero  (lambda (point) 0)))
+       (let ((zero  (fn (point) 0)))
          (down (down (up zero zero)
                      (up zero (/ 1 (tan theta))))
                (down (up zero (/ 1 (tan theta)))
@@ -671,50 +669,50 @@
 
     (pec
      (s:map/r
-      (lambda (omega)
-              ((omega
-                (((covariant-derivative sphere-Cartan gamma:N->M)
-                  d/dt)
-                 w))
-               ((the-real-line '->point) 'tau)))
-      (basis->1form-basis basis-over-gamma)))
-    #| Result:
+      (fn (omega)
+        ((omega
+          (((covariant-derivative sphere-Cartan gamma:N->M)
+            d/dt)
+           w))
+         ((the-real-line '->point) 'tau)))
+      (basis->oneform-basis basis-over-gamma)))
+    ;; Result:
     (up
      (+ (* -1 (sin (alpha tau)) ((D beta) tau) (w1 tau) (cos (alpha tau)))
         ((D w0) tau))
      (+ (/ (* (w0 tau) ((D beta) tau) (cos (alpha tau))) (sin (alpha tau)))
         (/ (* (w1 tau) ((D alpha) tau) (cos (alpha tau))) (sin (alpha tau)))
         ((D w1) tau)))
-    |#
+
     )
 
   (testing "geodesic-equations"
     (pec
      (s:map/r
-      (lambda (omega)
-              ((omega
-                (((covariant-derivative sphere-Cartan gamma:N->M)
-                  d/dt)
-                 ((differential gamma:N->M) d/dt)))
-               ((the-real-line '->point) 't)))
-      (basis->1form-basis basis-over-gamma)))
+      (fn (omega)
+        ((omega
+          (((covariant-derivative sphere-Cartan gamma:N->M)
+            d/dt)
+           ((differential gamma:N->M) d/dt)))
+         ((the-real-line '->point) 't)))
+      (basis->oneform-basis basis-over-gamma)))
 
-    #| Result:
+    ;; Result:
     (up
      (+ (* -1 (sin (alpha t)) (expt ((D beta) t) 2) (cos (alpha t)))
         (((expt D 2) alpha) t))
      (+ (/ (* 2 ((D beta) t) (cos (alpha t)) ((D alpha) t)) (sin (alpha t)))
         (((expt D 2) beta) t)))
-    |#
-    |#
-    ;;; Geodesic equation
+
+
+    ;; Geodesic equation
 
     (define-coordinates (up x y) R2-rect)
 
     (define (Gijk i j k)
       (literal-manifold-function
        (string->symbol
-        (string-append "G^"
+        (string-append "G↑"
                        (number->string i)
                        "_"
                        (number->string j)
@@ -756,72 +754,72 @@
 
     (pec
      (s:map/r
-      (lambda (omega)
-              ((omega
-                (((covariant-derivative (Christoffel->Cartan CG) gamma:N->M)
-                  d/dt)
-                 u))
-               ((the-real-line '->point) 't)))
-      (basis->1form-basis basis-over-gamma)))
-    #| Result:
+      (fn (omega)
+        ((omega
+          (((covariant-derivative (Christoffel->Cartan CG) gamma:N->M)
+            d/dt)
+           u))
+         ((the-real-line '->point) 't)))
+      (basis->oneform-basis basis-over-gamma)))
+    ;; Result:
     (up
-     (+ (* ((D alpha) t) (u0 t) (G^0_00 (up (alpha t) (beta t))))
-        (* ((D alpha) t) (u1 t) (G^0_10 (up (alpha t) (beta t))))
-        (* ((D beta) t) (u0 t) (G^0_01 (up (alpha t) (beta t))))
-        (* ((D beta) t) (u1 t) (G^0_11 (up (alpha t) (beta t))))
+     (+ (* ((D alpha) t) (u0 t) (G↑0_00 (up (alpha t) (beta t))))
+        (* ((D alpha) t) (u1 t) (G↑0_10 (up (alpha t) (beta t))))
+        (* ((D beta) t) (u0 t) (G↑0_01 (up (alpha t) (beta t))))
+        (* ((D beta) t) (u1 t) (G↑0_11 (up (alpha t) (beta t))))
         ((D u0) t))
-     (+ (* ((D alpha) t) (u0 t) (G^1_00 (up (alpha t) (beta t))))
-        (* ((D alpha) t) (u1 t) (G^1_10 (up (alpha t) (beta t))))
-        (* ((D beta) t) (u0 t) (G^1_01 (up (alpha t) (beta t))))
-        (* ((D beta) t) (u1 t) (G^1_11 (up (alpha t) (beta t))))
+     (+ (* ((D alpha) t) (u0 t) (G↑1_00 (up (alpha t) (beta t))))
+        (* ((D alpha) t) (u1 t) (G↑1_10 (up (alpha t) (beta t))))
+        (* ((D beta) t) (u0 t) (G↑1_01 (up (alpha t) (beta t))))
+        (* ((D beta) t) (u1 t) (G↑1_11 (up (alpha t) (beta t))))
         ((D u1) t)))
-    |#
+
 
     (pec
      (s:map/r
-      (lambda (omega)
-              ((omega
-                (((covariant-derivative (Christoffel->Cartan CG) gamma:N->M)
-                  d/dt)
-                 ((differential gamma:N->M) d/dt)))
-               ((the-real-line '->point) 't)))
-      (basis->1form-basis basis-over-gamma)))
-    #| Result:
+      (fn (omega)
+        ((omega
+          (((covariant-derivative (Christoffel->Cartan CG) gamma:N->M)
+            d/dt)
+           ((differential gamma:N->M) d/dt)))
+         ((the-real-line '->point) 't)))
+      (basis->oneform-basis basis-over-gamma)))
+    ;; Result:
     (up
-     (+ (* (expt ((D alpha) t) 2) (G^0_00 (up (alpha t) (beta t))))
-        (* ((D alpha) t) ((D beta) t) (G^0_01 (up (alpha t) (beta t))))
-        (* ((D alpha) t) ((D beta) t) (G^0_10 (up (alpha t) (beta t))))
-        (* (expt ((D beta) t) 2) (G^0_11 (up (alpha t) (beta t))))
+     (+ (* (expt ((D alpha) t) 2) (G↑0_00 (up (alpha t) (beta t))))
+        (* ((D alpha) t) ((D beta) t) (G↑0_01 (up (alpha t) (beta t))))
+        (* ((D alpha) t) ((D beta) t) (G↑0_10 (up (alpha t) (beta t))))
+        (* (expt ((D beta) t) 2) (G↑0_11 (up (alpha t) (beta t))))
         (((expt D 2) alpha) t))
-     (+ (* (expt ((D alpha) t) 2) (G^1_00 (up (alpha t) (beta t))))
-        (* ((D alpha) t) ((D beta) t) (G^1_01 (up (alpha t) (beta t))))
-        (* ((D alpha) t) ((D beta) t) (G^1_10 (up (alpha t) (beta t))))
-        (* (expt ((D beta) t) 2) (G^1_11 (up (alpha t) (beta t))))
+     (+ (* (expt ((D alpha) t) 2) (G↑1_00 (up (alpha t) (beta t))))
+        (* ((D alpha) t) ((D beta) t) (G↑1_01 (up (alpha t) (beta t))))
+        (* ((D alpha) t) ((D beta) t) (G↑1_10 (up (alpha t) (beta t))))
+        (* (expt ((D beta) t) 2) (G↑1_11 (up (alpha t) (beta t))))
         (((expt D 2) beta) t)))
-    |#
 
 
-    #|
-;;;; Geodesic Equations = Lagrange Equations
 
-;;; Here I restrict everything to the unit sphere.
-;;; The coordinates on the unit sphere
+
+;;; Geodesic Equations = Lagrange Equations
+
+    ;; Here I restrict everything to the unit sphere.
+    ;; The coordinates on the unit sphere
 
     (define-coordinates t R1-rect)
     (define-coordinates (up theta phi) S2-spherical)
 
-    (define 2-sphere-basis (coordinate-system->basis S2-spherical))
+    (define two-sphere-basis (coordinate-system->basis S2-spherical))
 
-;;; The Christoffel symbols (for r=1) (p.341 MTW) are:
+    ;; The Christoffel symbols (for r=1) (p.341 MTW) are:
 
     (define G-S2-1
       (make-Christoffel
-       (let ((zero  (lambda (point) 0)))
+       (let ((zero  (fn (point) 0)))
          (down (down (up zero zero)
                      (up zero (/ 1 (tan theta))))
                (down (up zero (/ 1 (tan theta)))
                      (up (- (* (sin theta) (cos theta))) zero))))
-       2-sphere-basis))
+       two-sphere-basis))
 
     (pec (let ((mu:N->M (compose (S2-spherical '->point)
                                  (up (literal-function 'mu-theta)
@@ -829,15 +827,15 @@
                                  (R1-rect '->coords)))
                (Cartan (Christoffel->Cartan G-S2-1)))
            (s:map/r
-            (lambda (w)
-                    ((w
-                      (((covariant-derivative Cartan mu:N->M) d/dt)
-                       ((differential mu:N->M) d/dt)))
-                     ((R1-rect '->point) 'tau)))
-            (basis->1form-basis
+            (fn (w)
+              ((w
+                (((covariant-derivative Cartan mu:N->M) d/dt)
+                 ((differential mu:N->M) d/dt)))
+               ((R1-rect '->point) 'tau)))
+            (basis->oneform-basis
              (basis->basis-over-map mu:N->M
                                     (Cartan->basis Cartan))))))
-    #| Result:
+    ;; Result:
     (up (+ (* -1
               (expt ((D mu-phi) tau) 2)
               (cos (mu-theta tau))
@@ -848,11 +846,10 @@
                  ((D mu-theta) tau))
               (sin (mu-theta tau)))
            (((expt D 2) mu-phi) tau)))
-    |#
-    
-;;; We can get the geodesic equations as ordinary Lagrange
-;;; equations of a free particle constrained to the surface
-;;; of the sphere:
+
+    ;; We can get the geodesic equations as ordinary Lagrange
+    ;; equations of a free particle constrained to the surface
+    ;; of the sphere:
 
     (define ((Lfree m) s)
       (let ((t (time s))
@@ -860,23 +857,23 @@
             (v (velocity s)))
         (* 1/2 m (square v))))
 
-    #|
-;;; F is really the embedding map, from the coordinates on the sphere
-;;; to the 3-space coordinates in the embedding manifold.
 
-;;; This hides the assumption that the R3 manifold is the same one as
-;;; the embedding manifold.
+    ;; F is really the embedding map, from the coordinates on the sphere
+    ;; to the 3-space coordinates in the embedding manifold.
+
+    ;; This hides the assumption that the R3 manifold is the same one as
+    ;; the embedding manifold.
 
     (define F
       (compose (R3-rect '->coords)
                (S2-spherical '->point)
                coordinate))
 
-;;; Actually (9 June 2009--GJS) this no longer works, because R3-rect
-;;; does not accept an S2-spherical point as in the same manifold.
+    ;; Actually (9 June 2009--GJS) this no longer works, because R3-rect
+    ;; does not accept an S2-spherical point as in the same manifold.
 
-;;; Fixed by explicit transfer of a point -- see manifold.scm
-    |#
+    ;; Fixed by explicit transfer of a point -- see manifold.scm
+
 
 
     (define F
@@ -892,26 +889,25 @@
            (up (literal-function 'theta)
                (literal-function 'phi)))
           't))
-    #| Result:
+    ;; Result:
     (down
      (+ (((expt D 2) theta) t)
         (* -1 (cos (theta t)) (sin (theta t)) (expt ((D phi) t) 2)))
      (+ (* (expt (sin (theta t)) 2) (((expt D 2) phi) t))
         (* 2 (cos (theta t)) (sin (theta t)) ((D phi) t) ((D theta) t))))
-    |#
 
 
-;;; Note these are DOWN while the geodesic equations are UP.  This is
-;;; due to the fact that the geodesic equations are raised by the
-;;; metric, which is diagonal, here R=1, and cancels an instance
-;;; of(expt (sin theta) 2).
 
-;;; Also see p.345 MTW for computing Christoffel symbols from Lagrange
-;;; equations.
-    |#
-    
-    #|
-;;; Exercise on computation of Christoffel symbols.
+    ;; Note these are DOWN while the geodesic equations are UP.  This is
+    ;; due to the fact that the geodesic equations are raised by the
+    ;; metric, which is diagonal, here R=1, and cancels an instance
+    ;; of(expt (sin theta) 2).
+
+    ;; Also see p.345 MTW for computing Christoffel symbols from Lagrange
+    ;; equations.
+
+
+    ;; Exercise on computation of Christoffel symbols.
 
     (install-coordinates R3-rect (up 'x 'y 'z))
     (define R3-rect-point ((R3-rect '->point) (up 'x0 'y0 'z0)))
@@ -922,66 +918,65 @@
     (define mpr (R3-rect '->coords))
 
     (pec (((* d/dr d/dr) mpr) R3-rect-point))
-    #| Result:
+    ;; Result:
     (up 0 0 0)
-    |#
-;;; So \Gamma^r_{rr} = 0, \Gamma^\theta_{rr} = 0
+
+    ;; So \Gamma↑r_{rr} = 0, \Gamma↑\theta_{rr} = 0
 
     (pec (((* d/dtheta d/dr) mpr) R3-rect-point))
-    #| Result:
+    ;; Result:
     (up (/ (* -1 y0) (sqrt (+ (expt x0 2) (expt y0 2))))
         (/ x0 (sqrt (+ (expt x0 2) (expt y0 2))))
         0)
-    |#
-;;; by hand = -sint d/dx + cost d/dy = 1/r d/dtheta
-;;; Indeed.
+
+    ;; by hand = -sint d/dx + cost d/dy = 1/r d/dtheta
+    ;; Indeed.
 
     (pec (((* d/dtheta d/dr) mpr) R3-cyl-point))
-    #| Result:
+    ;; Result:
     (up (* -1 (sin theta0)) (cos theta0) 0)
-    |#
-;;; So \Gamma^r_{r\theta} = 0, \Gamma^\theta_{r\theta} = 1/r
+
+    ;; So \Gamma↑r_{r\theta} = 0, \Gamma↑\theta_{r\theta} = 1/r
 
     (pec (((* d/dr d/dtheta) mpr) R3-rect-point))
-    #| Result:
+    ;; Result:
     (up (/ (* -1 y0) (sqrt (+ (expt x0 2) (expt y0 2))))
         (/ x0 (sqrt (+ (expt x0 2) (expt y0 2))))
         0)
-    |#
-;;; by hand = -sint d/dx + cost d/dy = 1/r d/dtheta
+
+    ;; by hand = -sint d/dx + cost d/dy = 1/r d/dtheta
 
     (pec (((* d/dr d/dtheta) mpr) R3-cyl-point))
-    #| Result:
+    ;; Result:
     (up (* -1 (sin theta0)) (cos theta0) 0)
-    |#
-;;; So \Gammar_{\theta r} = 0, \Gamma\theta_{\theta r} = 1/r
+
+    ;; So \Gammar_{\theta r} = 0, \Gamma\theta_{\theta r} = 1/r
 
     (pec (((* d/dtheta d/dtheta) mpr) R3-rect-point))
-    #| Result:
+    ;; Result:
     (up (* -1 x0) (* -1 y0) 0)
-    |#
-;;; by hand = -r cost d/dx - r sint d/dy = -r d/dr
+
+    ;; by hand = -r cost d/dx - r sint d/dy = -r d/dr
 
     (pec (((* d/dtheta d/dtheta) mpr) R3-cyl-point))
-    #| Result:
+    ;; Result:
     (up (* -1 r0 (cos theta0)) (* -1 r0 (sin theta0)) 0)
-    |#
-;;; So \Gammar_{\theta \theta} = -r, \Gamma\theta_{\theta \theta} = 0
 
-;;; These are correct Christoffel symbols...
-    |#
-    
-    #|
-;;; Computation of Covariant derivatives by difference quotient.
-;;; CD below is parallel in definition to the Lie Derivative.
-;;; Does not seem to depend on a derivative of basis vectors, in fact
-;;; the derivative of the basis vectors is multiplied by zero in the
-;;; product rule output.
+    ;; So \Gammar_{\theta \theta} = -r, \Gamma\theta_{\theta \theta} = 0
+
+    ;; These are correct Christoffel symbols...
+
+
+    ;; Computation of Covariant derivatives by difference quotient.
+    ;; CD below is parallel in definition to the Lie Derivative.
+    ;; Does not seem to depend on a derivative of basis vectors, in fact
+    ;; the derivative of the basis vectors is multiplied by zero in the
+    ;; product rule output.
 
     (define (Gijk i j k)
       (literal-manifold-function
        (string->symbol
-        (string-append "G^"
+        (string-append "G↑"
                        (number->string i)
                        "_"
                        (number->string j)
@@ -1017,27 +1012,27 @@
       (define (sigma-u sigma u) (up sigma u))
 
       (define chi (chart '->coords))
-      (define chi^-1 (chart '->point))
+      (define chi↑-1 (chart '->point))
 
       ;; ((gamma m) delta) is the point on gamma advanced by delta.
 
       (define ((gamma m) delta)
-        (chi^-1 (+ (chi m) (* delta ((v chi) m)))))
+        (chi↑-1 (+ (chi m) (* delta ((v chi) m)))))
 
       (let ((basis (Cartan->basis CF)))
         (let ((vector-basis (basis->vector-basis basis))
-              (1form-basis (basis->1form-basis basis)))
-          (let ((u^i (1form-basis u)))
+              (oneform-basis (basis->oneform-basis basis)))
+          (let ((u↑i (oneform-basis u)))
             (let ((initial-state
-                   (sigma-u (chi m) (u^i m))))
+                   (sigma-u (chi m) (u↑i m))))
 
               (define (bs state)
                 (let ((sigma (Sigma state)))
-                  (let ((m_0 (chi^-1 sigma)))
+                  (let ((m_0 (chi↑-1 sigma)))
                     (up ((v chi) m_0)
                         (* -1
                            (((Cartan->forms CF) v) m_0)
-                           (u^i m_0))))))
+                           (u↑i m_0))))))
 
               (define (vs fs)
                 (* (D fs) bs))
@@ -1050,12 +1045,12 @@
 
               (define (g delta)
                 (let ((advanced-m ((gamma m) delta)))
-                  (* (- (u^i advanced-m) (Au delta))
+                  (* (- (u↑i advanced-m) (Au delta))
                      ((vector-basis F) advanced-m))))
 
               ((D g) 0))))))
 
-;;; A bit simpler, but lacking in motivation?
+    ;; A bit simpler, but lacking in motivation?
 
     (define (((((CD CF chart) v) u) F) m)
 
@@ -1064,31 +1059,31 @@
       (define (sigma-u sigma u) (up sigma u))
 
       (define chi (chart '->coords))
-      (define chi^-1 (chart '->point))
+      (define chi↑-1 (chart '->point))
 
       ;; ((gamma m) delta) is the point on gamma advanced by delta.
 
       (define ((gamma m) delta)
-        (chi^-1 (+ (chi m) (* delta ((v chi) m)))))
+        (chi↑-1 (+ (chi m) (* delta ((v chi) m)))))
 
       (let ((basis (Cartan->basis CF)))
         (let ((vector-basis (basis->vector-basis basis))
-              (1form-basis (basis->1form-basis basis)))
-          (let ((u^i (1form-basis u)))
+              (oneform-basis (basis->oneform-basis basis)))
+          (let ((u↑i (oneform-basis u)))
             (let ((initial-state
-                   (sigma-u (chi m) (u^i m))))
+                   (sigma-u (chi m) (u↑i m))))
 
               ;; First-order approximation to A
 
               (define (Au delta)
-                (- (u^i m)
+                (- (u↑i m)
                    (* delta
                       (((Cartan->forms CF) v) m)
-                      (u^i m))))
+                      (u↑i m))))
 
               (define (g delta)
                 (let ((advanced-m ((gamma m) delta)))
-                  (* (- (u^i advanced-m) (Au delta))
+                  (* (- (u↑i advanced-m) (Au delta))
                      ((vector-basis F) advanced-m))))
 
               ((D g) 0))))))
@@ -1121,15 +1116,14 @@
              (((((covariant-derivative CF) X) Y) F) m_0))))
     0
                                         ;Too slow...                            ; ; ; ; ; ; ; ; ; ; ; ; ; ;
-    |#
-    
-    #|
-;;; Testing on forms.
+
+
+    ;; Testing on forms.
 
     (define (Gijk i j k)
       (literal-manifold-function
        (string->symbol
-        (string-append "G^"
+        (string-append "G↑"
                        (number->string i)
                        "_"
                        (number->string j)
@@ -1150,7 +1144,7 @@
 
     (define Y (literal-vector-field 'Y R2-rect))
 
-    (define omega (literal-1form-field 'omega R2-rect))
+    (define omega (literal-oneform-field 'omega R2-rect))
 
     (define q_0 (up 'q_x 'q_y))
 
@@ -1169,7 +1163,7 @@
     0
 
 
-    (define tau (literal-1form-field 'tau R2-rect))
+    (define tau (literal-oneform-field 'tau R2-rect))
 
     (define Z (literal-vector-field 'Z R2-rect))
 
@@ -1190,26 +1184,26 @@
              (+ (((wedge omega (D_x tau)) Y Z) m_0)
                 (((wedge (D_x omega) tau) Y Z) m_0)))))
     0
-    |#
+
 
     ;; Next, tests, for the actual functions:
-    #|
+
     (((geodesic-equation the-real-line R2-rect (literal-Cartan 'G R2-rect))
       (literal-manifold-map 'gamma the-real-line R2-rect))
      ((point the-real-line) 't))
-    #|
+
     (up
-     (+ (* (expt ((D gamma0) t) 2) (G_00^0 (up (gamma0 t) (gamma1 t))))
-        (* ((D gamma0) t) ((D gamma1) t) (G_10^0 (up (gamma0 t) (gamma1 t))))
-        (* ((D gamma0) t) ((D gamma1) t) (G_01^0 (up (gamma0 t) (gamma1 t))))
-        (* (expt ((D gamma1) t) 2) (G_11^0 (up (gamma0 t) (gamma1 t))))
+     (+ (* (expt ((D gamma0) t) 2) (G_00↑0 (up (gamma0 t) (gamma1 t))))
+        (* ((D gamma0) t) ((D gamma1) t) (G_10↑0 (up (gamma0 t) (gamma1 t))))
+        (* ((D gamma0) t) ((D gamma1) t) (G_01↑0 (up (gamma0 t) (gamma1 t))))
+        (* (expt ((D gamma1) t) 2) (G_11↑0 (up (gamma0 t) (gamma1 t))))
         (((expt D 2) gamma0) t))
-     (+ (* (expt ((D gamma0) t) 2) (G_00^1 (up (gamma0 t) (gamma1 t))))
-        (* ((D gamma0) t) ((D gamma1) t) (G_10^1 (up (gamma0 t) (gamma1 t))))
-        (* ((D gamma0) t) ((D gamma1) t) (G_01^1 (up (gamma0 t) (gamma1 t))))
-        (* (expt ((D gamma1) t) 2) (G_11^1 (up (gamma0 t) (gamma1 t))))
+     (+ (* (expt ((D gamma0) t) 2) (G_00↑1 (up (gamma0 t) (gamma1 t))))
+        (* ((D gamma0) t) ((D gamma1) t) (G_10↑1 (up (gamma0 t) (gamma1 t))))
+        (* ((D gamma0) t) ((D gamma1) t) (G_01↑1 (up (gamma0 t) (gamma1 t))))
+        (* (expt ((D gamma1) t) 2) (G_11↑1 (up (gamma0 t) (gamma1 t))))
         (((expt D 2) gamma1) t)))
-    |#
+
 
 
     (let ((C (literal-Cartan 'G R2-rect)))
@@ -1219,18 +1213,18 @@
          (((geodesic-equation the-real-line R2-rect (symmetrize-Cartan C))
            (literal-manifold-map 'gamma the-real-line R2-rect))
           ((point the-real-line) 't))))
-    #|
+
     (up 0 0)
-    |#
-    |#
+
+
 
 
     )
 
   (testing "parallel-transport-equation"
 
-    #|
-    (define M (make-manifold S^2-type 2 3))
+
+    (define M (make-manifold S↑2-type 2 3))
     (define S2-spherical
       (coordinate-system-at 'spherical 'north-pole M))
     (define-coordinates (up theta phi) S2-spherical)
@@ -1239,7 +1233,7 @@
 
     (define G-S2-1
       (make-Christoffel
-       (let ((zero  (lambda (point) 0)))
+       (let ((zero  (fn (point) 0)))
          (down (down (up zero zero)
                      (up zero (/ 1 (tan theta))))
                (down (up zero (/ 1 (tan theta)))
@@ -1261,9 +1255,9 @@
 
     (define u
       (basis-components->vector-field
-       (up (compose (literal-function 'u^0)
+       (up (compose (literal-function 'u↑0)
                     (chart the-real-line))
-           (compose (literal-function 'u^1)
+           (compose (literal-function 'u↑1)
                     (chart the-real-line)))
        (basis->vector-basis basis-over-gamma)))
 
@@ -1276,13 +1270,10 @@
       u)
      ((point the-real-line) 't))
 
-    #|
-    (up
-     (+ (* -1 (sin (alpha t)) ((D beta) t) (u^1 t) (cos (alpha t))) ((D u^0) t))
-     (+ (/ (* (u^0 t) ((D beta) t) (cos (alpha t))) (sin (alpha t)))
-        (/ (* (u^1 t) ((D alpha) t) (cos (alpha t))) (sin (alpha t)))
-        ((D u^1) t)))
-    |#
-    |#
 
+    (up
+     (+ (* -1 (sin (alpha t)) ((D beta) t) (u↑1 t) (cos (alpha t))) ((D u↑0) t))
+     (+ (/ (* (u↑0 t) ((D beta) t) (cos (alpha t))) (sin (alpha t)))
+        (/ (* (u↑1 t) ((D alpha) t) (cos (alpha t))) (sin (alpha t)))
+        ((D u↑1) t)))
     ))

--- a/test/sicmutils/calculus/curvature_test.cljc
+++ b/test/sicmutils/calculus/curvature_test.cljc
@@ -32,11 +32,9 @@
             [sicmutils.calculus.map :as cm]
             [sicmutils.calculus.vector-field :as vf]
             [sicmutils.mechanics.lagrange :refer [osculating-path]]
-            [sicmutils.mechanics.rotation :refer [rotate-x]]
-            [sicmutils.numerical.ode :refer [state-advancer]]
             [sicmutils.expression :as x]
             [sicmutils.function :refer [compose]]
-            [sicmutils.generic :as g :refer [+ - * / sin cos]]
+            [sicmutils.generic :as g :refer [+ - * /]]
             [sicmutils.operator :as o]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
             [sicmutils.structure :as s :refer [up down]]
@@ -66,58 +64,6 @@
                                  (g/cos theta)))
                            zero)))]
     (cov/make-Christoffel symbols basis)))
-
-(defn transform
-  "P.109"
-  [tilt]
-  (fn [[colat long]]
-    (let [x (* (g/sin colat) (g/cos long))
-          y (* (g/sin colat) (g/sin long))
-          z    (g/cos colat)
-          [vp0 vp1 vp2] ((rotate-x tilt) (up x y z))
-          colatp (g/acos vp2)
-          longp (g/atan vp1 vp0)]
-      (up colatp longp))))
-
-(defn tilted-path
-  "P.110. Use `letfn` internally so we don't bind `coords` in the namespace; this
-  keeps it a named private definition."
-  [source target tilt]
-  (let [xform (transform tilt)]
-    (letfn [(coords [t]
-              (xform (up (/ Math/PI 2) t)))]
-      (compose (m/point target)
-               coords
-               (m/chart source)))))
-
-(deftest new-test-move-to-ch-7
-  (let-coordinates [[theta phi] m/S2-spherical
-                    t           m/R1-rect]
-    (let [S2-basis       (b/coordinate-system->basis S2-spherical)
-          S2-Christoffel (S2-Christoffel S2-basis theta)
-          sphere-Cartan  (cov/Christoffel->Cartan S2-Christoffel)
-          g (fn [gamma Cartan]
-              (let [omega ((cov/Cartan->forms
-                            (cov/Cartan->Cartan-over-map Cartan gamma))
-                           ;; NOTE THE DIFFERENCE!!!
-                           d:dt)]
-                (fn []
-                  (fn [[t u]]
-                    (let [t-point ((m/point R1-rect) t)]
-                      (up 1 (* -1 (omega t-point) u)))))))
-          integrator    (state-advancer
-                         (g (tilted-path R1-rect S2-spherical 1)
-                            sphere-Cartan))
-          initial-state (up 0 (* ((D (transform 1)) (up (/ Math/PI 2) 0)) (up 1 0)))]
-      (is (= (up 1.570796326794894
-                 (up 0.9999999999545687 -1.676680708092223E-10))
-             (integrator initial-state (/ Math/PI 2))))
-
-      (is (= (up 1.0 (up 0.7651502649161671 0.9117920274079562))
-             (integrator initial-state 1)))
-
-      (is (= (up 0.7651502649370375 0.9117920272004736)
-             (* ((D (transform 1)) (up (/ Math/PI 2) 1)) (up 1 0)))))))
 
 (deftest curvature-tests
   (testing "tests from curvature.scm"

--- a/test/sicmutils/examples/rigid_rotation_test.cljc
+++ b/test/sicmutils/examples/rigid_rotation_test.cljc
@@ -23,8 +23,8 @@
             [sicmutils.env :as e :refer [up + - * /]]
             [sicmutils.examples.rigid-rotation :as rigid-rotation]
             [sicmutils.mechanics.rigid :as rigid]
-            [sicmutils.simplify :refer [hermetic-simplify-fixture]]
-            [sicmutils.polynomial.gcd :as pg]))
+            [sicmutils.polynomial.gcd :as pg]
+            [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
 
 (use-fixtures :each hermetic-simplify-fixture)
 

--- a/test/sicmutils/fdg/ch7_test.cljc
+++ b/test/sicmutils/fdg/ch7_test.cljc
@@ -20,7 +20,8 @@
 (ns sicmutils.fdg.ch7-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])
   (:require [clojure.test :refer [is deftest testing use-fixtures]]
-            [same :refer [ish?]]
+            [same :refer [ish? with-comparator]
+             #?@(:cljs [:include-macros true])]
             [sicmutils.env :as e :refer [+ - * / zero?
                                          D d freeze simplify partial
                                          up down exp
@@ -308,15 +309,16 @@
                            (g (tilted-path R1-rect S2-spherical 1)
                               sphere-Cartan))
             initial-state (up 0 (* ((D (transform 1)) (up (/ e/pi 2) 0)) (up 1 0)))]
-        (is (ish? (up 1.570796326794894
-                      (up 0.9999999999545687 -1.676680708092223E-10))
-                  (integrator initial-state (/ e/pi 2))))
+        (with-comparator (v/within 1e-6)
+          (is (ish? (up 1.570796326794894
+                        (up 0.9999999999545687 -1.676680708092223E-10))
+                    (integrator initial-state (/ e/pi 2))))
 
-        (is (ish? (up 1.0 (up 0.7651502649161671 0.9117920274079562))
-                  (integrator initial-state 1)))
+          (is (ish? (up 1.0 (up 0.7651502649161671 0.9117920274079562))
+                    (integrator initial-state 1)))
 
-        (is (ish? (up 0.7651502649370375 0.9117920272004736)
-                  (* ((D (transform 1)) (up (/ e/pi 2) 1)) (up 1 0))))))))
+          (is (ish? (up 0.7651502649370375 0.9117920272004736)
+                    (* ((D (transform 1)) (up (/ e/pi 2) 1)) (up 1 0)))))))))
 
 (deftest section-7-4
   (let-coordinates [[theta phi] S2-spherical

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -25,6 +25,7 @@
             [sicmutils.util.vector-set :as vs]
             [sicmutils.value :as v])
   #?(:clj
+     (:import (sicmutils.structure Structure))
      (:import (org.apache.commons.math3.complex Complex))))
 
 (def bigint
@@ -412,4 +413,17 @@
           (and (si/*comparator* 0.0 (g/imag-part this))
                (si/*comparator*
                 (g/real-part this) (u/double that)))
-          :else (v/= this that))))
+          :else (v/= this that)))
+
+  #?(:cljs s/Structure :clj Structure)
+  (ish [this that]
+    (cond (instance? #?(:cljs s/Structure :clj Structure) that)
+          (and (s/same-orientation? this that)
+               (si/ish (s/structure->vector this)
+                       (s/structure->vector that)))
+
+          (s/up? this)
+          (cond (vector? that)   (si/ish (s/structure->vector this) that)
+                (seqable? that) (si/ish (seq this) (seq that))
+                :else false)
+          :else false)))

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -420,14 +420,9 @@
 
   Symbol
   (ish [this that]
-    (cond (symbol? that) (= this that)
-
-          (an/literal-number? that)
-          (let [expr (x/expression-of that)]
-            (and (symbol? expr)
-                 (= this expr)))
-
-          :else false))
+    (if (symbol? that)
+      (= this that)
+      (v/= this that)))
 
   #?(:cljs s/Structure :clj Structure)
   (ish [this that]
@@ -437,7 +432,7 @@
                        (s/structure->vector that)))
 
           (s/up? this)
-          (cond (vector? that)   (si/ish (s/structure->vector this) that)
+          (cond (vector? that)  (si/ish (s/structure->vector this) that)
                 (seqable? that) (si/ish (seq this) (seq that))
                 :else false)
           :else false)))

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -9,8 +9,10 @@
   (:require [clojure.test.check.generators :as gen]
             [same :refer [zeroish?]]
             [same.ish :as si]
+            [sicmutils.abstract.number :as an]
             [sicmutils.complex :as c]
             [sicmutils.differential :as d]
+            [sicmutils.expression :as x]
             [sicmutils.generic :as g]
             [sicmutils.matrix :as m]
             [sicmutils.modint :as mi]
@@ -25,8 +27,9 @@
             [sicmutils.util.vector-set :as vs]
             [sicmutils.value :as v])
   #?(:clj
-     (:import (sicmutils.structure Structure))
-     (:import (org.apache.commons.math3.complex Complex))))
+     (:import (clojure.lang Symbol)
+              (sicmutils.structure Structure)
+              (org.apache.commons.math3.complex Complex))))
 
 (def bigint
   "js/BigInt in cljs, clojure.lang.BigInt in clj."
@@ -414,6 +417,17 @@
                (si/*comparator*
                 (g/real-part this) (u/double that)))
           :else (v/= this that)))
+
+  Symbol
+  (ish [this that]
+    (cond (symbol? that) (= this that)
+
+          (an/literal-number? that)
+          (let [expr (x/expression-of that)]
+            (and (symbol? expr)
+                 (= this expr)))
+
+          :else false))
 
   #?(:cljs s/Structure :clj Structure)
   (ish [this that]

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -88,7 +88,37 @@
 
   (testing "string rep"
     (is (= "(up sin cos tan)" (x/expression->string
-                               (s/up g/sin g/cos g/tan))))))
+                               (s/up g/sin g/cos g/tan)))))
+
+  (testing "approximate equality of structures"
+    (is (not (ish? {:a 1 :b (s/up 1.99999999999999 3)}
+                   {:a 1.00000000000001 :b (s/down 2 3.0)}))
+        "nested approx values with OPPOSITE orientation are not ish?")
+
+    (is (ish? {:a 1 :b (s/up 1.99999999999999 3)}
+              {:a 1.00000000000001 :b (s/up 2 3.0)})
+        "nested approx values with the SAME orientation are ish?")
+
+    (is (ish? [1.99999999999999 3]
+              (s/down 2 3.0))
+        "One potential problem is that explicit on the left is approximately
+        equal to either an up or down on the right.")
+
+    (is (and (not (ish? (s/down 1.99999999999999 3)
+                        [2 3.0]))
+             (not (ish? (s/down 1.99999999999999 3)
+                        (s/up 2 3.0))))
+        "Down on the left DOES distinguish, and is not equal to a vector or up
+    on the right.")
+
+    (is (and (ish? (s/up 1.99999999999999 3)
+                   [2 3.0])
+             (ish? (s/up 1.99999999999999 3)
+                   (s/up 2 3.0))
+             (not (ish? (s/up 1.99999999999999 3)
+                        (s/down 2 3.0))))
+        "up on the left also distinguishes by being equal to a vector or up, but
+        not a down.")))
 
 (defn arity-check
   "Takes a constructor function `build` and a `descriptor` string, and executes a


### PR DESCRIPTION
This PR addresses issues noticed by @phasetr in ch7 of FDG. I also noticed a number of tests in `covariant_derivative.scm` that I had missed; porting those exposed a bug in the text, which is fixed as of this PR.

From the CHANGELOG:

  - `sicmutils.calculus.coordinate/generate` moves to
    `sicmutils.calculus.manifold/c:generate`; this supports a bugfix where
    1-dimensional manifolds like `R1-rect`, aka `the-real-line`, return a
    coordinate prototype of a single element like `t` instead of a structure
    with a single entry, like `(up t)`. Thanks to @phasetr for the bug report
    that led to this fix, and @gjs for finding and fixing the bug.

  - `same.ish/Approximate` implemented for `sicmutils.structure/Structure`,
    allowing `ish?` comparison of `up` and `down` structures with approximate
    entries. Require `sicmutils.generator` for this feature. (NOTE: because
    protocols are implemented for the LEFT argument, `(ish? <vector> (down
    ...))` will still return true if the values are approximately equal, even
    though a `<vector>` is technically an `up` and should NOT equal a `down`. Do
    an explicit conversion to `up` using `sicmutils.structure/vector->up` if
    this distinction is important.)

  - `same.ish/Approximate` now defers to `sicmutils.value/=` for equality
    between `Symbol` and other types. This lets `ish?` handle equality between
    symbols like `'x` and literal expressions that happen to wrap a single
    symbol.

  - `Cartan->Cartan-over-map` now does NOT compose `(differential map)` with its
    internal Cartan forms. This fixed a bug in a code listing in section 7.3 of
    FDG.

  - Section 7.3 of FDG implemented as tests in `sicmutils.fdg.ch7-test`.

  - Many new tests and explorations ported over from `covariant-derivative.scm`.
    These live in `sicmutils.calculus.covariant-test`.

  - timeout exceptions resulting from full GCD are now caught in tests using
    `sicmutils.simplify/hermetic-simplify-fixture`. Previously, setting a low
    timeout where simplification failed would catch and move on in normal work,
    but fail in tests where fixtures were applied.