### PR TITLE
Convert doall calls to run!, dorun and mapv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [unreleased]
 
-- latest: convert `doall` calls to `run!`, `dorun` or `mapv` where applicable.
-  In cases where we were trying to force side effects (mostly in the tests),
-  this change prevents the environment from retaining the full sequence. This
-  will save memory!
+- #438: convert `doall` calls to `run!`, `dorun` or `mapv` where applicable. In
+  cases where we were trying to force side effects (mostly in the tests), this
+  change prevents the environment from retaining the full sequence. This will
+  save memory!
 
 - #434: allow pattern matching forms to successfully bind to `nil` or `false`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased]
 
+- latest: convert `doall` calls to `run!`, `dorun` or `mapv` where applicable.
+  In cases where we were trying to force side effects (mostly in the tests),
+  this change prevents the environment from retaining the full sequence. This
+  will save memory!
+
 - #434: allow pattern matching forms to successfully bind to `nil` or `false`.
 
 - #397: `sicmutils.calculus.manifold/typical-coords` now returns generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## [unreleased]
 
-- #438: convert `doall` calls to `run!`, `dorun` or `mapv` where applicable. In
-  cases where we were trying to force side effects (mostly in the tests), this
-  change prevents the environment from retaining the full sequence. This will
-  save memory!
+- #438:
+
+  - converts `doall` calls to `run!`, `dorun`, `doseq` or `mapv` where
+    applicable. In cases where we were trying to force side effects (mostly in
+    the tests), this change prevents the environment from retaining the full
+    sequence. This will save memory!
+
+  - adds missing tests from `connection.scm` to
+    `sicmutils.calculus.connection-test`, stressing pages 205 - 213 from MTW,
+    Gravitation.
 
 - #434: allow pattern matching forms to successfully bind to `nil` or `false`.
 

--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -221,11 +221,10 @@
                   (sequential? node)
                   (let [[f-sym & args] node]
                     (if-let [f (sym->f f-sym)]
-                      ;; NOTE: I'm not sure why this `doall` is required.
-                      ;; Without it, we were getting heisenbugs in the rational
+                      ;; NOTE: without `mapv` (ie, with `map` and a lazy
+                      ;; sequence), we were getting heisenbugs in the rational
                       ;; function simplifier, and `mismatched-arity` notes.
-                      (apply f (doall
-                                (map walk args)))
+                      (apply f (mapv walk args))
                       (u/illegal (str "Missing fn for symbol - " f-sym))))
                   :else node))]
     (walk

--- a/src/sicmutils/numerical/quadrature/midpoint.cljc
+++ b/src/sicmutils/numerical/quadrature/midpoint.cljc
@@ -184,8 +184,8 @@
       n-seq (interleave
              (iterate (fn [x] (* 2 x)) 2)
              (iterate (fn [x] (* 2 x)) 3))]
-  (doall (take 12 (midpoint-sequence f1 0 1 {:n n-seq})))
-  (doall (take 12 (map (qr/midpoint-sum f2 0 1) n-seq)))
+  (dorun (take 12 (midpoint-sequence f1 0 1 {:n n-seq})))
+  (dorun (take 12 (map (qr/midpoint-sum f2 0 1) n-seq)))
   (= [253 315]
      [@counter1 @counter2]))
 

--- a/src/sicmutils/numerical/quadrature/trapezoid.cljc
+++ b/src/sicmutils/numerical/quadrature/trapezoid.cljc
@@ -256,10 +256,10 @@
       n-seq (take (inc n-elements)
                   (iterate (fn [x] (* 2 x)) 1))]
   ;; Incremental version evaluating every `n` in the sequence $1, 2, 4, ...$:
-  (doall (trapezoid-sequence f1 0 1 {:n n-seq}))
+  (dorun (trapezoid-sequence f1 0 1 {:n n-seq}))
 
   ;; Non-incremental version evaluating every `n` in the sequence $1, 2, 4, ...$:
-  (doall (map (trapezoid-sum f2 0 1) n-seq))
+  (run! (trapezoid-sum f2 0 1) n-seq)
 
   ;; A single evaluation of the final `n`
   ((trapezoid-sum f3 0 1) (last n-seq))
@@ -290,8 +290,8 @@
       n-seq (take 12 (interleave
                       (iterate (fn [x] (* 2 x)) 2)
                       (iterate (fn [x] (* 2 x)) 3)))]
