### PR TITLE
Fix type bug in covariant.cljc tests, bug w/ derivatives of fns returning maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 0.20.0
 
+- #394 fixes a bug with derivatives of functions that returned a map... but
+  where the map was actually meant to represent some other type, by holding a
+  `:type` key. We do this for manifold families and manifold points, as two
+  examples. Now, instead of recursing into the values, the system will correctly
+  throw an error. (You can fix this by using a `defrecord` instead of a map and
+  implementing `sicmutils.differential/IPerturbed`.)
+
 - #393:
 
   - Forms like `(let-coordinates [(up x y) R2-rect] ...)` will now work even if

--- a/src/sicmutils/collection.cljc
+++ b/src/sicmutils/collection.cljc
@@ -196,7 +196,12 @@
    d/IPerturbed
    (perturbed? [m] (boolean (some d/perturbed? (vals m))))
    (replace-tag [m old new] (u/map-vals #(d/replace-tag % old new) m))
-   (extract-tangent [m tag] (u/map-vals #(d/extract-tangent % tag) m))))
+   (extract-tangent [m tag]
+     (if-let [t (:type m)]
+       ;; Do NOT attempt to recurse into the values if this map is being used as a
+       ;; simple representation for some other type, like a manifold point.
+       (u/unsupported (str "`extract-tangent` not supported for type " t "."))
+       (u/map-vals #(d/extract-tangent % tag) m)))))
 
 
 ;; ## Sets

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -1019,10 +1019,3 @@
                   gamma)
                  u)
                 ((point the-real-line) 't)))))))))
-
-
-
-;; AHHHHH, so this is hitting the default of extract-tangent!! Tell GJS. You
-;; cannot do that, you probably want a default that errors. In this case, you
-;; are hitting it because you have a derivative of a function that returns a
-;; manifold point.

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -158,8 +158,9 @@
                                         x)))]
                             ((D g) 0))))))]
             (is (zero?
-                 (- ((((Lie-test X) Y) f) R2-rect-point)
-                    ((((g/Lie-derivative X) Y) f) R2-rect-point))))))))
+                 (simplify
+                  (- ((((Lie-test X) Y) f) R2-rect-point)
+                     ((((g/Lie-derivative X) Y) f) R2-rect-point)))))))))
 
     (testing "Lie derivative satisfies extended Leibnitz rule"
       (let [V (vf/literal-vector-field 'V R2-rect)

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -39,7 +39,7 @@
             [sicmutils.calculus.vector-field :as vf]
             [sicmutils.mechanics.lagrange :as ml]
             [sicmutils.expression :as x]
-            [sicmutils.function :as f]
+            [sicmutils.function :as f :refer [compose]]
             [sicmutils.generic :as g :refer [+ - * / sin cos tan]]
             [sicmutils.polynomial.gcd :as pg]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
@@ -145,19 +145,21 @@
         ;; Is this correct? No! Cannot add to a manifold point.
 
         ;; g(t) = ( Y(f) ((I + t v(I))(x)) - Y(f circ (I + t v(I)))(x))
-        (letfn [(Lie-test [V]
-                  (fn [Y]
-                    (fn [f]
-                      (fn [x]
-                        (letfn [(g [t]
-                                  (- ((Y f) ((+ identity (* t (V identity))) x))
-                                     ((Y (f/compose f (+ identity (* t (V identity))))) x)))]
-                          ((D g) 0))))))]
-          (comment
-            ;; TODO I think this is broken in Lie.scm; it only works because
-            ;; zero-like on a point returns 0.
-            (is (= 0 (- ((((Lie-test X) Y) f) R2-rect-point)
-                        ((((g/Lie-derivative X) Y) f) R2-rect-point))))))))
+        (let [I (chart R2-rect)]
+          (letfn [(Lie-test [V]
+                    (fn [Y]
+                      (fn [f]
+                        (fn [x]
+                          (letfn [(g [t]
+                                    (- ((compose (Y f) (point R2-rect))
+                                        ((+ I (* t (V I))) x))
+                                       ((Y (compose f (point R2-rect)
+                                                    (+ I (* t (V I)))))
+                                        x)))]
+                            ((D g) 0))))))]
+            (is (zero?
+                 (- ((((Lie-test X) Y) f) R2-rect-point)
+                    ((((g/Lie-derivative X) Y) f) R2-rect-point))))))))
 
     (testing "Lie derivative satisfies extended Leibnitz rule"
       (let [V (vf/literal-vector-field 'V R2-rect)
@@ -196,7 +198,7 @@
                            ((point R2-rect) coords))))))
 
             gamma (fn [initial-point]
-                    (f/compose
+                    (compose
                      (point R2-rect)
                      (q ((chart R2-rect) initial-point))))
 
@@ -219,14 +221,14 @@
                (present
                 ((D (fn [t]
                       (- ((Y f) ((phiX t) m_0))
-                         ((Y (f/compose f (phiX t))) m_0))))
+                         ((Y (compose f (phiX t))) m_0))))
                  0))))
 
         (is (= 0 (simplify
                   (- result-via-Lie
                      ((D (fn [t]
                            (- ((Y f) ((phiX t) m_0))
-                              ((Y (f/compose f (phiX t))) m_0))))
+                              ((Y (compose f (phiX t))) m_0))))
                       0)))
                ))
 
@@ -596,15 +598,15 @@
                           (down (up zero (/ 1 (tan theta)))
                                 (up (- (* (sin theta) (cos theta))) zero))))
                   spherical-basis)
