### PR TITLE
Add define-coordinates implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+- new
+
+  - add `define-coordinates`, works in SCI too.
+
 - #386:
 
   - Aliases `sicmutils.mechanics.hamilton/phase-space-derivative` into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,21 @@
 
 ## [unreleased]
 
-- new
+- #393:
+
+  - Forms like `(let-coordinates [(up x y) R2-rect] ...)` will now work even if
+    `up` is not present in the environment. Previously this syntax was valid,
+    but only if `up` had been imported.
 
   - add `define-coordinates`, works in SCI too.
+
+  - TODO try to enable function `print-method`, note about how cider/nrepl
+    overwrites this
+
+  - fix `sicmutils.util` warning in cljs around `uuid`
+
+  - TODO convert all fdg book tests to use `define-coordinates`, matching what
+    is in the book.
 
 - #386:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,23 @@
     `up` is not present in the environment. Previously this syntax was valid,
     but only if `up` had been imported.
 
-  - add `define-coordinates`, works in SCI too.
+  - Adds the `sicmutils.calculus.coordinate/define-coordinates` macro, also
+    aliased into `sicmutils.env`. This macro allows you to write forms like
 
-  - TODO try to enable function `print-method`, note about how cider/nrepl
+```clj
+(define-coordinates (up t x y z) spacetime-rect)
+(define-coordinates [r theta] R2-polar)
+```
+
+  and install set of bindings for a manifold's coordinate functions, basis
+  vector fields and basis form fields into a namespace. This is used liberally
+  in Functional Differential Geometry. (You might still prefer `let-coordinates`
+  for temporary binding installation.)
+
+  - Adds new `print-method` implementations for Clojure's `AFunction` and
+    Clojurescript's `MetaFn` data structures.
+
+  try to enable function `print-method`, note about how cider/nrepl
     overwrites this
 
   - fix `sicmutils.util` warning in cljs around `uuid`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+## 0.20.0
+
 - #393:
 
   - Forms like `(let-coordinates [(up x y) R2-rect] ...)` will now work even if
@@ -21,16 +23,11 @@
   in Functional Differential Geometry. (You might still prefer `let-coordinates`
   for temporary binding installation.)
 
-  - Adds new `print-method` implementations for Clojure's `AFunction` and
-    Clojurescript's `MetaFn` data structures.
+  - Converts many of the `sicmutils.fdg` test namespaces to use the new
+    `define-coordinates` macro, making for a presentation closer to the book's.
 
-  try to enable function `print-method`, note about how cider/nrepl
-    overwrites this
-
-  - fix `sicmutils.util` warning in cljs around `uuid`
-
-  - TODO convert all fdg book tests to use `define-coordinates`, matching what
-    is in the book.
+  - Fixes a Clojurescript warning in `sicmutils.util` warning due to
+    redefinition of `clojure.core/uuid`
 
 - #386:
 

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   },
   "engines": {
     "npm": "6.14.8"
+  },
+  "devDependencies": {
+    "source-map-support": "^0.5.20"
   }
 }

--- a/src/sicmutils/calculus/coordinate.cljc
+++ b/src/sicmutils/calculus/coordinate.cljc
@@ -22,8 +22,9 @@
             [sicmutils.calculus.vector-field :as vf]
             [sicmutils.calculus.form-field :as ff]
             [sicmutils.structure :as s]
-            [sicmutils.util :as u]
-            [taoensso.timbre :as log]))
+            [sicmutils.util :as u])
+  #?(:clj
+     (:import (clojure.lang RT))))
 
 (defn coordinate-functions
   "Returns a structure similar to the [[manifold/coordinate-prototype]] of
@@ -163,18 +164,22 @@
        `(def ~sym ~form))
 
      :clj
-     (let [ns-sym  (ns-name ns)
-           nsm     (ns-map ns)
+     (let [ns-sym (ns-name ns)
+           nsm (ns-map ns)
            remote? (fn [sym]
                      (when-let [v (nsm sym)]
                        (not= *ns* (:ns (meta v)))))
            warn (fn [sym]
-                  `(log/warn '~sym
-                             "already refers to:"
-                             ~ (nsm sym)
-                             (str "in namespace:" '~ns-sym ",")
-                             "being replaced by:"
-                             ~(str "#'" ns-sym "/" sym)))]
+                  `(.println
+                    (RT/errPrintWriter)
+                    (str "WARNING: "
+                         '~sym
+                         " already refers to: "
+                         ~(nsm sym)
+                         " in namespace: "
+                         '~ns-sym
+                         ", being replaced by: "
+                         ~(str "#'" ns-sym "/" sym))))]
        (fn [sym form]
          (if (remote? sym)
            `(do

--- a/src/sicmutils/calculus/coordinate.cljc
+++ b/src/sicmutils/calculus/coordinate.cljc
@@ -23,9 +23,7 @@
             [sicmutils.calculus.form-field :as ff]
             [sicmutils.structure :as s]
             [sicmutils.util :as u]
-            [sicmutils.util.def :as ud])
-  #?(:clj
-     (:import (clojure.lang RT))))
+            [sicmutils.util.def :as ud]))
 
 (defn coordinate-functions
   "Returns a structure similar to the [[manifold/coordinate-prototype]] of

--- a/src/sicmutils/calculus/coordinate.cljc
+++ b/src/sicmutils/calculus/coordinate.cljc
@@ -53,21 +53,25 @@
   (up 'x 'y)
   ```
 
-  Such an object is useful for [[structure/mapr]]. The function `xf` is applied
-  before quoting."
-  [xf p]
+  Such an object is useful for [[structure/mapr]]."
+  [p]
   (letfn [(q [p]
-            (cond (and (sequential? p)
-                       ('#{up down} (first p))) `(~(first p) ~@(map q (rest p)))
+            (cond (and (sequential? p) ('#{up down} (first p)))
+                  (let [s (first p)
+                        prefix (if (= s 'up)
+                                 `s/up
+                                 `s/down)]
+                    `(~prefix ~@(map q (rest p))))
+
                   (vector? p) (mapv q p)
-                  (symbol? p) `'~(xf p)
+                  (symbol? p) (list 'quote p)
                   :else (u/illegal "Invalid coordinate prototype")))]
     (q p)))
 
 (defn ^:no-doc symbols-from-prototype
-  "Generates a list of symbols from the supplied argument prototype. The protype
-  is allowed to be a vector, a list like `(up x y)` or a bare symbol. Anything
-  else causes an exception.
+  "Generates a list of symbols from the supplied argument prototype. The
+  prototype is allowed to be a vector, a list like `(up x y)` or a bare symbol.
+  Anything else causes an exception.
 
   Nested structures are fine! The return value is a flat sequence."
   [p]
@@ -119,7 +123,7 @@
     `(let [[~@system-names :as c-systems#]
            (mapv m/with-coordinate-prototype
                  ~(into [] c-systems)
-                 ~(mapv #(quotify-coordinate-prototype identity %) prototypes))
+                 ~(mapv quotify-coordinate-prototype prototypes))
 
            ~(into [] coordinate-names)
            (flatten
@@ -151,3 +155,39 @@
   [coordinate-prototype coordinate-system & body]
   `(let-coordinates [~coordinate-prototype ~coordinate-system]
      ~@body))
+
+(defmacro define-coordinates
+  "Give some `coordinate-system` like `R2-rect` and a `coordinate-prototype` like
+  `[x y]` or `(up x y), `binds the following definitions into the namespace
+  where [[define-coordinates]] is invoked:
+
+  - `R2-rect` binds to a new version of the coordinate system with its
+    `coordinate-prototype` replaced by the supplied prototype
+
+  - `x` and `y` bind to coordinate functions, ie, functions from manifold point
+  to that particular coordinate
+
+  - `d:dx` and `d:dy` bind to the corresponding vector field procedures
+
+  - `dx` and `dy` bind to 1-forms for each coordinate."
+  [coordinate-prototype coordinate-system]
+  (let [sys-name           (symbol (name coordinate-system))
+        coord-names        (symbols-from-prototype coordinate-prototype)
+        vector-field-names (map vf/coordinate-name->vf-name coord-names)
+        form-field-names   (map ff/coordinate-name->ff-name coord-names)
+        value-sym          (gensym)]
+    `(do
+       (def ~sys-name
+         (m/with-coordinate-prototype
+           ~coordinate-system
+           ~(quotify-coordinate-prototype coordinate-prototype)))
+
+       (let [~value-sym
+             (into [] (flatten
+                       [(coordinate-functions ~sys-name)
+                        (vf/coordinate-system->vector-basis ~sys-name)
+                        (ff/coordinate-system->oneform-basis ~sys-name)]))]
+         ~@(map-indexed
+            (fn [i sym]
+              `(def ~sym (nth ~value-sym ~i)))
+            (concat coord-names vector-field-names form-field-names))))))

--- a/src/sicmutils/calculus/coordinate.cljc
+++ b/src/sicmutils/calculus/coordinate.cljc
@@ -23,8 +23,7 @@
             [sicmutils.calculus.form-field :as ff]
             [sicmutils.structure :as s]
             [sicmutils.util :as u]
-            [sicmutils.util.def :as ud
-             #?@(:cljs [:include-macros true])])
+            [sicmutils.util.def :as ud])
   #?(:clj
      (:import (clojure.lang RT))))
 
