### PR TITLE
Fix bug with define-coordinates in sci macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
     evaluate `(require '[sicmutils.env :refer :all])` against your SCI
     environment to get all bindings.
 
+  - bumps the default version of SCI to 0.2.7.
+
 ## 0.20.0
 
 - #348:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [unreleased]
 
+- #396:
+
+  - fixes a bug in the SCI version of `define-coordinates` which didn't allow
+    any rebinding of manifolds.
+
+  - Removes the `bindings` key from `sicmutils.env.sci/context-opts`.
+    https://github.com/babashka/sci/issues/637 is a bug with variable rebinding
+    that occurs when `:bindings` is in play. Instead of relying on this key,
+    evaluate `(require '[sicmutils.env :refer :all])` against your SCI
+    environment to get all bindings.
+
 ## 0.20.0
 
 - #348:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ and proper ratios in Clojurescript:
 ;;=> 3/2
 
 (asin -10)
-;;=> #sicm/complex "-1.5707963268 + 2.9932228461i"
+;;=> #sicm/complex [-1.5707963267948966 2.9932228461263786]
 ```
 
 Symbols are interpreted as abstract complex numbers, and arithmetic on them
@@ -116,7 +116,7 @@ to collapse symbolic expressions into tidy form:
 (simplify ((D cube) 'x))
 ;;=> (* 3 (expt x 2))
 
-(render
+(->infix
  (simplify ((D cube) 'x)))
 ;;-> "3 x²"
 ```
@@ -163,7 +163,7 @@ examples above and start to explore on your own.
   together.
 - Visit our [CLJDocs][CLJDOCS] page for an introduction and detailed
   documentation
-- Watch Colin's ["Physics in Clojure"][PHYSICS_IN_CLOJURE] talk for on overview
+- Watch Colin's ["Physics in Clojure"][PHYSICS_IN_CLOJURE] talk for an overview
   of SICMUtils and its implementation
 - Visit the HTML version of [Structure and Interpretation of Classical
   Mechanics](https://tgvaughan.github.io/sicm/). Many of the SICM exercises have

--- a/deps.edn
+++ b/deps.edn
@@ -9,5 +9,5 @@
         hiccup/hiccup {:mvn/version "1.0.5"},
         org.clojure/core.match {:mvn/version "1.0.0"},
         cljsjs/complex {:mvn/version "2.0.11-0"},
-        borkdude/sci {:mvn/version "0.2.5"},
+        borkdude/sci {:mvn/version "0.2.7"},
         cljsjs/bigfraction {:mvn/version "4.1.1-0"}}}

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  [org.clojure/clojurescript "1.10.773" :scope "provided"]
                  [org.clojure/core.match "1.0.0"]
                  [org.clojure/math.numeric-tower "0.0.4"]
-                 [borkdude/sci "0.2.5"]
+                 [borkdude/sci "0.2.7"]
                  [com.taoensso/timbre "5.1.2"
                   :exclusions [org.clojure/clojurescript]]
                  [dm3/stopwatch "0.1.1"]

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -144,8 +144,7 @@
   bindings) required to evaluate SICMUtils forms from inside of an SCI
   context. Pass these to `sci/init` to generate an sci context."}
   context-opts
-  {:namespaces namespaces
-   :bindings (namespaces 'sicmutils.env)})
+  {:namespaces namespaces})
 
 (def ^{:doc "sci context (currently only `:namespace` bindings) required to
   evaluate SICMUtils forms via SCI"}

--- a/src/sicmutils/env/sci/macros.cljc
+++ b/src/sicmutils/env/sci/macros.cljc
@@ -140,8 +140,8 @@
         sys-sym            (gensym)
         value-sym          (gensym)
         bind               (fn [sym form]
-                             `(do (ns-unmap *ns* '~sym)
-                                  (intern *ns* '~sym ~form)))]
+                             `(do (clojure.core/ns-unmap *ns* '~sym)
+                                  (clojure.core/intern *ns* '~sym ~form)))]
     `(let [~sys-sym (m/with-coordinate-prototype
                       ~coordinate-system
                       ~(cc/quotify-coordinate-prototype coordinate-prototype))]

--- a/src/sicmutils/util/def.cljc
+++ b/src/sicmutils/util/def.cljc
@@ -156,7 +156,7 @@
            nsm (ns-map ns)
            remote? (fn [sym]
                      (when-let [v (nsm sym)]
-                       (not= *ns* (:ns (meta v)))))
+                       (not= ns (:ns (meta v)))))
            warn (fn [sym]
                   `(.println
                     (RT/errPrintWriter)

--- a/test/sicmutils/env/sci_test.cljc
+++ b/test/sicmutils/env/sci_test.cljc
@@ -27,7 +27,10 @@
             [sicmutils.value :as v]))
 
 (defn eval [form]
-  (sci/eval-form (sci/fork es/context) form))
+  (let [ctx (sci/fork es/context)]
+    (sci/binding [sci/ns @sci/ns]
+      (sci/eval-form ctx '(require '[sicmutils.env :refer :all]))
+      (sci/eval-form ctx form))))
 
 (deftest pattern-tests
   (is (= ['(+ 2 1) "done!"]

--- a/test/sicmutils/fdg/ch1_test.cljc
+++ b/test/sicmutils/fdg/ch1_test.cljc
@@ -110,5 +110,5 @@
                    (* (* 'm (metric-components (gamma ((point R1-rect) 't))))
                       geodesic-equation-residuals))))
             "p10: This establishes that for a 2-dimensional space the
-               Euler-Lagrange equations are equivalent to the geodesic
-               equations.")))))
+             Euler-Lagrange equations are equivalent to the geodesic
+             equations.")))))


### PR DESCRIPTION
Woohoo, thanks @borkdude for the help with a local repro.

From the CHANGELOG:

- #396:

  - fixes a bug in the SCI version of `define-coordinates` which didn't allow
    any rebinding of manifolds.

  - Removes the `bindings` key from `sicmutils.env.sci/context-opts`.
    https://github.com/babashka/sci/issues/637 is a bug with variable rebinding
    that occurs when `:bindings` is in play. Instead of relying on this key,
    evaluate `(require '[sicmutils.env :refer :all])` against your SCI
    environment to get all bindings.