-  (doall (trapezoid-sequence f1 0 1 {:n n-seq}))
-  (doall (map (trapezoid-sum f2 0 1) n-seq))
+  (dorun (trapezoid-sequence f1 0 1 {:n n-seq}))
+  (run! (trapezoid-sum f2 0 1) n-seq)
   (= [162 327]
      [@counter1 @counter2]))
 

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -613,7 +613,7 @@
   For example:
 
   ```clojure
-  (doall (map-chain print (s/down (s/up 1 2) (s/up 3 4))))
+  (dorun (map-chain println (s/down (s/up 1 2) (s/up 3 4))))
 
   1 [0 0] [:s/down :s/up]
   2 [0 1] [:s/down :s/up]

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -84,18 +84,17 @@
 
 (deftest predicate-tests
   (testing "v/="
-    (dorun
-     (for [l ['x (an/literal-number 'x)]
-           r ['x (an/literal-number 'x)]]
-       (is (v/= l r))))
+    (doseq [l ['x (an/literal-number 'x)]
+            r ['x (an/literal-number 'x)]]
+      (is (v/= l r)))
 
-    (dorun
-     (for [l [12 (an/literal-number 12)]
-           r [12 (an/literal-number 12)]]
-       (do (is (v/= l r))
-           #?(:cljs (is (= l r)
-                        "cljs overrides equality, and can compare literals with
-                        true numbers on the left side."))))))
+    (doseq [l [12 (an/literal-number 12)]
+            r [12 (an/literal-number 12)]]
+      (is (v/= l r))
+      #?(:cljs
+         (is (= l r)
+             "cljs overrides equality, and can compare literals with
+                        true numbers on the left side."))))
 
   (checking "interaction with symbols" 100 [x gen/symbol]
             (is (not (an/literal-number? x))
@@ -139,12 +138,11 @@
                ;; NOTE: This is cased to NOT consider rational numbers for now.
                [[l-num r-num] (gen/vector sg/real-without-ratio 2)]
                (let [compare-bit (v/compare l-num r-num)]
-                 (dorun
-                  (for [l [l-num (an/literal-number l-num)]
-                        r [r-num (an/literal-number r-num)]]
-                    (cond (neg? compare-bit)  (is (< l r))
-                          (zero? compare-bit) (is (and (<= l r) (= l r) (>= l r)))
-                          :else (is (> l r))))))))
+                 (doseq [l [l-num (an/literal-number l-num)]
+                         r [r-num (an/literal-number r-num)]]
+                   (cond (neg? compare-bit)  (is (< l r))
+                         (zero? compare-bit) (is (and (<= l r) (= l r) (>= l r)))
+                         :else (is (> l r)))))))
 
   #?(:cljs
      (checking "`literal-number` implements valueOf properly" 100 [n sg/real]
@@ -196,9 +194,8 @@
                   others   [[(an/literal-number l) r]
                             [l (an/literal-number r)]
                             [(an/literal-number l) (an/literal-number r)]]]
-              (dorun
-               (for [[x y] others]
-                 (is (v/= expected (op x y)))))))]
+              (doseq [[x y] others]
+                (is (v/= expected (op x y))))))]
     (checking "+, -, *, / fall through to number ops"
               100 [x sg/native-integral
                    y sg/native-integral]
@@ -672,18 +669,17 @@
            (v/freeze
             (g/conjugate (an/literal-number
                           '(random x))))))
-    (dorun
-     (for [op @#'sym/conjugate-transparent-operators]
-       (is (= (v/freeze
-               (an/literal-number
-                (list op
-                      (g/conjugate 'x)
-                      (g/conjugate 'y))))
-              (v/freeze
-               (g/conjugate (an/literal-number
-                             (list op 'x 'y)))))
-           "This is a little busted, since we don't check for the proper number
-           of inputs... but conjugates move inside these operators."))))
+    (doseq [op @#'sym/conjugate-transparent-operators]
+      (is (= (v/freeze
+              (an/literal-number
+               (list op
+                     (g/conjugate 'x)
+                     (g/conjugate 'y))))
+             (v/freeze
+              (g/conjugate (an/literal-number
+                            (list op 'x 'y)))))
+          "This is a little busted, since we don't check for the proper number
+           of inputs... but conjugates move inside these operators.")))
 
   (checking "make-rectangular" 100 [re gen/symbol
                                     im gen/symbol]

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -84,12 +84,12 @@
 
 (deftest predicate-tests
   (testing "v/="
-    (doall
+    (dorun
      (for [l ['x (an/literal-number 'x)]
            r ['x (an/literal-number 'x)]]
        (is (v/= l r))))
 
-    (doall
+    (dorun
      (for [l [12 (an/literal-number 12)]
            r [12 (an/literal-number 12)]]
        (do (is (v/= l r))
@@ -139,7 +139,7 @@
                ;; NOTE: This is cased to NOT consider rational numbers for now.
                [[l-num r-num] (gen/vector sg/real-without-ratio 2)]
                (let [compare-bit (v/compare l-num r-num)]
-                 (doall
+                 (dorun
                   (for [l [l-num (an/literal-number l-num)]
                         r [r-num (an/literal-number r-num)]]
                     (cond (neg? compare-bit)  (is (< l r))
@@ -196,7 +196,7 @@
                   others   [[(an/literal-number l) r]
                             [l (an/literal-number r)]
                             [(an/literal-number l) (an/literal-number r)]]]
-              (doall
+              (dorun
                (for [[x y] others]
                  (is (v/= expected (op x y)))))))]
     (checking "+, -, *, / fall through to number ops"
@@ -672,7 +672,7 @@
            (v/freeze
             (g/conjugate (an/literal-number
                           '(random x))))))
-    (doall
+    (dorun
      (for [op @#'sym/conjugate-transparent-operators]
        (is (= (v/freeze
                (an/literal-number

--- a/test/sicmutils/calculus/connection_test.cljc
+++ b/test/sicmutils/calculus/connection_test.cljc
@@ -173,7 +173,7 @@
                       polar-Gamma))
               curvature (curv/Riemann nabla)]
           (testing "Now look at curvature:"
-            (doall
+            (dorun
              (for [alpha [dr dtheta]
                    beta [d:dr d:dtheta]
                    gamma [d:dr d:dtheta]
@@ -226,7 +226,7 @@
               (let [nabla (cov/covariant-derivative
                            (cov/Christoffel->Cartan spherical-Gamma))
                     curvature (curv/Riemann nabla)]
-                (doall
+                (dorun
                  (for [alpha [dr dtheta dphi]
                        beta [d:dr d:dtheta]
                        gamma [d:dr d:dtheta]
@@ -308,7 +308,7 @@
                      (orthonormal-spherical-Lorentz-basis c-2))))]
 
             (testing "look at curvature: (154s as of 11.9.2021)"
-              (doall
+              (dorun
                (for [alpha [dt dr dtheta dphi]
                      beta [d:dt d:dr d:dtheta d:dphi]
                      gamma [d:dt d:dr d:dtheta d:dphi]

--- a/test/sicmutils/calculus/connection_test.cljc
+++ b/test/sicmutils/calculus/connection_test.cljc
@@ -173,14 +173,14 @@
                       polar-Gamma))
               curvature (curv/Riemann nabla)]
           (testing "Now look at curvature:"
-            (dorun
-             (for [alpha [dr dtheta]
-                   beta [d:dr d:dtheta]
-                   gamma [d:dr d:dtheta]
-                   delta [d:dr d:dtheta]]
-               (is (= 0 (simplify
-                         ((curvature alpha beta gamma delta)
-                          polar-point)))))))))))
+            (doseq [alpha [dr dtheta]
+                    beta [d:dr d:dtheta]
+                    gamma [d:dr d:dtheta]
+                    delta [d:dr d:dtheta]]
+              (is (zero?
+                   (simplify
+                    ((curvature alpha beta gamma delta)
+                     polar-point))))))))))
 
   (testing "sphere block"
     (let [spherical m/R3-rect]
@@ -222,101 +222,212 @@
                           (up (* -1 r (g/expt (g/sin theta) 2))
                               (* -1 (g/sin theta) (g/cos theta)) zero))))
                  (b/coordinate-system->basis spherical))]
-            (testing"Now look at curvature:"
+            (testing "Now look at curvature:"
               (let [nabla (cov/covariant-derivative
                            (cov/Christoffel->Cartan spherical-Gamma))
                     curvature (curv/Riemann nabla)]
-                (dorun
-                 (for [alpha [dr dtheta dphi]
-                       beta [d:dr d:dtheta]
-                       gamma [d:dr d:dtheta]
-                       delta [d:dr d:dtheta]]
-                   (is (= 0 (simplify
-                             ((curvature alpha beta gamma delta)
-                              spherical-point))))))))))))))
+                (doseq [alpha [dr dtheta dphi]
+                        beta [d:dr d:dtheta]
+                        gamma [d:dr d:dtheta]
+                        delta [d:dr d:dtheta]]
+                  (is (zero?
+                       (simplify
+                        ((curvature alpha beta gamma delta)
+                         spherical-point)))))))))))))
 
-;; TODO: This one takes quite a while, so we only install this test trapped in a
-;; comment. Turn it into a BENCHMARK when we sort those out.
-(deftest spherical-flat-lorentz
-  (comment
-    (testing "MTW p205 spherical flat lorentz"
-      (let [spherical-Lorentz m/R4-rect]
-        (let-coordinates [[t r theta phi] spherical-Lorentz]
-          (let [spherical-Lorentz-basis
-                (b/coordinate-system->basis spherical-Lorentz)
+(deftest spherical-flat-lorentz-tests
+  (testing "MTW p205 spherical flat lorentz"
+    (let [spherical-Lorentz m/R4-rect]
+      (let-coordinates [[t r theta phi] spherical-Lorentz]
+        (let [spherical-Lorentz-basis
+              (b/coordinate-system->basis spherical-Lorentz)
 
-                ;; TODO how is this not used??
-                spherical-Lorentz-metric
-                (fn [c-2]
-                  (fn [v1 v2]
-                    (+ (* -1 c-2 (* (dt v1) (dt v2)))
-                       (* (dr v1) (dr v2))
-                       (* (g/square r)
-                          (+ (* (dtheta v1) (dtheta v2))
-                             (* (g/square (g/sin theta))
-                                (* (dphi v1) (dphi v2))))))))
+              spherical-Lorentz-metric
+              (fn [c-2]
+                (fn [v1 v2]
+                  (+ (* -1 c-2 (* (dt v1) (dt v2)))
+                     (* (dr v1) (dr v2))
+                     (* (g/square r)
+                        (+ (* (dtheta v1) (dtheta v2))
+                           (* (g/square (g/sin theta))
+                              (* (dphi v1) (dphi v2))))))))
 
-                spherical-Lorentz-point
-                ((m/point spherical-Lorentz) (up 't 'r 'theta 'phi))
+              spherical-Lorentz-point
+              ((m/point spherical-Lorentz) (up 't 'r 'theta 'phi))
 
-                orthonormal-spherical-Lorentz-vector-basis
-                (fn [c-2]
-                  (down (* (/ 1 (g/sqrt c-2)) d:dt)
-                        d:dr
-                        (* (/ 1 r) d:dtheta)
-                        (* (/ 1 (* r (g/sin theta))) d:dphi)))
+              orthonormal-spherical-Lorentz-vector-basis
+              (fn [c-2]
+                (down (* (/ 1 (g/sqrt c-2)) d:dt)
+                      d:dr
+                      (* (/ 1 r) d:dtheta)
+                      (* (/ 1 (* r (g/sin theta))) d:dphi)))
 
-                orthonormal-spherical-Lorentz-oneform-basis
-                (fn [c-2]
-                  (let [orthonormal-spherical-Lorentz-vectors
-                        (orthonormal-spherical-Lorentz-vector-basis c-2)]
-                    (b/vector-basis->dual orthonormal-spherical-Lorentz-vectors
-                                          spherical-Lorentz)))
+              orthonormal-spherical-Lorentz-oneform-basis
+              (fn [c-2]
+                (let [orthonormal-spherical-Lorentz-vectors
+                      (orthonormal-spherical-Lorentz-vector-basis c-2)]
+                  (b/vector-basis->dual orthonormal-spherical-Lorentz-vectors
+                                        spherical-Lorentz)))
 
-                orthonormal-spherical-Lorentz-basis
-                (fn [c-2]
-                  (b/make-basis
-                   (orthonormal-spherical-Lorentz-vector-basis c-2)
-                   (orthonormal-spherical-Lorentz-oneform-basis c-2)))
+              orthonormal-spherical-Lorentz-basis
+              (fn [c-2]
+                (b/make-basis
+                 (orthonormal-spherical-Lorentz-vector-basis c-2)
+                 (orthonormal-spherical-Lorentz-oneform-basis c-2)))]
 
-                orthonormal-spherical-Lorentz-second-connection
-                (fn [c-2]
-                  (let [zero m/zero-manifold-function]
-                    (cov/make-Christoffel
-                     (down
-                      (down (up zero zero zero zero)
-                            (up zero zero zero zero)
-                            (up zero zero zero zero)
-                            (up zero zero zero zero))
-                      (down (up zero zero zero zero)
-                            (up zero zero zero zero)
-                            (up zero zero zero zero)
-                            (up zero zero zero zero))
-                      (down (up zero zero zero zero)
-                            (up zero zero (/ 1 r) zero)
-                            (up zero (/ -1 r) zero zero)
-                            (up zero zero zero zero))
-                      (down (up zero zero zero zero)
-                            (up zero zero zero (/ 1 r))
-                            (up zero zero zero (/ (g/cos theta)
-                                                  (* r (g/sin theta))))
-                            (up zero
-                                (/ -1 r)
-                                (/ (* -1 (g/cos theta))
-                                   (* r (g/sin theta)))
-                                zero)))
-                     (orthonormal-spherical-Lorentz-basis c-2))))]
+          (is (= '(down (up 1 0 0 0)
+                        (up 0 1 0 0)
+                        (up 0 0 1 0)
+                        (up 0 0 0 1))
+                 (simplify
+                  ((s/mapr
+                    (orthonormal-spherical-Lorentz-oneform-basis 'c↑2)
+	                  (orthonormal-spherical-Lorentz-vector-basis 'c↑2))
+                   spherical-Lorentz-point))))
 
-            (testing "look at curvature: (154s as of 11.9.2021)"
-              (dorun
-               (for [alpha [dt dr dtheta dphi]
-                     beta [d:dt d:dr d:dtheta d:dphi]
-                     gamma [d:dt d:dr d:dtheta d:dphi]
-                     delta [d:dt d:dr d:dtheta d:dphi]]
-                 (is (= 0 (simplify
-                           (((curv/Riemann
-                              (cov/covariant-derivative
-                               (cov/Christoffel->Cartan
-                                (orthonormal-spherical-Lorentz-second-connection 'c↑2))))
-                             alpha beta gamma delta)
-                            spherical-Lorentz-point)))))))))))))
+          (is (= -1
+                 (simplify
+                  (((spherical-Lorentz-metric 'c↑2)
+                    (get (orthonormal-spherical-Lorentz-vector-basis 'c↑2) 0)
+                    (get (orthonormal-spherical-Lorentz-vector-basis 'c↑2) 0))
+                   spherical-Lorentz-point))))
+
+          (is  (= 1 (simplify
+                     (((spherical-Lorentz-metric 'c↑2)
+                       (get (orthonormal-spherical-Lorentz-vector-basis 'c↑2) 1)
+                       (get (orthonormal-spherical-Lorentz-vector-basis 'c↑2) 1))
+                      spherical-Lorentz-point))))
+
+          (is  (= 1 (simplify
+                     (((spherical-Lorentz-metric 'c↑2)
+                       (get (orthonormal-spherical-Lorentz-vector-basis 'c↑2) 2)
+                       (get (orthonormal-spherical-Lorentz-vector-basis 'c↑2) 2))
+                      spherical-Lorentz-point))))
+
+          (is (= 1 (simplify
+                    (((spherical-Lorentz-metric 'c↑2)
+                      (get (orthonormal-spherical-Lorentz-vector-basis 'c↑2) 3)
+                      (get (orthonormal-spherical-Lorentz-vector-basis 'c↑2) 3))
+                     spherical-Lorentz-point))))
+
+          (is (= '(down
+                   (down (down 0 0 0 0) (down 0 0 0 0) (down 0 0 0 0) (down 0 0 0 0))
+                   (down (down 0 0 0 0) (down 0 0 0 0) (down 0 0 0 0) (down 0 0 0 0))
+                   (down (down 0 0 0 0)
+                         (down 0 0 (/ 1 r) 0)
+                         (down 0 (/ -1 r) 0 0)
+                         (down 0 0 0 0))
+                   (down (down 0 0 0 0)
+                         (down 0 0 0 (/ 1 r))
+                         (down 0 0 0 (/ (cos theta) (* r (sin theta))))
+                         (down 0
+                               (/ -1 r)
+                               (/ (* -1 (cos theta))
+                                  (* r (sin theta)))
+                               0)))
+                 (simplify
+                  ((cov/Christoffel->symbols
+                    (conn/metric->connection-1
+                     (spherical-Lorentz-metric 'c↑2)
+			               (orthonormal-spherical-Lorentz-basis 'c↑2)))
+                   spherical-Lorentz-point)))
+              "with metric->connection-1")
+
+          (testing "with metric->connection-2. Comment from GJS: 'The last
+          two [with connections 1 and 2] are essentially the same. Is this
+          correct?' (note from @sritchie - they ARE the same with ups at the
+          bottom level vs downs.)"
+            (let [foo (g/simplify
+                       ((cov/Christoffel->symbols
+                         (conn/metric->connection-2
+                          (spherical-Lorentz-metric 'c↑2)
+			                    (orthonormal-spherical-Lorentz-basis 'c↑2)))
+                        spherical-Lorentz-point))]
+              (is (= '(down
+                       (down (up 0 0 0 0) (up 0 0 0 0) (up 0 0 0 0) (up 0 0 0 0))
+                       (down (up 0 0 0 0) (up 0 0 0 0) (up 0 0 0 0) (up 0 0 0 0))
+                       (down (up 0 0 0 0)
+                             (up 0 0 (/ 1 r) 0)
+                             (up 0 (/ -1 r) 0 0)
+                             (up 0 0 0 0))
+                       (down (up 0 0 0 0)
+                             (up 0 0 0 (/ 1 r))
+                             (up 0 0 0 (/ (cos theta) (* r (sin theta))))
+                             (up 0
+                                 (/ -1 r)
+                                 (/ (* -1 (cos theta)) (* r (sin theta)))
+                                 0)))
+                     (v/freeze foo)))
+
+              ;; Check answers from MTW p.213
+              ;; t r theta phi
+              ;; 0 1 2     3
+              (is (= '(/ (cos theta) (* r (sin theta)))
+                     (v/freeze
+                      (get-in foo [3 2 3]))))
+
+              (is (= '(/ (* -1 (cos theta)) (* r (sin theta)))
+                     (v/freeze
+                      (get-in foo [3 3 2]))))
+
+              (is (= '(/ 1 r)
+                     (v/freeze
+                      (get-in foo [2 1 2]))))
+
+              (is (= '(/ 1 r)
+                     (v/freeze
+                      (get-in foo [3 1 3]))))
+
+              (is (= '(/ -1 r)
+                     (v/freeze
+                      (get-in foo [2 2 1]))))
+
+              (is (= '(/ -1 r)
+                     (v/freeze
+                      (get-in foo [3 3 1]))))))
+
+          ;; TODO: This one takes quite a while, so we only install this test
+          ;; trapped in a comment. Turn it into a BENCHMARK when we sort those
+          ;; out.
+          (comment
+            (let [orthonormal-spherical-Lorentz-second-connection
+                  (fn [c-2]
+                    (let [zero m/zero-manifold-function]
+                      (cov/make-Christoffel
+                       (down
+                        (down (up zero zero zero zero)
+                              (up zero zero zero zero)
+                              (up zero zero zero zero)
+                              (up zero zero zero zero))
+                        (down (up zero zero zero zero)
+                              (up zero zero zero zero)
+                              (up zero zero zero zero)
+                              (up zero zero zero zero))
+                        (down (up zero zero zero zero)
+                              (up zero zero (/ 1 r) zero)
+                              (up zero (/ -1 r) zero zero)
+                              (up zero zero zero zero))
+                        (down (up zero zero zero zero)
+                              (up zero zero zero (/ 1 r))
+                              (up zero zero zero (/ (g/cos theta)
+                                                    (* r (g/sin theta))))
+                              (up zero
+                                  (/ -1 r)
+                                  (/ (* -1 (g/cos theta))
+                                     (* r (g/sin theta)))
+                                  zero)))
+                       (orthonormal-spherical-Lorentz-basis c-2))))]
+
+              (testing "look at curvature: (150s as of 12.8.2021)"
+                (doseq [alpha [dt dr dtheta dphi]
+                        beta [d:dt d:dr d:dtheta d:dphi]
+                        gamma [d:dt d:dr d:dtheta d:dphi]
+                        delta [d:dt d:dr d:dtheta d:dphi]]
+                  (is (zero?
+                       (simplify
+                        (((curv/Riemann
+                           (cov/covariant-derivative
+                            (cov/Christoffel->Cartan
+                             (orthonormal-spherical-Lorentz-second-connection 'c↑2))))
+                          alpha beta gamma delta)
+                         spherical-Lorentz-point)))))))))))))

--- a/test/sicmutils/calculus/curvature_test.cljc
+++ b/test/sicmutils/calculus/curvature_test.cljc
@@ -141,7 +141,7 @@
                   a-function)
                  a-point))))
 
-        (doall
+        (dorun
          (for [x [d:dtheta d:dphi]
                y [d:dtheta d:dphi]]
            (is (= 0 (simplify
@@ -163,7 +163,7 @@
             G-S2-1 (S2-Christoffel M-basis theta)
             nabla (cov/covariant-derivative
                    (cov/Christoffel->Cartan G-S2-1))]
-        (doall
+        (dorun
          (for [x [d:dtheta d:dphi]
                y [d:dtheta d:dphi]]
            (is (= 0 (simplify

--- a/test/sicmutils/calculus/curvature_test.cljc
+++ b/test/sicmutils/calculus/curvature_test.cljc
@@ -141,13 +141,13 @@
                   a-function)
                  a-point))))
 
-        (dorun
-         (for [x [d:dtheta d:dphi]
-               y [d:dtheta d:dphi]]
-           (is (= 0 (simplify
-                     ((((c/torsion-vector nabla) x y)
-                       a-function)
-                      a-point))))))
+        (doseq [x [d:dtheta d:dphi]
+                y [d:dtheta d:dphi]]
+          (is (zero?
+               (simplify
+                ((((c/torsion-vector nabla) x y)
+                  a-function)
+                 a-point)))))
 
         (is (= 1 (simplify
                   (((c/Riemann nabla)
@@ -163,13 +163,13 @@
             G-S2-1 (S2-Christoffel M-basis theta)
             nabla (cov/covariant-derivative
                    (cov/Christoffel->Cartan G-S2-1))]
-        (dorun
-         (for [x [d:dtheta d:dphi]
-               y [d:dtheta d:dphi]]
-           (is (= 0 (simplify
-                     ((((c/torsion-vector nabla) x y)
-                       a-function)
-                      a-point))))))
+        (doseq [x [d:dtheta d:dphi]
+                y [d:dtheta d:dphi]]
+          (is (zero?
+               (simplify
+                ((((c/torsion-vector nabla) x y)
+                  a-function)
+                 a-point)))))
 
         (is (= 1 (simplify
                   (((c/Riemann nabla)

--- a/test/sicmutils/calculus/hodge_star_test.cljc
+++ b/test/sicmutils/calculus/hodge_star_test.cljc
@@ -82,11 +82,11 @@
               SR-V (b/basis->vector-basis SR-basis)
               SR-V1 (flatten (hs/Gram-Schmidt SR-V (g-Lorentz 'c)))]
           (testing "SR-V1 is orthogonal"
-            (dorun
-             (for [v1 SR-V1
-                   v2 (rest (drop-while #(not= % v1) SR-V1))]
-               (is (= 0 (simplify
-                         (((g-Lorentz 'c) v1 v2) an-event)))))))
+            (doseq [v1 SR-V1
+                    v2 (rest (drop-while #(not= % v1) SR-V1))]
+              (is (zero?
+                   (simplify
+                    (((g-Lorentz 'c) v1 v2) an-event))))))
 
           (testing "SR-V1 is normal"
             (is (= [-1 1 1 1]

--- a/test/sicmutils/calculus/hodge_star_test.cljc
+++ b/test/sicmutils/calculus/hodge_star_test.cljc
@@ -82,7 +82,7 @@
               SR-V (b/basis->vector-basis SR-basis)
               SR-V1 (flatten (hs/Gram-Schmidt SR-V (g-Lorentz 'c)))]
           (testing "SR-V1 is orthogonal"
-            (doall
+            (dorun
              (for [v1 SR-V1
                    v2 (rest (drop-while #(not= % v1) SR-V1))]
                (is (= 0 (simplify

--- a/test/sicmutils/calculus/tensor_test.cljc
+++ b/test/sicmutils/calculus/tensor_test.cljc
@@ -65,7 +65,7 @@
 (defn run-tensor-test [T types coordsys]
   (let [args (mapv (literal-field coordsys) types)
         f    ((literal-field coordsys) :scalar)]
-    (doall
+    (dorun
      (for [i (range (count types))
            :let [thing ((literal-field coordsys) (nth types i))]]
        (simplify

--- a/test/sicmutils/calculus/tensor_test.cljc
+++ b/test/sicmutils/calculus/tensor_test.cljc
@@ -65,16 +65,15 @@
 (defn run-tensor-test [T types coordsys]
   (let [args (mapv (literal-field coordsys) types)
         f    ((literal-field coordsys) :scalar)]
-    (dorun
-     (for [i (range (count types))
-           :let [thing ((literal-field coordsys) (nth types i))]]
-       (simplify
-        ((- (apply T (assoc args i
-                            (+ (* f (get args i))
-                               thing)))
-            (+ (* f (apply T args))
-               (apply T (assoc args i thing))))
-         (m/typical-point coordsys)))))))
+    (for [i (range (count types))
+          :let [thing ((literal-field coordsys) (nth types i))]]
+      (simplify
+       ((- (apply T (assoc args i
+                           (+ (* f (get args i))
+                              thing)))
+           (+ (* f (apply T args))
+              (apply T (assoc args i thing))))
+        (m/typical-point coordsys))))))
 
 (deftest ^:long long-tensor-tests
   (is (= [0 0 0 0]

--- a/test/sicmutils/differential_test.cljc
+++ b/test/sicmutils/differential_test.cljc
@@ -124,7 +124,7 @@
        (checking "[[Differential]] is transparent to native comparison operators" 100
                  [[l-num r-num] (gen/vector real-minus-rationals 2)]
                  (let [compare-bit (v/compare l-num r-num)]
-                   (doall
+                   (dorun
                     (for [l [l-num (d/bundle-element l-num 1 0)]
                           r [r-num (d/bundle-element r-num 1 0)]]
                       (cond (neg? compare-bit)  (is (< l r))

--- a/test/sicmutils/differential_test.cljc
+++ b/test/sicmutils/differential_test.cljc
@@ -124,12 +124,11 @@
        (checking "[[Differential]] is transparent to native comparison operators" 100
                  [[l-num r-num] (gen/vector real-minus-rationals 2)]
                  (let [compare-bit (v/compare l-num r-num)]
-                   (dorun
-                    (for [l [l-num (d/bundle-element l-num 1 0)]
-                          r [r-num (d/bundle-element r-num 1 0)]]
-                      (cond (neg? compare-bit)  (is (< l r))
-                            (zero? compare-bit) (is (and (<= l r) (= l r) (>= l r)))
-                            :else (is (> l r)))))))))
+                   (doseq [l [l-num (d/bundle-element l-num 1 0)]
+                           r [r-num (d/bundle-element r-num 1 0)]]
+                     (cond (neg? compare-bit)  (is (< l r))
+                           (zero? compare-bit) (is (and (<= l r) (= l r) (>= l r)))
+                           :else (is (> l r))))))))
 
   (checking "v/numerical?" 100 [diff (sg/differential sg/real)]
             (is (v/numerical? diff)

--- a/test/sicmutils/numerical/quadrature/riemann_test.cljc
+++ b/test/sicmutils/numerical/quadrature/riemann_test.cljc
@@ -111,8 +111,8 @@
 
         ;; run each sequence fully through, counting the function invocations
         ;; required by each.
-        (doall (qr/left-sequence f1 0 10 {:n n-seq}))
-        (doall (map (@#'qr/left-sum f2 0 10) n-seq))
+        (dorun (qr/left-sequence f1 0 10 {:n n-seq}))
+        (run! (@#'qr/left-sum f2 0 10) n-seq)
         (is (= 210
                (int (ua/sum identity 1 21))
                @counter2)

--- a/test/sicmutils/numerical/quadrature/trapezoid_test.cljc
+++ b/test/sicmutils/numerical/quadrature/trapezoid_test.cljc
@@ -101,10 +101,10 @@
                 n-seq (take (inc n)
                             (iterate (fn [x] (* 2 x)) 1))]
             ;; Incremental version evaluating every `n` in the sequence $1, 2, 4, ...$:
-            (doall (qt/trapezoid-sequence f1 0 1 {:n n-seq}))
+            (dorun (qt/trapezoid-sequence f1 0 1 {:n n-seq}))
 
             ;; Non-incremental version evaluating every `n` in the sequence $1, 2, 4, ...$:
-            (doall (map (qt/trapezoid-sum f2 0 1) n-seq))
+            (run! (qt/trapezoid-sum f2 0 1) n-seq)
 
             ;; A single evaluation of the final `n`
             ((qt/trapezoid-sum f3 0 1) (last n-seq))

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -1086,7 +1086,7 @@
            (A '(- (up (+ (/ d a)
                          (/ (- b) a)))
                   (up (/ (- y) (+ a b))))))
-        "This test exploded without the doall that forces add-symbol! calls in
+        "This test exploded without the `doall` that forces add-symbol! calls in
         analyze.clj.")
 
     (is (= 'x (A '(* (/ 1 2) (+ x x)))))

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -323,18 +323,16 @@
   (checking "s/component" 100
             [s (sg/structure1
                 (sg/structure1 sg/real 5) 5)]
-            (dorun
-             (for [i (range 0 5)
-                   j (range 0 5)]
-               (is (= (get-in s [i j])
-                      ((s/component i j) s))))))
+            (doseq [i (range 0 5)
+                    j (range 0 5)]
+              (is (= (get-in s [i j])
+                     ((s/component i j) s)))))
 
   (testing "same-orientation?"
     (testing "up and vector same"
-      (dorun
-       (for [l [(s/up 1 2) [1 2]]
-             r [(s/up 1 2) [1 2]]]
-         (is (s/same-orientation? l r)))))
+      (doseq [l [(s/up 1 2) [1 2]]
+              r [(s/up 1 2) [1 2]]]
+        (is (s/same-orientation? l r))))
 
     (testing "down is unique"
       (is (s/same-orientation? (s/down 1 2) (s/down 1 2)))

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -323,7 +323,7 @@
   (checking "s/component" 100
             [s (sg/structure1
                 (sg/structure1 sg/real 5) 5)]
-            (doall
+            (dorun
              (for [i (range 0 5)
                    j (range 0 5)]
                (is (= (get-in s [i j])
@@ -331,7 +331,7 @@
 
   (testing "same-orientation?"
     (testing "up and vector same"
-      (doall
+      (dorun
        (for [l [(s/up 1 2) [1 2]]
              r [(s/up 1 2) [1 2]]]
          (is (s/same-orientation? l r)))))


### PR DESCRIPTION
From the CHANGELOG:

- latest: convert `doall` calls to `run!`, `dorun` or `mapv` where applicable.
  In cases where we were trying to force side effects (mostly in the tests),
  this change prevents the environment from retaining the full sequence. This
  will save memory!