### PR TITLE
Allow pattern matches to match nil, false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- #434: allow pattern matching forms to successfully bind to `nil` or `false`.
+
 - #397: `sicmutils.calculus.manifold/typical-coords` now returns generated
   coordinate symbols that start with the same symbol as the coordinate system's
   prototype, like:

--- a/src/pattern/match.cljc
+++ b/src/pattern/match.cljc
@@ -167,7 +167,7 @@
      (predicate pred)
      (fn bind-match [frame data succeed]
        (when (pred data)
-         (if-let [binding (frame sym)]
+         (if-let [[_ binding] (find frame sym)]
            (core:and (= binding data)
                      (succeed frame))
            (succeed (assoc frame sym data))))))))

--- a/test/pattern/match_test.cljc
+++ b/test/pattern/match_test.cljc
@@ -80,6 +80,26 @@
     (is (= {:x 'a} ((m/bind :x) {} 'a identity)))
     (is (= {:x '(a b)} ((m/bind :x) {} '(a b) identity))))
 
+  (testing "bind on nil, false"
+    (is (false? ((m/bind :x) {:x false} nil identity))
+        "false and nil don't match")
+
+    (is (false? ((m/bind :x) {:x nil} false identity))
+        "false and nil don't match")
+
+    (is (= {:x false} ((m/bind :x) {} false identity))
+        "false is bound if present")
+
+    (is (= {:x false}
+           ((m/bind :x) {:x false} false identity)
+           ((m/bind :x) {} false identity))
+        "false is bound if present and equal, or not present")
+
+    (is (= {:x nil}
+           ((m/bind :x) {:x nil} nil identity)
+           ((m/bind :x) {} nil identity))
+        "nil is bound if present and equal, or not present"))
+
   (testing "bind with constraint"
     (is (= {:x 6} ((m/bind :x integer?) {} 6 identity)))
 


### PR DESCRIPTION
This PR fixes an issue discovered by @AdamHaber, where pattern binding failed on false or nil values.