### PR TITLE
prepend prototype symbol in typical-coords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [unreleased]
 
+- `sicmutils.calculus.manifold/typical-coords` now returns generated coordinate
+  symbols that start with the same symbol as the coordinate system's prototype,
+  like:
+
+```clj
+(typical-coords R2-polar)
+(up x065308 x165309)
+
+(typical-coords
+ (with-coordinate-prototype R2-polar (up 'r 'theta)))
+(up r65312 theta65313)
+```
+
 ## 0.20.1
 
 - #396:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 ## [unreleased]
 
-- `sicmutils.calculus.manifold/typical-coords` now returns generated coordinate
-  symbols that start with the same symbol as the coordinate system's prototype,
-  like:
+- #397: `sicmutils.calculus.manifold/typical-coords` now returns generated
+  coordinate symbols that start with the same symbol as the coordinate system's
+  prototype, like:
 
 ```clj
 (typical-coords R2-polar)
-(up x065308 x165309)
+;;=> (up x065308 x165309)
 
 (typical-coords
  (with-coordinate-prototype R2-polar (up 'r 'theta)))
-(up r65312 theta65313)
+;;=> (up r65312 theta65313)
 ```
 
 ## 0.20.1

--- a/src/sicmutils/calculus/manifold.cljc
+++ b/src/sicmutils/calculus/manifold.cljc
@@ -417,8 +417,7 @@
 
   See [[typical-point]] for a coordinate-free version of this function."
   [coordinate-system]
-  (s/typical-object
-   (coordinate-prototype coordinate-system)))
+  (s/mapr gensym (coordinate-prototype coordinate-system)))
 
 (defn typical-point
   "Given an [[ICoordinateSystem]], returns a unique, symbolically-represented


### PR DESCRIPTION
I had missed that this is how the original scmutils version worked!

- `sicmutils.calculus.manifold/typical-coords` now returns generated coordinate
  symbols that start with the same symbol as the coordinate system's prototype,
  like:

```clj
(typical-coords R2-polar)
(up x065308 x165309)

(typical-coords
 (with-coordinate-prototype R2-polar (up 'r 'theta)))
(up r65312 theta65313)
```