@@ -158,53 +157,6 @@
   `(let-coordinates [~coordinate-prototype ~coordinate-system]
      ~@body))
 
-(defn ^:no-doc careful-def
-  "Given some namespace `ns`, returns a function of some binding symbol and a form
-  to bind. The function returns either
-
-  - A form like `(def ~sym ~form)`, if `sym` is not currently bound into `ns`
-
-  - If `sym` is bound already, returns a form that emits a warning and then
-    uses `ns-unmap` and `intern` to reassign the binding.
-
-  In Clojure, this behavior matches redefinitions of symbols bound in
-  `clojure.core`. Symbols bound with `def` that are already imported from other
-  namespaces cause an exception, hence this more careful workaround.
-
-  (In Clojurescript, only forms like `(def ~sym ~form)` are emitted, since the
-  compiler does not currently error in case 2 and already handles emitting the
-  warning for us.)"
-  [ns]
-  (ud/fork
-   :cljs
-   (fn [sym form]
-     `(def ~sym ~form))
-
-   :clj
-   (let [ns-sym (ns-name ns)
-         nsm (ns-map ns)
-         remote? (fn [sym]
-                   (when-let [v (nsm sym)]
-                     (not= *ns* (:ns (meta v)))))
-         warn (fn [sym]
-                `(.println
-                  (RT/errPrintWriter)
-                  (str "WARNING: "
-                       '~sym
-                       " already refers to: "
-                       ~(nsm sym)
-                       " in namespace: "
-                       '~ns-sym
-                       ", being replaced by: "
-                       ~(str "#'" ns-sym "/" sym))))]
-     (fn [sym form]
-       (if (remote? sym)
-         `(do
-            ~(warn sym)
-            (ns-unmap '~ns-sym '~sym)
-            (intern '~ns-sym '~sym ~form))
-         `(def ~sym ~form))))))
-
 (defmacro define-coordinates
   "Give some `coordinate-system` like `R2-rect` and a `coordinate-prototype` like
   `[x y]` or `(up x y), `binds the following definitions into the namespace
@@ -226,7 +178,7 @@
         form-field-names   (map ff/coordinate-name->ff-name coord-names)
         sys-sym            (gensym)
         value-sym          (gensym)
-        bind               (careful-def *ns*)]
+        bind               (ud/careful-def *ns*)]
     `(let [~sys-sym (m/with-coordinate-prototype
                       ~coordinate-system
                       ~(quotify-coordinate-prototype coordinate-prototype))]

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -125,6 +125,9 @@
 (defmacro using-coordinates [& args]
   `(cc/using-coordinates ~@args))
 
+(defmacro define-coordinates [& args]
+  `(cc/define-coordinates ~@args))
+
 (defn ref
   "A shim so that ref can act like nth in SICM contexts, as clojure core ref
   elsewhere."

--- a/src/sicmutils/env/sci/macros.cljc
+++ b/src/sicmutils/env/sci/macros.cljc
@@ -107,7 +107,7 @@
     `(let [[~@c-systems :as c-systems#]
            (mapv m/with-coordinate-prototype
                  ~(into [] c-systems)
-                 ~(mapv #(cc/quotify-coordinate-prototype identity %) prototypes))
+                 ~(mapv cc/quotify-coordinate-prototype prototypes))
 
            ~(into [] coordinate-names)
            (flatten
@@ -130,6 +130,30 @@
          [coordinate-prototype coordinate-system]
          body))
 
+(defn define-coordinates
+  "Originally defined in `sicmutils.calculus.coordinate`."
+  [_ _ coordinate-prototype coordinate-system]
+  (let [sys-name           (symbol (name coordinate-system))
+        coord-names        (cc/symbols-from-prototype coordinate-prototype)
+        vector-field-names (map vf/coordinate-name->vf-name coord-names)
+        form-field-names   (map ff/coordinate-name->ff-name coord-names)
+        value-sym          (gensym)]
+    `(do
+       (def ~sys-name
+         (m/with-coordinate-prototype
+           ~coordinate-system
+           ~(cc/quotify-coordinate-prototype coordinate-prototype)))
+
+       (let [~value-sym
+             (into [] (flatten
+                       [(cc/coordinate-functions ~sys-name)
+                        (vf/coordinate-system->vector-basis ~sys-name)
+                        (ff/coordinate-system->oneform-basis ~sys-name)]))]
+         ~@(map-indexed
+            (fn [i sym]
+              `(def ~sym (nth ~value-sym ~i)))
+            (concat coord-names vector-field-names form-field-names))))))
+
 (defn- tag-as-macro [f]
   (vary-meta f assoc :sci/macro true))
 
@@ -137,7 +161,8 @@
   {'literal-function       (tag-as-macro literal-function)
    'with-literal-functions (tag-as-macro with-literal-functions)
    'let-coordinates        (tag-as-macro let-coordinates)
-   'using-coordinates      (tag-as-macro using-coordinates)})
+   'using-coordinates      (tag-as-macro using-coordinates)
+   'define-coordinates     (tag-as-macro define-coordinates)})
 
 (def pattern-macros
   {'pattern     (tag-as-macro pattern)
@@ -155,4 +180,5 @@
    (select-keys all ['with-literal-functions])
 
    'sicmutils.calculus.coordinate
-   (select-keys all ['let-coordinates 'using-coordinates])})
+   (select-keys all ['let-coordinates 'using-coordinates
+                     'define-coordinates])})

--- a/src/sicmutils/function.cljc
+++ b/src/sicmutils/function.cljc
@@ -200,33 +200,6 @@
           (apply f (map g/* xs factors)))
         (with-meta {:arity (arity f)}))))
 
-(defn install-fn-printers!
-  "NOTE: If you are using Emacs + cider-nrepl, these two `print-method`
-  implementations will not be installed. I'm currently working on a fix to get
-  this enabled in the Emacs environment... But if you want to test this feature
-  out, simply execute these forms.
-  https://github.com/clojure-emacs/cider-nrepl/blob/master/src/cider/nrepl/print_method.clj#L42-L71
-
-  TODO write a with-methods instead to do this..."
-  []
-  #?(:clj
-     (do
-       (defmethod print-method AFunction [f ^java.io.Writer w]
-         (.write w (.toString ^Object (v/freeze f))))
-
-       (defmethod print-method MultiFn [f ^java.io.Writer w]
-         (.write w (.toString ^Object (v/freeze f)))))
-
-     :cljs
-     (extend-protocol IPrintWithWriter
-       MetaFn
-       (-pr-writer [x writer _]
-         (write-all writer (.toString (v/freeze x))))
-
-       MultiFn
-       (-pr-writer [x writer _]
-         (write-all writer (.toString (v/freeze x)))))))
-
 (extend-protocol v/Value
   MultiFn
   (zero? [_] false)

--- a/src/sicmutils/function.cljc
+++ b/src/sicmutils/function.cljc
@@ -34,7 +34,7 @@
             [sicmutils.util :as u]
             [sicmutils.value :as v])
   #?(:clj
-     (:import (clojure.lang RestFn Fn MultiFn Keyword Symbol Var)
+     (:import (clojure.lang AFunction RestFn Fn MultiFn Keyword Symbol Var)
               (java.lang.reflect Method))))
 
 ;; ## Function Algebra
@@ -200,6 +200,25 @@
           (apply f (map g/* xs factors)))
         (with-meta {:arity (arity f)}))))
 
+#?(:clj
+   ;; TODO how to get this enabled?
+   ;;
+   ;; Ah, cider is setting one.
+   (defmethod print-method AFunction [^AFunction f ^java.io.Writer w]
+     (.write w (.toString (v/freeze f))))
+
+   ;; TODO do something similar for multifns if we can get the
+   ;; cider.nrepl.print-method ones disabled, if we in fact want to keep these.
+   ;; But maybe the right thing to do is to just force `freeze` for this... for
+   ;; functions.
+   )
+
+#?(:cljs
+   (extend-protocol IPrintWithWriter
+     MetaFn
+     (-pr-writer [x writer _]
+       (write-all writer (.toString (v/freeze x))))))
+
 (extend-protocol v/Value
   MultiFn
   (zero? [_] false)
@@ -215,7 +234,7 @@
       (core-get @v/object-name-map f f)))
   (kind [o] ::v/function)
 
-  #?(:clj Fn :cljs function)
+  #?(:clj AFunction :cljs function)
   (zero? [_] false)
   (one? [_] false)
   (identity? [_] false)

--- a/src/sicmutils/function.cljc
+++ b/src/sicmutils/function.cljc
@@ -34,7 +34,7 @@
             [sicmutils.util :as u]
             [sicmutils.value :as v])
   #?(:clj
-     (:import (clojure.lang AFunction RestFn Fn MultiFn Keyword Symbol Var)
+     (:import (clojure.lang AFunction RestFn MultiFn Keyword Symbol Var)
               (java.lang.reflect Method))))
 
 ;; ## Function Algebra
@@ -380,7 +380,7 @@
 
 #?(:clj
    (extend-protocol IArity
-     Fn
+     AFunction
      (arity [f] (:arity (meta f) (reflect-on-arity f))))
 
    :cljs

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -24,7 +24,7 @@
                            int core-int
                            long core-long
                            double core-double}
-                  #?@(:cljs [:exclude [bigint double long int]]))
+                  #?@(:cljs [:exclude [bigint double long int uuid]]))
   (:require #?(:clj [clojure.math.numeric-tower :as nt])
             #?(:cljs goog.math.Integer)
             #?(:cljs goog.math.Long)

--- a/src/sicmutils/util/def.cljc
+++ b/src/sicmutils/util/def.cljc
@@ -17,7 +17,9 @@
 ;; along with this code; if not, see <http://www.gnu.org/licenses/>.
 ;;
 
-(ns sicmutils.util.def)
+(ns sicmutils.util.def
+  #?(:clj
+     (:import (clojure.lang RT))))
 
 (defmacro ^:no-doc fork
   "I borrowed this lovely, mysterious macro from `macrovich`:

--- a/src/sicmutils/util/def.cljc
+++ b/src/sicmutils/util/def.cljc
@@ -127,3 +127,50 @@
                                                  (str d))]]
                            `(def ~d ~sym))]
     `(do ~@expanded-imports)))
+
+(defn careful-def
+  "Given some namespace `ns`, returns a function of some binding symbol and a form
+  to bind. The function returns either
+
+  - A form like `(def ~sym ~form)`, if `sym` is not currently bound into `ns`
+
+  - If `sym` is bound already, returns a form that emits a warning and then
+    uses `ns-unmap` and `intern` to reassign the binding.
+
+  In Clojure, this behavior matches redefinitions of symbols bound in
+  `clojure.core`. Symbols bound with `def` that are already imported from other
+  namespaces cause an exception, hence this more careful workaround.
+
+  (In Clojurescript, only forms like `(def ~sym ~form)` are emitted, since the
+  compiler does not currently error in case 2 and already handles emitting the
+  warning for us.)"
+  [ns]
+  (fork
+   :cljs
+   (fn [sym form]
+     `(def ~sym ~form))
+
+   :clj
+   (let [ns-sym (ns-name ns)
+         nsm (ns-map ns)
+         remote? (fn [sym]
+                   (when-let [v (nsm sym)]
+                     (not= *ns* (:ns (meta v)))))
+         warn (fn [sym]
+                `(.println
+                  (RT/errPrintWriter)
+                  (str "WARNING: "
+                       '~sym
+                       " already refers to: "
+                       ~(nsm sym)
+                       " in namespace: "
+                       '~ns-sym
+                       ", being replaced by: "
+                       ~(str "#'" ns-sym "/" sym))))]
+     (fn [sym form]
+       (if (remote? sym)
+         `(do
+            ~(warn sym)
+            (ns-unmap '~ns-sym '~sym)
+            (intern '~ns-sym '~sym ~form))
+         `(def ~sym ~form))))))

--- a/test/sicmutils/env/sci_test.cljc
+++ b/test/sicmutils/env/sci_test.cljc
@@ -96,7 +96,25 @@
                    (let [p ((point R2-rect) (up 1 2))]
                      [(= 1 (x p))
                       (= 2 (y p))]))))
-        "using-coordinates works")
+        "using-coordinates works!")
+
+    (is (= [true true]
+           (eval '(do (define-coordinates [x y] R2-rect)
+
+                      (let [p ((point R2-rect) (up 1 2))]
+                        [(= 1 (x p))
+                         (= 2 (y p))]))))
+        "define-coordinates version of that test")
+
+    (is (eval '(do (define-coordinates (up x y) R2-rect)
+
+                   (let [circular (- (* x d:dy) (* y d:dx))]
+                     (= '(+ (* 3 x0) (* -2 y0))
+                        (freeze
+                         (simplify
+                          ((circular (+ (* 2 x) (* 3 y)))
+                           ((point R2-rect) (up 'x0 'y0)))))))))
+        "define-coordinates works with a test from form_field_test.cljc")
 
     (testing "internal defn, funky symbols, internal with-literal-functions macro"
       (is (= "down(- m (Dφ(t))² r(t) + m D²r(t) + DU(r(t)), 2 m Dφ(t) r(t) Dr(t) + m (r(t))² D²φ(t))"

--- a/test/sicmutils/fdg/ch10_test.cljc
+++ b/test/sicmutils/fdg/ch10_test.cljc
@@ -25,8 +25,8 @@
                                          wedge
                                          down up
                                          point
-                                         R3-rect S2-spherical
-                                         let-coordinates]
+                                         S2-spherical
+                                         define-coordinates]
              #?@(:cljs [:include-macros true])]
             [sicmutils.value :as v]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
@@ -36,317 +36,318 @@
 (def simplify
   (comp v/freeze e/simplify))
 
-(def spherical R3-rect)
+(def spherical e/R3-rect)
+(define-coordinates [r theta phi] spherical)
+
+(def SR e/R4-rect)
+(define-coordinates [ct x y z] SR)
 
 (deftest ch10-tests
   (testing "spherical coordinates, p156"
-    (let-coordinates [[r theta phi] spherical]
-      (let [R3-spherical-point ((point spherical) (up 'r0 'theta0 'phi0))
-            spherical-metric (fn [v1 v2]
-                               (+ (* (dr v1) (dr v2))
-                                  (* (square r)
-                                     (+ (* (dtheta v1) (dtheta v2))
-                                        (* (expt (sin theta) 2)
-                                           (dphi v1) (dphi v2))))))
-            e_0 d:dr
-            e_1 (* (/ 1 r) d:dtheta)
-            e_2 (* (/ 1 (* r (sin theta))) d:dphi)
-            orthonormal-spherical-vector-basis (down e_0 e_1 e_2)
+    (let [R3-spherical-point ((point spherical) (up 'r0 'theta0 'phi0))
+          spherical-metric (fn [v1 v2]
+                             (+ (* (dr v1) (dr v2))
+                                (* (square r)
+                                   (+ (* (dtheta v1) (dtheta v2))
+                                      (* (expt (sin theta) 2)
+                                         (dphi v1) (dphi v2))))))
+          e_0 d:dr
+          e_1 (* (/ 1 r) d:dtheta)
+          e_2 (* (/ 1 (* r (sin theta))) d:dphi)
+          orthonormal-spherical-vector-basis (down e_0 e_1 e_2)
 
-            orthonormal-spherical-oneform-basis
-            (e/vector-basis->dual orthonormal-spherical-vector-basis
-                                  spherical)
+          orthonormal-spherical-oneform-basis
+          (e/vector-basis->dual orthonormal-spherical-vector-basis
+                                spherical)
 
-            orthonormal-spherical-basis
-            (e/make-basis orthonormal-spherical-vector-basis
-                          orthonormal-spherical-oneform-basis)]
-        (is (= '(up (((partial 0) f) (up r0 theta0 phi0))
-                    (/ (((partial 1) f) (up r0 theta0 phi0))
-                       r0)
-                    (/ (((partial 2) f) (up r0 theta0 phi0))
-                       (* r0 (sin theta0))))
-               (simplify
-                ((orthonormal-spherical-oneform-basis
-                  ((e/gradient spherical-metric orthonormal-spherical-basis)
-                   (e/literal-manifold-function 'f spherical)))
-                 R3-spherical-point)))
-            "The components of the gradient of a scalar field are obtained
+          orthonormal-spherical-basis
+          (e/make-basis orthonormal-spherical-vector-basis
+                        orthonormal-spherical-oneform-basis)]
+      (is (= '(up (((partial 0) f) (up r0 theta0 phi0))
+                  (/ (((partial 1) f) (up r0 theta0 phi0))
+                     r0)
+                  (/ (((partial 2) f) (up r0 theta0 phi0))
+                     (* r0 (sin theta0))))
+             (simplify
+              ((orthonormal-spherical-oneform-basis
+                ((e/gradient spherical-metric orthonormal-spherical-basis)
+                 (e/literal-manifold-function 'f spherical)))
+               R3-spherical-point)))
+          "The components of the gradient of a scalar field are obtained
             using the dual basis (p157)")
 
-        (let [v (+ (* (e/literal-manifold-function 'v↑0 spherical) e_0)
-                   (* (e/literal-manifold-function 'v↑1 spherical) e_1)
-                   (* (e/literal-manifold-function 'v↑2 spherical) e_2))]
-          (is (= '(up
-                   (/ (+ (* (sin theta0) (((partial 1) v↑2) (up r0 theta0 phi0)))
-                         (* (v↑2 (up r0 theta0 phi0)) (cos theta0))
-                         (* -1 (((partial 2) v↑1) (up r0 theta0 phi0))))
-                      (* r0 (sin theta0)))
-                   (/ (+ (* -1 r0 (sin theta0) (((partial 0) v↑2) (up r0 theta0 phi0)))
-                         (* -1 (sin theta0) (v↑2 (up r0 theta0 phi0)))
-                         (((partial 2) v↑0) (up r0 theta0 phi0)))
-                      (* r0 (sin theta0)))
-                   (/ (+ (* r0 (((partial 0) v↑1) (up r0 theta0 phi0)))
-                         (v↑1 (up r0 theta0 phi0))
-                         (* -1 (((partial 1) v↑0) (up r0 theta0 phi0))))
-                      r0))
+      (let [v (+ (* (e/literal-manifold-function 'v↑0 spherical) e_0)
+                 (* (e/literal-manifold-function 'v↑1 spherical) e_1)
+                 (* (e/literal-manifold-function 'v↑2 spherical) e_2))]
+        (is (= '(up
+                 (/ (+ (* (sin theta0) (((partial 1) v↑2) (up r0 theta0 phi0)))
+                       (* (v↑2 (up r0 theta0 phi0)) (cos theta0))
+                       (* -1 (((partial 2) v↑1) (up r0 theta0 phi0))))
+                    (* r0 (sin theta0)))
+                 (/ (+ (* -1 r0 (sin theta0) (((partial 0) v↑2) (up r0 theta0 phi0)))
+                       (* -1 (sin theta0) (v↑2 (up r0 theta0 phi0)))
+                       (((partial 2) v↑0) (up r0 theta0 phi0)))
+                    (* r0 (sin theta0)))
+                 (/ (+ (* r0 (((partial 0) v↑1) (up r0 theta0 phi0)))
+                       (v↑1 (up r0 theta0 phi0))
+                       (* -1 (((partial 1) v↑0) (up r0 theta0 phi0))))
+                    r0))
+               (simplify
+                ((orthonormal-spherical-oneform-basis
+                  ((e/curl spherical-metric orthonormal-spherical-basis) v))
+                 R3-spherical-point)))
+            "The curl is a bit complicated (p158)")
+
+        (testing "But the divergence and Laplacian are simpler"
+          (is (= '(/ (+ (* r0 (sin theta0) (((partial 0) v↑0) (up r0 theta0 phi0)))
+                        (* 2 (sin theta0) (v↑0 (up r0 theta0 phi0)))
+                        (* (sin theta0) (((partial 1) v↑1) (up r0 theta0 phi0)))
+                        (* (cos theta0) (v↑1 (up r0 theta0 phi0)))
+                        (((partial 2) v↑2) (up r0 theta0 phi0)))
+                     (* r0 (sin theta0)))
                  (simplify
-                  ((orthonormal-spherical-oneform-basis
-                    ((e/curl spherical-metric orthonormal-spherical-basis) v))
+                  (((e/divergence spherical-metric orthonormal-spherical-basis) v)
                    R3-spherical-point)))
-              "The curl is a bit complicated (p158)")
+              "divergence")
 
-          (testing "But the divergence and Laplacian are simpler"
-            (is (= '(/ (+ (* r0 (sin theta0) (((partial 0) v↑0) (up r0 theta0 phi0)))
-                          (* 2 (sin theta0) (v↑0 (up r0 theta0 phi0)))
-                          (* (sin theta0) (((partial 1) v↑1) (up r0 theta0 phi0)))
-                          (* (cos theta0) (v↑1 (up r0 theta0 phi0)))
-                          (((partial 2) v↑2) (up r0 theta0 phi0)))
-                       (* r0 (sin theta0)))
-                   (simplify
-                    (((e/divergence spherical-metric orthonormal-spherical-basis) v)
-                     R3-spherical-point)))
-                "divergence")
-
-            (is (= '(/ (+ (* (expt r0 2)
-                             (expt (sin theta0) 2)
-                             (((expt (partial 0) 2) f) (up r0 theta0 phi0)))
-                          (* 2 r0 (((partial 0) f) (up r0 theta0 phi0)) (expt (sin theta0) 2))
-                          (* (((partial 1) f) (up r0 theta0 phi0)) (sin theta0) (cos theta0))
-                          (* (expt (sin theta0) 2)
-                             (((expt (partial 1) 2) f) (up r0 theta0 phi0)))
-                          (((expt (partial 2) 2) f) (up r0 theta0 phi0)))
-                       (* (expt r0 2) (expt (sin theta0) 2)))
-                   (simplify
-                    (((e/Laplacian spherical-metric orthonormal-spherical-basis)
-                      (e/literal-manifold-function 'f spherical))
-                     R3-spherical-point)))
-                "Laplacian")))))))
+          (is (= '(/ (+ (* (expt r0 2)
+                           (expt (sin theta0) 2)
+                           (((expt (partial 0) 2) f) (up r0 theta0 phi0)))
+                        (* 2 r0 (((partial 0) f) (up r0 theta0 phi0)) (expt (sin theta0) 2))
+                        (* (((partial 1) f) (up r0 theta0 phi0)) (sin theta0) (cos theta0))
+                        (* (expt (sin theta0) 2)
+                           (((expt (partial 1) 2) f) (up r0 theta0 phi0)))
+                        (((expt (partial 2) 2) f) (up r0 theta0 phi0)))
+                     (* (expt r0 2) (expt (sin theta0) 2)))
+                 (simplify
+                  (((e/Laplacian spherical-metric orthonormal-spherical-basis)
+                    (e/literal-manifold-function 'f spherical))
+                   R3-spherical-point)))
+              "Laplacian"))))))
 
 (deftest wave-equation-tests
   (testing "The wave equation (p159)"
-    (let [SR e/R4-rect]
-      (let-coordinates [[ct x y z] SR]
-        (let [an-event ((point SR) (up 'ct0 'x0 'y0 'z0))
+    (let [an-event ((point SR) (up 'ct0 'x0 'y0 'z0))
 
-              a-vector (+ (* (e/literal-manifold-function 'v↑t SR) d:dct)
-                          (* (e/literal-manifold-function 'v↑x SR) d:dx)
-                          (* (e/literal-manifold-function 'v↑y SR) d:dy)
-                          (* (e/literal-manifold-function 'v↑z SR) d:dz))
+          a-vector (+ (* (e/literal-manifold-function 'v↑t SR) d:dct)
+                      (* (e/literal-manifold-function 'v↑x SR) d:dx)
+                      (* (e/literal-manifold-function 'v↑y SR) d:dy)
+                      (* (e/literal-manifold-function 'v↑z SR) d:dz))
 
-              ;; NOTE that this suite of tests differs from the book in that we
-              ;; include the c^2 term in the code, and track it all the way
-              ;; through. The book assumes c==1.
-              g-Minkowski (fn [u v]
-                            (+ (* -1 (square 'c) (dct u) (dct v))
-                               (* (dx u) (dx v))
-                               (* (dy u) (dy v))
-                               (* (dz u) (dz v))))
-              SR-vector-basis (down (* (/ 1 'c) d:dct) d:dx d:dy d:dz)
-              SR-oneform-basis (up (* 'c dct) dx dy dz)
-              SR-basis
-              (e/make-basis SR-vector-basis
-                            SR-oneform-basis)]
-          (is (= '(+ (* -1 (expt c 2) (expt (v↑t (up ct0 x0 y0 z0)) 2))
-                     (expt (v↑x (up ct0 x0 y0 z0)) 2)
-                     (expt (v↑y (up ct0 x0 y0 z0)) 2)
-                     (expt (v↑z (up ct0 x0 y0 z0)) 2))
-                 (simplify
-                  ((g-Minkowski a-vector a-vector) an-event)))
-              "p159")
+          ;; NOTE that this suite of tests differs from the book in that we
+          ;; include the c^2 term in the code, and track it all the way
+          ;; through. The book assumes c==1.
+          g-Minkowski (fn [u v]
+                        (+ (* -1 (square 'c) (dct u) (dct v))
+                           (* (dx u) (dx v))
+                           (* (dy u) (dy v))
+                           (* (dz u) (dz v))))
+          SR-vector-basis (down (* (/ 1 'c) d:dct) d:dx d:dy d:dz)
+          SR-oneform-basis (up (* 'c dct) dx dy dz)
+          SR-basis
+          (e/make-basis SR-vector-basis
+                        SR-oneform-basis)]
+      (is (= '(+ (* -1 (expt c 2) (expt (v↑t (up ct0 x0 y0 z0)) 2))
+                 (expt (v↑x (up ct0 x0 y0 z0)) 2)
+                 (expt (v↑y (up ct0 x0 y0 z0)) 2)
+                 (expt (v↑z (up ct0 x0 y0 z0)) 2))
+             (simplify
+              ((g-Minkowski a-vector a-vector) an-event)))
+          "p159")
 
-          (is (= '(down (down -1 0 0 0)
-                        (down  0 1 0 0)
-                        (down  0 0 1 0)
-                        (down  0 0 0 1))
-                 (simplify
-                  ((g-Minkowski SR-vector-basis SR-vector-basis) an-event)))
-              "We check that it is orthonormal with respect to the metric (p160)")
+      (is (= '(down (down -1 0 0 0)
+                    (down  0 1 0 0)
+                    (down  0 0 1 0)
+                    (down  0 0 0 1))
+             (simplify
+              ((g-Minkowski SR-vector-basis SR-vector-basis) an-event)))
+          "We check that it is orthonormal with respect to the metric (p160)")
 
-          (let [phi (e/literal-manifold-function 'phi SR)]
-            (is (= '(/ (+ (* -1 (expt c 2) (((expt (partial 1) 2) phi) (up ct0 x0 y0 z0)))
-                          (* -1 (expt c 2) (((expt (partial 2) 2) phi) (up ct0 x0 y0 z0)))
-                          (* -1 (expt c 2) (((expt (partial 3) 2) phi) (up ct0 x0 y0 z0)))
-                          (((expt (partial 0) 2) phi) (up ct0 x0 y0 z0)))
-                       (expt c 2))
-                   (simplify
-                    (((e/Laplacian g-Minkowski SR-basis) phi) an-event)))
-                "So, the Laplacian of a scalar field is the wave equation! (p160)"))
+      (let [phi (e/literal-manifold-function 'phi SR)]
+        (is (= '(/ (+ (* -1 (expt c 2) (((expt (partial 1) 2) phi) (up ct0 x0 y0 z0)))
+                      (* -1 (expt c 2) (((expt (partial 2) 2) phi) (up ct0 x0 y0 z0)))
+                      (* -1 (expt c 2) (((expt (partial 3) 2) phi) (up ct0 x0 y0 z0)))
+                      (((expt (partial 0) 2) phi) (up ct0 x0 y0 z0)))
+                   (expt c 2))
+               (simplify
+                (((e/Laplacian g-Minkowski SR-basis) phi) an-event)))
+            "So, the Laplacian of a scalar field is the wave equation! (p160)"))
 
-          (testing "Electrodynamics (p160)"
-            (let [Faraday (fn [Ex Ey Ez Bx By Bz]
-                            (+ (* Ex 'c (wedge dx dct))
-                               (* Ey 'c (wedge dy dct))
-                               (* Ez 'c (wedge dz dct))
-                               (* Bx (wedge dy dz))
-                               (* By (wedge dz dx))
-                               (* Bz (wedge dx dy))))
+      (testing "Electrodynamics (p160)"
+        (let [Faraday (fn [Ex Ey Ez Bx By Bz]
+                        (+ (* Ex 'c (wedge dx dct))
+                           (* Ey 'c (wedge dy dct))
+                           (* Ez 'c (wedge dz dct))
+                           (* Bx (wedge dy dz))
+                           (* By (wedge dz dx))
+                           (* Bz (wedge dx dy))))
 
-                  Maxwell (fn [Ex Ey Ez Bx By Bz]
-                            (+ (* -1 Bx 'c (wedge dx dct))
-                               (* -1 By 'c (wedge dy dct))
-                               (* -1 Bz 'c (wedge dz dct))
-                               (* Ex (wedge dy dz))
-                               (* Ey (wedge dz dx))
-                               (* Ez (wedge dx dy))))
-                  SR-star (e/Hodge-star g-Minkowski SR-basis)]
-              (is (zero?
-                   (simplify
-                    (((- (SR-star (Faraday 'Ex 'Ey 'Ez 'Bx 'By 'Bz))
-                         (Maxwell 'Ex 'Ey 'Ez 'Bx 'By 'Bz))
-                      (e/literal-vector-field 'u SR)
-                      (e/literal-vector-field 'v SR))
-                     an-event)))
-                  "And indeed, it transforms the Faraday tensor into the Maxwell
+              Maxwell (fn [Ex Ey Ez Bx By Bz]
+                        (+ (* -1 Bx 'c (wedge dx dct))
+                           (* -1 By 'c (wedge dy dct))
+                           (* -1 Bz 'c (wedge dz dct))
+                           (* Ex (wedge dy dz))
+                           (* Ey (wedge dz dx))
+                           (* Ez (wedge dx dy))))
+              SR-star (e/Hodge-star g-Minkowski SR-basis)]
+          (is (zero?
+               (simplify
+                (((- (SR-star (Faraday 'Ex 'Ey 'Ez 'Bx 'By 'Bz))
+                     (Maxwell 'Ex 'Ey 'Ez 'Bx 'By 'Bz))
+                  (e/literal-vector-field 'u SR)
+                  (e/literal-vector-field 'v SR))
+                 an-event)))
+              "And indeed, it transforms the Faraday tensor into the Maxwell
                    tensor (p161)")
 
-              (testing "Defining the 4-current density J."
-                ;; Charge density is a manifold function.  Current density is a
-                ;; vector field having only spatial components
-                (let [J (fn [charge-density Ix Iy Iz]
-                          (- (* (/ 1 'c) (+ (* Ix dx) (* Iy dy) (* Iz dz)))
-                             (* charge-density 'c dct)))
+          (testing "Defining the 4-current density J."
+            ;; Charge density is a manifold function.  Current density is a
+            ;; vector field having only spatial components
+            (let [J (fn [charge-density Ix Iy Iz]
+                      (- (* (/ 1 'c) (+ (* Ix dx) (* Iy dy) (* Iz dz)))
+                         (* charge-density 'c dct)))
 
-                      F (Faraday (e/literal-manifold-function 'Ex SR)
-                                 (e/literal-manifold-function 'Ey SR)
-                                 (e/literal-manifold-function 'Ez SR)
-                                 (e/literal-manifold-function 'Bx SR)
-                                 (e/literal-manifold-function 'By SR)
-                                 (e/literal-manifold-function 'Bz SR))
+                  F (Faraday (e/literal-manifold-function 'Ex SR)
+                             (e/literal-manifold-function 'Ey SR)
+                             (e/literal-manifold-function 'Ez SR)
+                             (e/literal-manifold-function 'Bx SR)
+                             (e/literal-manifold-function 'By SR)
+                             (e/literal-manifold-function 'Bz SR))
 
-                      four-current (J (e/literal-manifold-function 'rho SR)
-                                      (e/literal-manifold-function 'Ix SR)
-                                      (e/literal-manifold-function 'Iy SR)
-                                      (e/literal-manifold-function 'Iz SR))]
-                  ;; Maxwell's equations in the form language ar:  dF=0, d(*F)=fourpi *J
-                  (is (= '(+ (((partial 1) Bx) (up ct0 x0 y0 z0))
-                             (((partial 2) By) (up ct0 x0 y0 z0))
-                             (((partial 3) Bz) (up ct0 x0 y0 z0)))
-                         (simplify
-                          (((e/d F) d:dx d:dy d:dz) an-event)))
-                      "div B = 0")
+                  four-current (J (e/literal-manifold-function 'rho SR)
+                                  (e/literal-manifold-function 'Ix SR)
+                                  (e/literal-manifold-function 'Iy SR)
+                                  (e/literal-manifold-function 'Iz SR))]
+              ;; Maxwell's equations in the form language ar:  dF=0, d(*F)=fourpi *J
+              (is (= '(+ (((partial 1) Bx) (up ct0 x0 y0 z0))
+                         (((partial 2) By) (up ct0 x0 y0 z0))
+                         (((partial 3) Bz) (up ct0 x0 y0 z0)))
+                     (simplify
+                      (((e/d F) d:dx d:dy d:dz) an-event)))
+                  "div B = 0")
 
-                  (testing "The three mixed space and time components of
+              (testing "The three mixed space and time components of
                             equation 10.13 are equation 10.16 (p163)"
-                    (is (= '(/ (+ (* c (((partial 2) Ez) (up ct0 x0 y0 z0)))
-                                  (* -1 c (((partial 3) Ey) (up ct0 x0 y0 z0)))
-                                  (((partial 0) Bx) (up ct0 x0 y0 z0)))
-                               c)
-                           (simplify
-                            (((e/d F) (* (/ 1 'c) d:dct) d:dy d:dz) an-event)))
-                        "curl E = -1/c dB/dt")
+                (is (= '(/ (+ (* c (((partial 2) Ez) (up ct0 x0 y0 z0)))
+                              (* -1 c (((partial 3) Ey) (up ct0 x0 y0 z0)))
+                              (((partial 0) Bx) (up ct0 x0 y0 z0)))
+                           c)
+                       (simplify
+                        (((e/d F) (* (/ 1 'c) d:dct) d:dy d:dz) an-event)))
+                    "curl E = -1/c dB/dt")
 
-                    (is (= '(/ (+ (* c (((partial 3) Ex) (up ct0 x0 y0 z0)))
-                                  (* -1 c (((partial 1) Ez) (up ct0 x0 y0 z0)))
-                                  (((partial 0) By) (up ct0 x0 y0 z0)))
-                               c)
-                           (simplify
-                            (((e/d F) (* (/ 1 'c) d:dct) d:dz d:dx) an-event))))
+                (is (= '(/ (+ (* c (((partial 3) Ex) (up ct0 x0 y0 z0)))
+                              (* -1 c (((partial 1) Ez) (up ct0 x0 y0 z0)))
+                              (((partial 0) By) (up ct0 x0 y0 z0)))
+                           c)
+                       (simplify
+                        (((e/d F) (* (/ 1 'c) d:dct) d:dz d:dx) an-event))))
 
-                    (is (= '(/ (+ (* c (((partial 1) Ey) (up ct0 x0 y0 z0)))
-                                  (* -1 c (((partial 2) Ex) (up ct0 x0 y0 z0)))
-                                  (((partial 0) Bz) (up ct0 x0 y0 z0)))
-                               c)
-                           (simplify
-                            (((e/d F) (* (/ 1 'c) d:dct) d:dx d:dy) an-event)))))
+                (is (= '(/ (+ (* c (((partial 1) Ey) (up ct0 x0 y0 z0)))
+                              (* -1 c (((partial 2) Ex) (up ct0 x0 y0 z0)))
+                              (((partial 0) Bz) (up ct0 x0 y0 z0)))
+                           c)
+                       (simplify
+                        (((e/d F) (* (/ 1 'c) d:dct) d:dx d:dy) an-event)))))
 
-                  (is (= '(+ (* -4 pi (rho (up ct0 x0 y0 z0)))
-                             (((partial 1) Ex) (up ct0 x0 y0 z0))
-                             (((partial 2) Ey) (up ct0 x0 y0 z0))
-                             (((partial 3) Ez) (up ct0 x0 y0 z0)))
-                         (simplify
-                          (((- (e/d (SR-star F)) (* 4 'pi (SR-star four-current)))
-                            d:dx d:dy d:dz)
-                           an-event)))
-                      "div E = fourpi rho, The purely spatial component of
+              (is (= '(+ (* -4 pi (rho (up ct0 x0 y0 z0)))
+                         (((partial 1) Ex) (up ct0 x0 y0 z0))
+                         (((partial 2) Ey) (up ct0 x0 y0 z0))
+                         (((partial 3) Ez) (up ct0 x0 y0 z0)))
+                     (simplify
+                      (((- (e/d (SR-star F)) (* 4 'pi (SR-star four-current)))
+                        d:dx d:dy d:dz)
+                       an-event)))
+                  "div E = fourpi rho, The purely spatial component of
                        equation 10.14 is equation 10.17")
 
-                  (testing "And finally, the three mixed time and space
+              (testing "And finally, the three mixed time and space
                             components of equation 10.14 are equation
                             10.18 (p164)"
-                    (is (= '(/ (+ (* -1 c (((partial 2) Bz) (up ct0 x0 y0 z0)))
-                                  (* c (((partial 3) By) (up ct0 x0 y0 z0)))
-                                  (* 4 pi (Ix (up ct0 x0 y0 z0)))
-                                  (((partial 0) Ex) (up ct0 x0 y0 z0)))
-                               c)
-                           (simplify
-                            (((- (e/d (SR-star F)) (* 4 'pi (SR-star four-current)))
-                              (* (/ 1 'c) d:dct) d:dy d:dz)
-                             an-event)))
-                        "curl B = 1/c dE/dt + fourpi I")
+                (is (= '(/ (+ (* -1 c (((partial 2) Bz) (up ct0 x0 y0 z0)))
+                              (* c (((partial 3) By) (up ct0 x0 y0 z0)))
+                              (* 4 pi (Ix (up ct0 x0 y0 z0)))
+                              (((partial 0) Ex) (up ct0 x0 y0 z0)))
+                           c)
+                       (simplify
+                        (((- (e/d (SR-star F)) (* 4 'pi (SR-star four-current)))
+                          (* (/ 1 'c) d:dct) d:dy d:dz)
+                         an-event)))
+                    "curl B = 1/c dE/dt + fourpi I")
 
-                    (is (= '(/ (+ (* -1 c (((partial 3) Bx) (up ct0 x0 y0 z0)))
-                                  (* c (((partial 1) Bz) (up ct0 x0 y0 z0)))
-                                  (* 4 pi (Iy (up ct0 x0 y0 z0)))
-                                  (((partial 0) Ey) (up ct0 x0 y0 z0)))
-                               c)
-                           (simplify
-                            (((- (e/d (SR-star F)) (* 4 'pi (SR-star four-current)))
-                              (* (/ 1 'c) d:dct) d:dz d:dx)
-                             an-event))))
+                (is (= '(/ (+ (* -1 c (((partial 3) Bx) (up ct0 x0 y0 z0)))
+                              (* c (((partial 1) Bz) (up ct0 x0 y0 z0)))
+                              (* 4 pi (Iy (up ct0 x0 y0 z0)))
+                              (((partial 0) Ey) (up ct0 x0 y0 z0)))
+                           c)
+                       (simplify
+                        (((- (e/d (SR-star F)) (* 4 'pi (SR-star four-current)))
+                          (* (/ 1 'c) d:dct) d:dz d:dx)
+                         an-event))))
 
-                    (is (= '(/ (+ (* -1 c (((partial 1) By) (up ct0 x0 y0 z0)))
-                                  (* c (((partial 2) Bx) (up ct0 x0 y0 z0)))
-                                  (* 4 pi (Iz (up ct0 x0 y0 z0)))
-                                  (((partial 0) Ez) (up ct0 x0 y0 z0)))
-                               c)
-                           (simplify
-                            (((- (e/d (SR-star F)) (* 4 'pi (SR-star four-current)))
-                              (* (/ 1 'c) d:dct) d:dx d:dy)
-                             an-event)))))
+                (is (= '(/ (+ (* -1 c (((partial 1) By) (up ct0 x0 y0 z0)))
+                              (* c (((partial 2) Bx) (up ct0 x0 y0 z0)))
+                              (* 4 pi (Iz (up ct0 x0 y0 z0)))
+                              (((partial 0) Ez) (up ct0 x0 y0 z0)))
+                           c)
+                       (simplify
+                        (((- (e/d (SR-star F)) (* 4 'pi (SR-star four-current)))
+                          (* (/ 1 'c) d:dct) d:dx d:dy)
+                         an-event)))))
 
-                  (testing "Lorentz force (p164)"
-                    (let [E (up (e/literal-manifold-function 'Ex SR)
-                                (e/literal-manifold-function 'Ey SR)
-                                (e/literal-manifold-function 'Ez SR))
-                          B (up (e/literal-manifold-function 'Bx SR)
-                                (e/literal-manifold-function 'By SR)
-                                (e/literal-manifold-function 'Bz SR))
-                          V (up 'V_x 'V_y 'V_z)]
-                      (is (= '(up (+ (* V_y q (Bz (up ct0 x0 y0 z0)))
-                                     (* -1 V_z q (By (up ct0 x0 y0 z0)))
-                                     (* q (Ex (up ct0 x0 y0 z0))))
-                                  (+ (* -1 V_x q (Bz (up ct0 x0 y0 z0)))
-                                     (* V_z q (Bx (up ct0 x0 y0 z0)))
-                                     (* q (Ey (up ct0 x0 y0 z0))))
-                                  (+ (* V_x q (By (up ct0 x0 y0 z0)))
-                                     (* -1 V_y q (Bx (up ct0 x0 y0 z0)))
-                                     (* q (Ez (up ct0 x0 y0 z0)))))
+              (testing "Lorentz force (p164)"
+                (let [E (up (e/literal-manifold-function 'Ex SR)
+                            (e/literal-manifold-function 'Ey SR)
+                            (e/literal-manifold-function 'Ez SR))
+                      B (up (e/literal-manifold-function 'Bx SR)
+                            (e/literal-manifold-function 'By SR)
+                            (e/literal-manifold-function 'Bz SR))
+                      V (up 'V_x 'V_y 'V_z)]
+                  (is (= '(up (+ (* V_y q (Bz (up ct0 x0 y0 z0)))
+                                 (* -1 V_z q (By (up ct0 x0 y0 z0)))
+                                 (* q (Ex (up ct0 x0 y0 z0))))
+                              (+ (* -1 V_x q (Bz (up ct0 x0 y0 z0)))
+                                 (* V_z q (Bx (up ct0 x0 y0 z0)))
+                                 (* q (Ey (up ct0 x0 y0 z0))))
+                              (+ (* V_x q (By (up ct0 x0 y0 z0)))
+                                 (* -1 V_y q (Bx (up ct0 x0 y0 z0)))
+                                 (* q (Ez (up ct0 x0 y0 z0)))))
+                         (simplify
+                          (* 'q (+ (E an-event) (e/cross-product V (B an-event))))))
+                      "The 3-space force that results is a mess (p165)")
+
+                  ;; TODO eta-inverse is not defined, so these will not run.
+                  (comment
+                    (let [Force (fn [charge F four-velocity component]
+                                  (* -1 charge
+                                     (e/contract
+                                      (fn [a b]
+                                        (e/contract
+                                         (fn [e w]
+                                           (* (w four-velocity)
+                                              (F e a)
+                                              (eta-inverse b component)))
+                                         SR-basis))
+                                      SR-basis)))
+                          Ux (fn [beta]
+                               (+ (* (/ 1 (sqrt (- 1 (square beta)))) d:dct)
+                                  (* (/ beta (sqrt (- 1 (square beta)))) d:dx)))]
+                      (is (= '(* q (Ex (up ct0 x0 y0 z0)))
                              (simplify
-                              (* 'q (+ (E an-event) (e/cross-product V (B an-event))))))
-                          "The 3-space force that results is a mess (p165)")
-
-                      ;; TODO eta-inverse is not defined, so these will not run.
-                      (comment
-                        (let [Force (fn [charge F four-velocity component]
-                                      (* -1 charge
-                                         (e/contract
-                                          (fn [a b]
-                                            (e/contract
-                                             (fn [e w]
-                                               (* (w four-velocity)
-                                                  (F e a)
-                                                  (eta-inverse b component)))
-                                             SR-basis))
-                                          SR-basis)))
-                              Ux (fn [beta]
-                                   (+ (* (/ 1 (sqrt (- 1 (square beta)))) d:dct)
-                                      (* (/ beta (sqrt (- 1 (square beta)))) d:dx)))]
-                          (is (= '(* q (Ex (up ct0 x0 y0 z0)))
-                                 (simplify
-                                  ((Force 'q F d:dct dx) an-event)))
-                              "the force in the ˆx direction for a stationary
+                              ((Force 'q F d:dct dx) an-event)))
+                          "the force in the ˆx direction for a stationary
                             particle is...")
 
-                          (is (= '(/ (+ (* -1 q v/c (Bz (up ct0 x0 y0 z0)))
-                                        (* q (Ey (up ct0 x0 y0 z0))))
-                                     (sqrt (+ 1 (* -1 (expt v:c 2)))))
-                                 ((Force 'q F (Ux 'v:c) dy) an-event))
-                              "If we give a particle a more general timelike
+                      (is (= '(/ (+ (* -1 q v/c (Bz (up ct0 x0 y0 z0)))
+                                    (* q (Ey (up ct0 x0 y0 z0))))
+                                 (sqrt (+ 1 (* -1 (expt v:c 2)))))
+                             ((Force 'q F (Ux 'v:c) dy) an-event))
+                          "If we give a particle a more general timelike
                              4-velocity in the xˆ direction we can see how the
                              ˆy component of the force involves both the
                              electric and magnetic field")
 
-                          (is (= '(/ (* q v:c (Ex (up ct0 x0 y0 z0)))
-                                     (sqrt (+ 1 (* -1 (expt v:c 2)))))
-                                 ((Force ’q F (Ux 'v:c) dct) an-event))
-                              "From ex 10.1b"))))))))))))))
+                      (is (= '(/ (* q v:c (Ex (up ct0 x0 y0 z0)))
+                                 (sqrt (+ 1 (* -1 (expt v:c 2)))))
+                             ((Force ’q F (Ux 'v:c) dct) an-event))
+                          "From ex 10.1b"))))))))))))

--- a/test/sicmutils/fdg/ch11_test.cljc
+++ b/test/sicmutils/fdg/ch11_test.cljc
@@ -23,9 +23,7 @@
                                          zero?
                                          up
                                          rotate-x rotate-y rotate-z
-                                         point chart
-                                         let-coordinates]
-             #?@(:cljs [:include-macros true])]
+                                         point chart]]
             [sicmutils.value :as v]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
 

--- a/test/sicmutils/fdg/ch1_test.cljc
+++ b/test/sicmutils/fdg/ch1_test.cljc
@@ -24,9 +24,9 @@
                                          D compose
                                          up down
                                          sin cos square
-                                         R1-rect R2-rect
+                                         R2-rect
                                          chart point
-                                         let-coordinates]
+                                         define-coordinates]
              #?@(:cljs [:include-macros true])]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
             [sicmutils.value :as v]))
@@ -62,6 +62,8 @@
     (let [e (e/coordinate-system->vector-basis coordsys)]
       ((L2 mass metric) ((point coordsys) x) (* e v)))))
 
+(define-coordinates t e/R1-rect)
+
 (deftest chapter-one-tests
   (is (= '(+ (* (/ 1 2) (expt R 2) m (expt phidot 2) (expt (sin theta) 2))
              (* (/ 1 2) (expt R 2) m (expt thetadot 2)))
@@ -92,22 +94,21 @@
 
       ;; Now we can compute the residuals of the Euler-Lagrange equations, but
       ;; we get a large messy expression that we will not show.
-      (let-coordinates [t R1-rect]
-        (let [Lagrange-residuals (((e/Lagrange-equations L) coordinate-path) 't)
-              R2-basis (e/coordinate-system->basis R2-rect)
-              Cartan
-              (e/Christoffel->Cartan
-               (e/metric->Christoffel-2 the-metric R2-basis))
-              geodesic-equation-residuals (((((e/covariant-derivative Cartan gamma) d:dt)
-                                             ((e/differential gamma) d:dt))
-                                            (chart R2-rect))
-                                           ((point R1-rect) 't))
-              metric-components (e/metric->components the-metric R2-basis)]
-          (is (= '(down 0 0)
-                 (simplify
-                  (- Lagrange-residuals
-                     (* (* 'm (metric-components (gamma ((point R1-rect) 't))))
-                        geodesic-equation-residuals))))
-              "p10: This establishes that for a 2-dimensional space the
+      (let [Lagrange-residuals (((e/Lagrange-equations L) coordinate-path) 't)
+            R2-basis (e/coordinate-system->basis R2-rect)
+            Cartan
+            (e/Christoffel->Cartan
+             (e/metric->Christoffel-2 the-metric R2-basis))
+            geodesic-equation-residuals (((((e/covariant-derivative Cartan gamma) d:dt)
+                                           ((e/differential gamma) d:dt))
+                                          (chart R2-rect))
+                                         ((point R1-rect) 't))
+            metric-components (e/metric->components the-metric R2-basis)]
+        (is (= '(down 0 0)
+               (simplify
+                (- Lagrange-residuals
+                   (* (* 'm (metric-components (gamma ((point R1-rect) 't))))
+                      geodesic-equation-residuals))))
+            "p10: This establishes that for a 2-dimensional space the
                Euler-Lagrange equations are equivalent to the geodesic
-               equations."))))))
+               equations.")))))

--- a/test/sicmutils/fdg/ch2_test.cljc
+++ b/test/sicmutils/fdg/ch2_test.cljc
@@ -27,9 +27,8 @@
                                          up down
                                          sin cos square cube sqrt atan
                                          point chart
-                                         R2-rect R2-polar
                                          S2-spherical S2-Riemann
-                                         let-coordinates]
+                                         define-coordinates]
              #?@(:cljs [:include-macros true])]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
 
@@ -37,6 +36,9 @@
 
 (def simplify
   (comp e/freeze e/simplify))
+
+(define-coordinates (up x y) e/R2-rect)
+(define-coordinates (up r theta) e/R2-polar)
 
 (def R2-rect-chi (chart R2-rect))
 (def R2-rect-chi-inverse (point R2-rect))
@@ -86,60 +88,57 @@
       (is (= '(g-rect (up x0 y0)) (simplify (g R2-rect-point))))
       (is (= '(g-rect (up x0 y0)) (simplify (g corresponding-polar-point))))
 
-      (let-coordinates [[x y]     R2-rect
-                        [r theta] R2-polar]
-        (testing "page 17"
-          (is (= 'x0
-                 (x (R2-rect-chi-inverse (up 'x0 'y0)))))
+      (testing "page 17"
+        (is (= 'x0
+               (x (R2-rect-chi-inverse (up 'x0 'y0)))))
 
-          (is (= '(* r0 (cos theta0))
-                 (simplify
-                  (x (R2-polar-chi-inverse (up 'r0 'theta0))))))
+        (is (= '(* r0 (cos theta0))
+               (simplify
+                (x (R2-polar-chi-inverse (up 'r0 'theta0))))))
 
-          (is (= 'r0
-                 (simplify
-                  (r (R2-polar-chi-inverse (up 'r0 'theta0))))))
+        (is (= 'r0
+               (simplify
+                (r (R2-polar-chi-inverse (up 'r0 'theta0))))))
 
-          (is (= '(sqrt (+ (expt x0 2) (expt y0 2)))
-                 (simplify
-                  (r (R2-rect-chi-inverse (up 'x0 'y0))))))
+        (is (= '(sqrt (+ (expt x0 2) (expt y0 2)))
+               (simplify
+                (r (R2-rect-chi-inverse (up 'x0 'y0))))))
 
-          (is (= '(atan y0 x0)
-                 (simplify
-                  (theta (R2-rect-chi-inverse (up 'x0 'y0)))))))
+        (is (= '(atan y0 x0)
+               (simplify
+                (theta (R2-rect-chi-inverse (up 'x0 'y0)))))))
 
-        ;; We can work with the coordinate functions in a natural manner,
-        ;; defining new manifold functions in terms of them:
-        (let [h (+ (* x (square r)) (cube y))]
-          (is (= '(+ (expt x0 3) (* x0 (expt y0 2))
-                     (expt y0 3))
-                 (simplify
-                  (h R2-rect-point))))
+      ;; We can work with the coordinate functions in a natural manner,
+      ;; defining new manifold functions in terms of them:
+      (let [h (+ (* x (square r)) (cube y))]
+        (is (= '(+ (expt x0 3) (* x0 (expt y0 2))
+                   (expt y0 3))
+               (simplify
+                (h R2-rect-point))))
 
-          (is (= '(+ (* (expt r0 3) (expt (sin theta0) 3))
-                     (* (expt r0 3) (cos theta0)))
-                 (simplify
-                  (h (R2-polar-chi-inverse
-                      (up 'r0 'theta0)))))))
+        (is (= '(+ (* (expt r0 3) (expt (sin theta0) 3))
+                   (* (expt r0 3) (cos theta0)))
+               (simplify
+                (h (R2-polar-chi-inverse
+                    (up 'r0 'theta0)))))))
 
+      (is (= '(/ (+ (* -2 a x)
+                    (* -2 a (sqrt (+ (expt x 2) (expt y 2))))
+                    (expt x 2)
+                    (expt y 2))
+                 (sqrt (+ (expt x 2) (expt y 2))))
+             (simplify
+              ((- r (* 2 'a (+ 1 (cos theta))))
+               ((point R2-rect) (up 'x 'y))))))
+
+      (testing "Setup for ex2.1, p18"
         (is (= '(/ (+ (* -2 a x)
                       (* -2 a (sqrt (+ (expt x 2) (expt y 2))))
-                      (expt x 2)
-                      (expt y 2))
+                      (expt x 2) (expt y 2))
                    (sqrt (+ (expt x 2) (expt y 2))))
                (simplify
                 ((- r (* 2 'a (+ 1 (cos theta))))
                  ((point R2-rect) (up 'x 'y)))))))
-
-      (testing "Setup for ex2.1, p18"
-        (let-coordinates [[r theta] R2-polar]
-          (is (= '(/ (+ (* -2 a x)
-                        (* -2 a (sqrt (+ (expt x 2) (expt y 2))))
-                        (expt x 2) (expt y 2))
-                     (sqrt (+ (expt x 2) (expt y 2))))
-                 (simplify
-                  ((- r (* 2 'a (+ 1 (cos theta))))
-                   ((point R2-rect) (up 'x 'y))))))))
 
       (testing "ex2.2"
         (is (= '(up (acos (/ (+ (expt rho 2) -1)

--- a/test/sicmutils/fdg/ch3_test.cljc
+++ b/test/sicmutils/fdg/ch3_test.cljc
@@ -28,8 +28,7 @@
                                          up down
                                          sin cos square exp
                                          point chart
-                                         R2-rect R2-polar
-                                         let-coordinates]
+                                         define-coordinates]
              #?@(:cljs [:include-macros true])]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
             [sicmutils.value :as v]))
@@ -39,10 +38,14 @@
 (def simplify
   (comp e/freeze e/simplify))
 
+(define-coordinates [x y] e/R2-rect)
+(define-coordinates [r theta] e/R2-polar)
+
+(def R2-rect-point ((point R2-rect) (up 'x0 'y0)))
+(def R2->R '(-> (UP Real Real) Real))
+
 (deftest section-3-1
-  (let [R2-rect-point ((point R2-rect) (up 'x0 'y0))
-        R2->R '(-> (UP Real Real) Real)
-        v (e/components->vector-field
+  (let [v (e/components->vector-field
            (up (literal-function 'b↑0 R2->R)
                (literal-function 'b↑1 R2->R))
            R2-rect)
@@ -69,111 +72,103 @@
              (up 'x0 'y0)))))))
 
 (deftest section-3-2
-  (let-coordinates [[x y]     R2-rect
-                    [r theta] R2-polar]
-    (let [R2-rect-point ((point R2-rect) (up 'x0 'y0))]
-      (testing "page 27"
-        (is (= '(* 2 x0)
-               (simplify
-                ((d:dx (square r)) R2-rect-point))))
+  (testing "page 27"
+    (is (= '(* 2 x0)
+           (simplify
+            ((d:dx (square r)) R2-rect-point))))
 
-        (is (= '(+ (* 2 x0) (* 4 y0) 3)
-               (simplify
-                (((+ d:dx (* 2 d:dy)) (+ (square r) (* 3 x)))
-                 R2-rect-point))))))))
+    (is (= '(+ (* 2 x0) (* 4 y0) 3)
+           (simplify
+            (((+ d:dx (* 2 d:dy)) (+ (square r) (* 3 x)))
+             R2-rect-point))))))
 
 (deftest section-3-3
-  (let-coordinates [[x y] R2-rect]
-    (let [circular (- (* x d:dy) (* y d:dx))]
-      (is (= '((up 1 0)
-               (up 0 t)
-               (up (* (/ -1 2) (expt t 2)) 0)
-               (up 0 (* (/ -1 6) (expt t 3)))
-               (up (* (/ 1 24) (expt t 4)) 0)
-               (up 0 (* (/ 1 120) (expt t 5))))
-             (simplify
-              (take 6
-                    (seq
-                     (((exp (* 't circular)) (chart R2-rect))
-                      ((point R2-rect) (up 1 0))))))))
-      (is (= '(up
-               (+ (* (/ -1 720) (expt delta-t 6))
-                  (* (/ 1 24) (expt delta-t 4))
-                  (* (/ -1 2) (expt delta-t 2))
-                  1)
-               (+ (* (/ 1 120) (expt delta-t 5))
-                  (* (/ -1 6) (expt delta-t 3))
-                  delta-t))
-             (simplify
-              ((((e/evolution 6) 'delta-t circular) (chart R2-rect))
-               ((point R2-rect) (up 1 0)))))))))
+  (let [circular (- (* x d:dy) (* y d:dx))]
+    (is (= '((up 1 0)
+             (up 0 t)
+             (up (* (/ -1 2) (expt t 2)) 0)
+             (up 0 (* (/ -1 6) (expt t 3)))
+             (up (* (/ 1 24) (expt t 4)) 0)
+             (up 0 (* (/ 1 120) (expt t 5))))
+           (simplify
+            (take 6
+                  (seq
+                   (((exp (* 't circular)) (chart R2-rect))
+                    ((point R2-rect) (up 1 0))))))))
+    (is (= '(up
+             (+ (* (/ -1 720) (expt delta-t 6))
+                (* (/ 1 24) (expt delta-t 4))
+                (* (/ -1 2) (expt delta-t 2))
+                1)
+             (+ (* (/ 1 120) (expt delta-t 5))
+                (* (/ -1 6) (expt delta-t 3))
+                delta-t))
+           (simplify
+            ((((e/evolution 6) 'delta-t circular) (chart R2-rect))
+             ((point R2-rect) (up 1 0))))))))
 
 (deftest section-3-5
-  (let-coordinates [[x y]     R2-rect
-                    [r theta] R2-polar]
-    (let [R2-rect-point ((point R2-rect) (up 'x0 'y0))
-          R2->R '(-> (UP Real Real) Real)
-          omega (e/components->oneform-field
-                 (down (literal-function 'a_0 R2->R)
-                       (literal-function 'a_1 R2->R))
-                 R2-rect)
-          omega2 (e/literal-oneform-field 'a R2-rect)
-          circular (- (* x d:dy) (* y d:dx))]
-      (is (= '(oneform-field (down a_0 a_1))
-             (v/freeze omega))
-          "TODO - why does this freeze into this form?")
+  (let [omega (e/components->oneform-field
+               (down (literal-function 'a_0 R2->R)
+                     (literal-function 'a_1 R2->R))
+               R2-rect)
+        omega2 (e/literal-oneform-field 'a R2-rect)
+        circular (- (* x d:dy) (* y d:dx))]
+    (is (= '(oneform-field (down a_0 a_1))
+           (v/freeze omega))
+        "TODO - why does this freeze into this form?")
 
-      (testing "page 35, with and without literal-oneform-field shorthand"
-        (is (= '(down (a_0 (up x0 y0)) (a_1 (up x0 y0)))
-               (simplify
-                ((omega (down d:dx d:dy)) R2-rect-point))))
-
-        (is (= '(down (a_0 (up x0 y0)) (a_1 (up x0 y0)))
-               (simplify
-                ((omega2 (down d:dx d:dy)) R2-rect-point)))))
-
-      (is (= '(down (((partial 0) f-rect) (up x0 y0))
-                    (((partial 1) f-rect) (up x0 y0)))
+    (testing "page 35, with and without literal-oneform-field shorthand"
+      (is (= '(down (a_0 (up x0 y0)) (a_1 (up x0 y0)))
              (simplify
-              (((e/d (literal-manifold-function 'f-rect R2-rect))
-                (e/coordinate-system->vector-basis R2-rect))
-               R2-rect-point)))
-          "p35")
+              ((omega (down d:dx d:dy)) R2-rect-point))))
 
-      (is (= '(down
-               (/ (+ (* r (cos theta) (((partial 0) f-polar) (up r theta)))
-                     (* -1 (sin theta) (((partial 1) f-polar) (up r theta))))
-                  r)
-               (/ (+ (* r (sin theta) (((partial 0) f-polar) (up r theta)))
-                     (* (cos theta) (((partial 1) f-polar) (up r theta))))
-                  r))
+      (is (= '(down (a_0 (up x0 y0)) (a_1 (up x0 y0)))
              (simplify
-              (((e/d (literal-manifold-function 'f-polar R2-polar))
-                (e/coordinate-system->vector-basis R2-rect))
-               ((point R2-polar) (up 'r 'theta)))))
-          "page 36")
+              ((omega2 (down d:dx d:dy)) R2-rect-point)))))
 
-      (is (= 0 ((dx d:dy) R2-rect-point)))
-      (is (= 1 ((dx d:dx) R2-rect-point)))
+    (is (= '(down (((partial 0) f-rect) (up x0 y0))
+                  (((partial 1) f-rect) (up x0 y0)))
+           (simplify
+            (((e/d (literal-manifold-function 'f-rect R2-rect))
+              (e/coordinate-system->vector-basis R2-rect))
+             R2-rect-point)))
+        "p35")
 
-      (is (= '(* -1 y0)
+    (is (= '(down
+             (/ (+ (* r (cos theta) (((partial 0) f-polar) (up r theta)))
+                   (* -1 (sin theta) (((partial 1) f-polar) (up r theta))))
+                r)
+             (/ (+ (* r (sin theta) (((partial 0) f-polar) (up r theta)))
+                   (* (cos theta) (((partial 1) f-polar) (up r theta))))
+                r))
+           (simplify
+            (((e/d (literal-manifold-function 'f-polar R2-polar))
+              (e/coordinate-system->vector-basis R2-rect))
+             ((point R2-polar) (up 'r 'theta)))))
+        "page 36")
+
+    (is (= 0 ((dx d:dy) R2-rect-point)))
+    (is (= 1 ((dx d:dx) R2-rect-point)))
+
+    (is (= '(* -1 y0)
+           (simplify
+            ((dx circular) R2-rect-point))))
+
+    (is (= 'x0 ((dy circular) R2-rect-point)))
+
+    (testing "page 37"
+      (is (= 0 (simplify ((dr circular) R2-rect-point))))
+      (is (= 1 (simplify ((dtheta circular) R2-rect-point))))
+
+      (let [f (literal-manifold-function 'f-rect R2-rect)]
+        (is (zero?
              (simplify
-              ((dx circular) R2-rect-point))))
+              (((- circular d:dtheta) f) R2-rect-point))))))
 
-      (is (= 'x0 ((dy circular) R2-rect-point)))
-
-      (testing "page 37"
-        (is (= 0 (simplify ((dr circular) R2-rect-point))))
-        (is (= 1 (simplify ((dtheta circular) R2-rect-point))))
-
-        (let [f (literal-manifold-function 'f-rect R2-rect)]
-          (is (zero?
-               (simplify
-                (((- circular d:dtheta) f) R2-rect-point))))))
-
-      (let [v (literal-vector-field 'b R2-rect)]
-        (is (= '(+ (* (a_0 (up x0 y0)) (b↑0 (up x0 y0)))
-                   (* (a_1 (up x0 y0)) (b↑1 (up x0 y0))))
-               (simplify
-                ((omega v) R2-rect-point)))
-            "page 38")))))
+    (let [v (literal-vector-field 'b R2-rect)]
+      (is (= '(+ (* (a_0 (up x0 y0)) (b↑0 (up x0 y0)))
+                 (* (a_1 (up x0 y0)) (b↑1 (up x0 y0))))
+             (simplify
+              ((omega v) R2-rect-point)))
+          "page 38"))))

--- a/test/sicmutils/fdg/ch5_test.cljc
+++ b/test/sicmutils/fdg/ch5_test.cljc
@@ -27,97 +27,96 @@
                                          literal-vector-field
                                          up down
                                          point chart wedge
-                                         R2-rect R3-rect R3-cyl
-                                         let-coordinates]
+                                         R2-rect
+                                         define-coordinates]
              #?@(:cljs [:include-macros true])]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]))
 
 (use-fixtures :each hermetic-simplify-fixture)
 
+(define-coordinates [x y z] e/R3-rect)
+(define-coordinates [r theta z-cyl] e/R3-cyl)
+
+(def R3-rect-point ((point R3-rect) (up 'x0 'y0 'z0)))
+(def R3-cyl-point  ((point R3-cyl) (up 'r0 'theta0 'z0)))
+
 (deftest section-5-1
-  (let-coordinates [[x y z]     R3-rect
-                    [r theta z-cyl] R3-cyl]
-    (let [R3-rect-point ((point R3-rect) (up 'x0 'y0 'z0))
-          R3-cyl-point  ((point R3-cyl) (up 'r0 'theta0 'z0))
-          u (+ (* 'u↑0 d:dx) (* 'u↑1 d:dy))
-          v (+ (* 'v↑0 d:dx) (* 'v↑1 d:dy))
-          a (+ (* 'a↑0 d:dr) (* 'a↑1 d:dtheta))
-          b (+ (* 'b↑0 d:dr) (* 'b↑1 d:dtheta))]
+  (let [u (+ (* 'u↑0 d:dx) (* 'u↑1 d:dy))
+        v (+ (* 'v↑0 d:dx) (* 'v↑1 d:dy))
+        a (+ (* 'a↑0 d:dr) (* 'a↑1 d:dtheta))
+        b (+ (* 'b↑0 d:dr) (* 'b↑1 d:dtheta))]
 
-      (is (= '(+ (* u↑0 v↑1) (* -1 u↑1 v↑0))
+    (is (= '(+ (* u↑0 v↑1) (* -1 u↑1 v↑0))
+           (simplify
+            (((wedge dx dy) u v) R3-rect-point)))
+        "Page 60")
+
+    (is (= '(+ (* a↑0 b↑1) (* -1 a↑1 b↑0))
+           (simplify
+            (((wedge dr dtheta) a b) R3-cyl-point)))
+        "Page 60"))
+
+  (let [u (+ (* 'u↑0 d:dx) (* 'u↑1 d:dy) (* 'u↑2 d:dz))
+        v (+ (* 'v↑0 d:dx) (* 'v↑1 d:dy) (* 'v↑2 d:dz))
+        w (+ (* 'w↑0 d:dx) (* 'w↑1 d:dy) (* 'w↑2 d:dz))]
+    (testing "page 61"
+      (is (= '(+ (* u↑0 v↑1 w↑2)
+                 (* -1 u↑0 v↑2 w↑1)
+                 (* -1 u↑1 v↑0 w↑2)
+                 (* u↑1 v↑2 w↑0)
+                 (* u↑2 v↑0 w↑1)
+                 (* -1 u↑2 v↑1 w↑0))
              (simplify
-              (((wedge dx dy) u v) R3-rect-point)))
-          "Page 60")
+              (((wedge dx dy dz) u v w) R3-rect-point))))
 
-      (is (= '(+ (* a↑0 b↑1) (* -1 a↑1 b↑0))
-             (simplify
-              (((wedge dr dtheta) a b) R3-cyl-point)))
-          "Page 60"))
+      (is (zero?
+           (simplify
+            (- (((wedge dx dy dz) u v w) R3-rect-point)
+               (e/determinant
+                (e/matrix-by-rows '[u↑0 u↑1 u↑2]
+                                  '[v↑0 v↑1 v↑2]
+                                  '[w↑0 w↑1 w↑2])))))
+          "This last expression is the determinant of a 3×3 matrix"))
 
-    (let [R3-rect-point ((point R3-rect) (up 'x0 'y0 'z0))
-          u (+ (* 'u↑0 d:dx) (* 'u↑1 d:dy) (* 'u↑2 d:dz))
-          v (+ (* 'v↑0 d:dx) (* 'v↑1 d:dy) (* 'v↑2 d:dz))
-          w (+ (* 'w↑0 d:dx) (* 'w↑1 d:dy) (* 'w↑2 d:dz))]
-      (testing "page 61"
-        (is (= '(+ (* u↑0 v↑1 w↑2)
-                   (* -1 u↑0 v↑2 w↑1)
-                   (* -1 u↑1 v↑0 w↑2)
-                   (* u↑1 v↑2 w↑0)
-                   (* u↑2 v↑0 w↑1)
-                   (* -1 u↑2 v↑1 w↑0))
-               (simplify
-                (((wedge dx dy dz) u v w) R3-rect-point))))
-
-        (is (zero?
-             (simplify
-              (- (((wedge dx dy dz) u v w) R3-rect-point)
-                 (e/determinant
-                  (e/matrix-by-rows '[u↑0 u↑1 u↑2]
-                                    '[v↑0 v↑1 v↑2]
-                                    '[w↑0 w↑1 w↑2])))))
-            "This last expression is the determinant of a 3×3 matrix"))
-
-      (is (= 1 (((wedge dx dy dz) d:dx d:dy d:dz)
-                R3-rect-point))))))
+    (is (= 1 (((wedge dx dy dz) d:dx d:dy d:dz)
+              R3-rect-point)))))
 
 (deftest section-5-2
   ;; Fun with unicode variable names!
-  (let-coordinates [[x y z] R3-rect]
-    (let [a (literal-manifold-function 'α R3-rect)
-          b (literal-manifold-function 'β R3-rect)
-          c (literal-manifold-function 'γ R3-rect)
-          θ (+ (* a dx) (* b dy) (* c dz))
-          X (literal-vector-field 'X-rect R3-rect)
-          Y (literal-vector-field 'Y-rect R3-rect)
-          R3-rect-point ((point R3-rect) (up 'x0 'y0 'z0))
-          ω (+ (* a (wedge dy dz))
-               (* b (wedge dz dx))
-               (* c (wedge dx dy)))
-          Z (literal-vector-field 'Z-rect R3-rect)]
-      (is (zero?
-           (simplify
-            (((- (d θ)
-                 (+ (wedge (d a) dx)
-                    (wedge (d b) dy)
-                    (wedge (d c) dz)))
-              X Y)
-             R3-rect-point)))
-          "page 63")
+  (let [a (literal-manifold-function 'α R3-rect)
+        b (literal-manifold-function 'β R3-rect)
+        c (literal-manifold-function 'γ R3-rect)
+        θ (+ (* a dx) (* b dy) (* c dz))
+        X (literal-vector-field 'X-rect R3-rect)
+        Y (literal-vector-field 'Y-rect R3-rect)
+        ω (+ (* a (wedge dy dz))
+             (* b (wedge dz dx))
+             (* c (wedge dx dy)))
+        Z (literal-vector-field 'Z-rect R3-rect)]
+    (is (zero?
+         (simplify
+          (((- (d θ)
+               (+ (wedge (d a) dx)
+                  (wedge (d b) dy)
+                  (wedge (d c) dz)))
+            X Y)
+           R3-rect-point)))
+        "page 63")
 
-      (is (zero?
-           (simplify
-            (((- (d ω)
-                 (+ (wedge (d a) dy dz)
-                    (wedge (d b) dz dx)
-                    (wedge (d c) dx dy)))
-              X Y Z)
-             R3-rect-point)))
-          "page 64")
+    (is (zero?
+         (simplify
+          (((- (d ω)
+               (+ (wedge (d a) dy dz)
+                  (wedge (d b) dz dx)
+                  (wedge (d c) dx dy)))
+            X Y Z)
+           R3-rect-point)))
+        "page 64")
 
-      (is (zero?
-           (simplify
-            (((d (d θ)) X Y Z) R3-rect-point)))
-          "page 65"))))
+    (is (zero?
+         (simplify
+          (((d (d θ)) X Y Z) R3-rect-point)))
+        "page 65")))
 
 (deftest section-5-4
   (let [v (literal-vector-field 'v-rect R2-rect)
@@ -139,23 +138,21 @@
            R2-rect-point)))
         "page 67"))
 
-  (let-coordinates [[x y z] R3-rect]
-    (let [a (literal-manifold-function 'a-rect R3-rect)
-          b (literal-manifold-function 'b-rect R3-rect)
-          c (literal-manifold-function 'c-rect R3-rect)
-          flux-through-boundary-element (+ (* a (wedge dy dz))
-                                           (* b (wedge dz dx))
-                                           (* c (wedge dx dy)))
-          production-in-volume-element (* (+ (d:dx a) (d:dy b) (d:dz c))
-                                          (wedge dx dy dz))
-          X (literal-vector-field 'X-rect R3-rect)
-          Y (literal-vector-field 'Y-rect R3-rect)
-          Z (literal-vector-field 'Z-rect R3-rect)
-          R3-rect-point((point R3-rect) (up 'x0 'y0 'z0))]
-      (is (zero?
-           (simplify
-            (((- production-in-volume-element
-                 (d flux-through-boundary-element))
-              X Y Z)
-             R3-rect-point)))
-          "page 69"))))
+  (let [a (literal-manifold-function 'a-rect R3-rect)
+        b (literal-manifold-function 'b-rect R3-rect)
+        c (literal-manifold-function 'c-rect R3-rect)
+        flux-through-boundary-element (+ (* a (wedge dy dz))
+                                         (* b (wedge dz dx))
+                                         (* c (wedge dx dy)))
+        production-in-volume-element (* (+ (d:dx a) (d:dy b) (d:dz c))
+                                        (wedge dx dy dz))
+        X (literal-vector-field 'X-rect R3-rect)
+        Y (literal-vector-field 'Y-rect R3-rect)
+        Z (literal-vector-field 'Z-rect R3-rect)]
+    (is (zero?
+         (simplify
+          (((- production-in-volume-element
+               (d flux-through-boundary-element))
+            X Y Z)
+           R3-rect-point)))
+        "page 69")))

--- a/test/sicmutils/fdg/ch7_test.cljc
+++ b/test/sicmutils/fdg/ch7_test.cljc
@@ -160,26 +160,25 @@
                      ((point R3-rect) (up 1 0 0))))))))))
 
 (deftest section-7-1c
-  (e/let-coordinates
-   [[x y z] R3-rect]
-   (let [X (e/literal-vector-field 'X-rect R3-rect)
-         Y (e/literal-vector-field 'Y-rect R3-rect)
-         Z (e/literal-vector-field 'Z-rect R3-rect)
-         a (e/literal-manifold-function 'alpha R3-rect)
-         b (e/literal-manifold-function 'beta R3-rect)
-         c (e/literal-manifold-function 'gamma R3-rect)
-         omega (+ (* a (wedge dx dy))
-                  (* b (wedge dy dz))
-                  (* c (wedge dz dx)))
-         L1 (fn [X]
-              (fn [omega]
-                (+ ((e/interior-product X) (d omega))
-                   (d ((e/interior-product X) omega)))))]
-     (is (zero?
-          (simplify
-           ((- (((e/Lie-derivative X) omega) Y Z)
-               (((L1 X) omega) Y Z))
-            ((point R3-rect) (up 'x0 'y0 'z0)))))))))
+  (let-coordinates [[x y z] R3-rect]
+    (let [X (e/literal-vector-field 'X-rect R3-rect)
+          Y (e/literal-vector-field 'Y-rect R3-rect)
+          Z (e/literal-vector-field 'Z-rect R3-rect)
+          a (e/literal-manifold-function 'alpha R3-rect)
+          b (e/literal-manifold-function 'beta R3-rect)
+          c (e/literal-manifold-function 'gamma R3-rect)
+          omega (+ (* a (wedge dx dy))
+                   (* b (wedge dy dz))
+                   (* c (wedge dz dx)))
+          L1 (fn [X]
+               (fn [omega]
+                 (+ ((e/interior-product X) (d omega))
+                    (d ((e/interior-product X) omega)))))]
+      (is (zero?
+           (simplify
+            ((- (((e/Lie-derivative X) omega) Y Z)
+                (((L1 X) omega) Y Z))
+             ((point R3-rect) (up 'x0 'y0 'z0)))))))))
 
 (defn F-parallel [omega phi coordinate-system]
   (let [basis  (e/coordinate-system->basis coordinate-system)

--- a/test/sicmutils/fdg/einstein_test.cljc
+++ b/test/sicmutils/fdg/einstein_test.cljc
@@ -23,11 +23,12 @@
             [sicmutils.calculus.form-field :as ff]
             [sicmutils.calculus.indexed :as ci]
             [sicmutils.calculus.vector-field :as vf]
-            [sicmutils.env :as e :refer [+ - * / expt sin let-coordinates
+            [sicmutils.env :as e :refer [+ - * / expt sin
                                          literal-function
                                          with-literal-functions
                                          spacetime-rect spacetime-sphere
-                                         compose square point up]
+                                         compose square point up
+                                         let-coordinates]
              #?@(:cljs [:include-macros true])]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
             [sicmutils.value :as v]))

--- a/test/sicmutils/function_test.cljc
+++ b/test/sicmutils/function_test.cljc
@@ -73,6 +73,10 @@
               (is ((v/exact? identity) n))
               (is (not ((v/exact? identity) n)))))
 
+  (checking "print-method uses a function's name" 100 [s gen/string]
+            (is (= s (pr-str
+                      (with-meta identity {:name s})))))
+
   (testing "v/freeze"
     (is (= ['+ '- '* '/ 'modulo 'quotient 'remainder
             'negative? '< '<= '> '>= '=
@@ -80,6 +84,14 @@
            (map v/freeze [+ - * / mod quot rem
                           neg? < <= > >= =
                           g/partial-derivative]))
+        "Certain functions freeze to symbols")
+
+    (is (= ["+" "-" "*" "/" "modulo" "quotient" "remainder"
+            "negative?" "<" "<=" ">" ">=" "="
+            "partial-derivative"]
+           (map pr-str [+ - * / mod quot rem
+                        neg? < <= > >= =
+                        g/partial-derivative]))
         "Certain functions freeze to symbols")
 
     (is (= (map v/freeze [g/+ g/- g/* g//

--- a/test/sicmutils/function_test.cljc
+++ b/test/sicmutils/function_test.cljc
@@ -73,10 +73,6 @@
               (is ((v/exact? identity) n))
               (is (not ((v/exact? identity) n)))))
 
-  (checking "print-method uses a function's name" 100 [s gen/string]
-            (is (= s (pr-str
-                      (with-meta identity {:name s})))))
-
   (testing "v/freeze"
     (is (= ['+ '- '* '/ 'modulo 'quotient 'remainder
             'negative? '< '<= '> '>= '=
@@ -84,14 +80,6 @@
            (map v/freeze [+ - * / mod quot rem
                           neg? < <= > >= =
                           g/partial-derivative]))
-        "Certain functions freeze to symbols")
-
-    (is (= ["+" "-" "*" "/" "modulo" "quotient" "remainder"
-            "negative?" "<" "<=" ">" ">=" "="
-            "partial-derivative"]
-           (map pr-str [+ - * / mod quot rem
-                        neg? < <= > >= =
-                        g/partial-derivative]))
         "Certain functions freeze to symbols")
 
     (is (= (map v/freeze [g/+ g/- g/* g//


### PR DESCRIPTION
From the CHANGELOG:

- #393:

  - Forms like `(let-coordinates [(up x y) R2-rect] ...)` will now work even if
    `up` is not present in the environment. Previously this syntax was valid,
    but only if `up` had been imported.

  - Adds the `sicmutils.calculus.coordinate/define-coordinates` macro, also
    aliased into `sicmutils.env`. This macro allows you to write forms like

```clj
(define-coordinates (up t x y z) spacetime-rect)
(define-coordinates [r theta] R2-polar)
```

  and install set of bindings for a manifold's coordinate functions, basis
  vector fields and basis form fields into a namespace. This is used liberally
  in Functional Differential Geometry. (You might still prefer `let-coordinates`
  for temporary binding installation.)

  - Converts many of the `sicmutils.fdg` test namespaces to use the new
    `define-coordinates` macro, making for a presentation closer to the book's.

  - Fixes a Clojurescript warning in `sicmutils.util` warning due to
    redefinition of `clojure.core/uuid`