### PR TITLE
Bugfix in exp-contract rules, exact result from (exp 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [unreleased]
 
+- newest:
+
+  - Modifies `(g/exp 0)` to return an exact 1, vs the previous `1.0`.
+
+  - Fixes a bug in `sicmutils.rules/exp-contract` leftover from the port from
+    Scheme. Thanks to @adamhaber for pointing this out!
+
 - #438:
 
   - converts `doall` calls to `run!`, `dorun`, `doseq` or `mapv` where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-- newest:
+- #440:
 
   - Modifies `(g/exp 0)` to return an exact 1, vs the previous `1.0`.
 

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -149,7 +149,9 @@
              (Math/log2 x))))
 
 (defmethod g/exp [::v/real] [a]
-  (Math/exp a))
+  (if (core-zero? a)
+    1
+    (Math/exp a)))
 
 (defn ^:private exact-divide
   "Checked implementation of g/exact-divide general enough to use for any type

--- a/src/sicmutils/simplify/rules.cljc
+++ b/src/sicmutils/simplify/rules.cljc
@@ -1449,7 +1449,7 @@ out of the first term of the argument."}
     =>
     (* ??x1 ??x3 ??x5 (exp (+ ?x2 ?x4)))
 
-    (expt (exp ?x) (? p)) => (exp (* ?p ?x))
+    (expt (exp ?x) ?p) => (exp (* ?p ?x))
 
     (/ (exp ?x) (exp ?y)) => (exp (- ?x ?y))
 

--- a/test/sicmutils/function_test.cljc
+++ b/test/sicmutils/function_test.cljc
@@ -409,7 +409,7 @@
       (is (= -4 ((g/- add2) 2)))
       (is (= 9 ((g/sqrt add2) 79)))
       (is (= #sicm/ratio 1/9 ((g/invert add2) 7)))
-      (is (= 1.0 (explog 1.0)))
+      (is (= 1 (explog 1.0)))
       (is (ish? 99.0 (explog 99.0)))
       (is (ish? 20.085536923187668 ((g/exp add2) 1.0)))
       (is (ish? 4.718281828459045 ((add2 g/exp) 1.0))))

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -197,7 +197,8 @@
     (is (= (c/complex 0 Math/PI) (g/log -1))))
 
   (testing "exp"
-    (is (= 1.0 (g/exp 0)))))
+    (is (= 1 (g/exp 0))
+        "exp(0) evaluates to an exact 1, vs 1.0")))
 
 ;; Test of generic wrapper operations.
 

--- a/test/sicmutils/simplify/rules_test.cljc
+++ b/test/sicmutils/simplify/rules_test.cljc
@@ -133,7 +133,12 @@
 
     (is (= '(* (/ 1 2) (log x))
            ((rule) '(log (sqrt x))))
-        "Drop the internal sqrt down as a 1/2 exponent.")))
+        "Drop the internal sqrt down as a 1/2 exponent."))
+
+  (testing "exp-contract"
+    (is (= '(exp (* 2 x))
+           (r/exp-contract '(expt (exp x) 2)))
+        "Test for bugfix from issue #439 ")))
 
 (deftest magnitude-tests
   (is (= '(expt x 10)


### PR DESCRIPTION
This PR fixes #439 :

  - Modifies `(g/exp 0)` to return an exact 1, vs the previous `1.0`.

  - Fixes a bug in `sicmutils.rules/exp-contract` leftover from the port from
    Scheme. Thanks to @adamhaber for pointing this out!