-          gamma:N->M (f/compose (point S2-spherical)
+          gamma:N->M (compose (point S2-spherical)
                                 (up (af/literal-function 'alpha)
                                     (af/literal-function 'beta))
                                 (chart the-real-line))
           basis-over-gamma (cm/basis->basis-over-map gamma:N->M spherical-basis)
           w (vf/basis-components->vector-field
-             (up (f/compose (af/literal-function 'w0)
+             (up (compose (af/literal-function 'w0)
                             (chart the-real-line))
-                 (f/compose (af/literal-function 'w1)
+                 (compose (af/literal-function 'w1)
                             (chart the-real-line)))
              (b/basis->vector-basis basis-over-gamma))
           sphere-Cartan (cov/Christoffel->Cartan G-S2-1)]
@@ -648,7 +650,7 @@
                       t the-real-line]
       (let [CG (cov/make-Christoffel G (b/coordinate-system->basis R2-rect))
 
-            gamma:N->M (f/compose
+            gamma:N->M (compose
                         (point R2-rect)
                         (up (af/literal-function 'alpha)
                             (af/literal-function 'beta))
@@ -657,10 +659,10 @@
                               gamma:N->M
                               (b/coordinate-system->basis R2-rect))
             u (vf/basis-components->vector-field
-               (up (f/compose (af/literal-function 'u0)
-                              (chart the-real-line))
-                   (f/compose (af/literal-function 'u1)
-                              (chart the-real-line)))
+               (up (compose (af/literal-function 'u0)
+                            (chart the-real-line))
+                   (compose (af/literal-function 'u1)
+                            (chart the-real-line)))
                (b/basis->vector-basis basis-over-gamma))]
         (is (= '(up (+ (* (G↑0_00 (up (alpha t) (beta t))) ((D alpha) t) (u0 t))
                        (* ((D alpha) t) (G↑0_10 (up (alpha t) (beta t))) (u1 t))
@@ -719,10 +721,10 @@
                      (down (up zero (/ 1 (tan theta)))
                            (up (- (* (sin theta) (cos theta))) zero))))
              two-sphere-basis)
-            mu:N->M (f/compose (point S2-spherical)
-                               (up (af/literal-function 'mu-theta)
-                                   (af/literal-function 'mu-phi))
-                               (chart R1-rect))
+            mu:N->M (compose (point S2-spherical)
+                             (up (af/literal-function 'mu-theta)
+                                 (af/literal-function 'mu-phi))
+                             (chart R1-rect))
             Cartan (cov/Christoffel->Cartan G-S2-1)]
         (is (= '(up (+ (* -1
                           (sin (mu-theta tau))
@@ -764,12 +766,12 @@
           ;; this no longer works, because R3-rect does not accept an S2-spherical
           ;; point as in the same manifold. Fixed by explicit transfer of a point --
           ;; see manifold.scm
-          F (f/compose
+          F (compose
              (chart R3-rect)
              (man/transfer-point S2-spherical R3-rect)
              (point S2-spherical)
              ml/coordinate)
-          Lsphere (f/compose (Lfree 1) (ml/F->C F))]
+          Lsphere (compose (Lfree 1) (ml/F->C F))]
       ;; Note these are DOWN while the geodesic equations are UP.  This is
       ;; due to the fact that the geodesic equations are raised by the
       ;; metric, which is diagonal, here R=1, and cancels an instance
@@ -991,16 +993,16 @@
                                           (cos theta)))
                                     zero))))
                   S2-basis)
-          gamma (f/compose (point S2-spherical)
-                           (up (af/literal-function 'alpha)
-                               (af/literal-function 'beta))
-                           (chart the-real-line))
+          gamma (compose (point S2-spherical)
+                         (up (af/literal-function 'alpha)
+                             (af/literal-function 'beta))
+                         (chart the-real-line))
           basis-over-gamma (cm/basis->basis-over-map gamma S2-basis)
           u (vf/basis-components->vector-field
-             (up (f/compose (af/literal-function 'u↑0)
-                            (chart the-real-line))
-                 (f/compose (af/literal-function 'u↑1)
-                            (chart the-real-line)))
+             (up (compose (af/literal-function 'u↑0)
+                          (chart the-real-line))
+                 (compose (af/literal-function 'u↑1)
+                          (chart the-real-line)))
              (b/basis->vector-basis basis-over-gamma))
           sphere-Cartan (cov/Christoffel->Cartan G-S2-1)]
 
@@ -1017,3 +1019,10 @@
                   gamma)
                  u)
                 ((point the-real-line) 't)))))))))
+
+
+
+;; AHHHHH, so this is hitting the default of extract-tangent!! Tell GJS. You
+;; cannot do that, you probably want a default that errors. In this case, you
+;; are hitting it because you have a derivative of a function that returns a
+;; manifold point.

--- a/test/sicmutils/calculus/derivative_test.cljc
+++ b/test/sicmutils/calculus/derivative_test.cljc
@@ -151,7 +151,18 @@
               :cube '(* 3 (expt x 2))}
              (simplify ((D f) 'x)))
           "derivative of a fn returning a map returns the derivative for each
-          value")))
+          value"))
+
+    (letfn [(f [x]
+              {:type ::my-custom-type
+               :square (g/square x)
+               :cube   (g/cube x)})]
+      (is (thrown? #?(:clj UnsupportedOperationException :cljs js/Error)
+                   ((D f) 'x))
+          "If the function returns a map with a `:type` key, the system will NOT
+          attempt to recurse into the values, and will instead error. (If you
+          want to take derivatives of some object represented with a map, either
+          use a `defrecord` or `deftype` or file an issue to discuss!.)")))
 
   (testing "Operator"
     (letfn [(f [x]


### PR DESCRIPTION
This PR fixes an issue I encountered when converting Lie.scm in the scmutils codebase. One of the examples errored for me instead of returning the expected value.

Figuring this out helped me tidy up an edge case with derivatives of functions that return maps. I'll add my email to GJS with the scmutils problem details as an issue comment.