### PR TITLE
Make factorial, number-of-combinations more efficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-- new fixes #441 by upgrading the implementations of
+- #442 fixes #441 by upgrading the implementations of
   `sicmutils.util.permute/{factorial,number-of-combinations}` to be able to
   handle large inputs. Thanks to @swapneils for the report.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+- new fixes #441 by upgrading the implementations of
+  `sicmutils.util.permute/{factorial,number-of-combinations}` to be able to
+  handle large inputs. Thanks to @swapneils for the report.
+
 - #440:
 
   - Modifies `(g/exp 0)` to return an exact 1, vs the previous `1.0`.

--- a/src/sicmutils/util/permute.cljc
+++ b/src/sicmutils/util/permute.cljc
@@ -217,15 +217,15 @@
 ;; The tests compare this implementation to the more obvious relationship with
 ;; factorials.
 
-(let [* #?(:clj *' :cljs g/*)
-      / #?(:clj / :cljs g//)]
+(let [*   #?(:clj *' :cljs g/*)
+      div #?(:clj / :cljs g//)]
   (defn number-of-combinations
     "Returns 'n choose k', the number of possible ways of choosing `k` distinct
   elements from a collection of `n` total items."
     [n k]
     (if (> (* 2 k) n)
       (number-of-combinations n (- n k))
-      (transduce (map (fn [i] (/ (- (inc n) i) i)))
+      (transduce (map (fn [i] (div (- (inc n) i) i)))
                  *
                  (range 1 (inc k))))))
 

--- a/test/sicmutils/util/permute_test.cljc
+++ b/test/sicmutils/util/permute_test.cljc
@@ -152,7 +152,11 @@
 
   (testing "factorial"
     (is (= (apply g/* (range 1 8))
-           (p/factorial 7))))
+           (p/factorial 7)))
+
+    (is (= #sicm/bigint "15511210043330985984000000"
+           (p/factorial 25))
+        "factorial can handle `n` that triggers overflow in cljs and clj."))
 
   (checking "number-of-permutations" 100
             [xs (gen/let [n (gen/choose 0 6)]
@@ -167,7 +171,22 @@
                        (gen/choose 0 n)))]
             (is (= (p/number-of-combinations (count xs) k)
                    (count
-                    (p/combinations xs k))))))
+                    (p/combinations xs k)))))
+
+  (letfn [(n-choose-k [n k]
+            ;; simple but inefficient implementation for comparison with the
+            ;; more efficient method in the library.
+            (g/quotient
+             (p/factorial n)
+             (g/* (p/factorial (- n k))
+                  (p/factorial k))))]
+    (is (= (n-choose-k 1000 290)
+           (p/number-of-combinations 1000 290))
+        "n choose k with large values")
+
+    (is (= (n-choose-k 1000 800)
+           (p/number-of-combinations 1000 800))
+        "k > n/2")))
 
 (deftest permutation-test
   (testing "permutation-sequence"


### PR DESCRIPTION
fixes #441 by upgrading the implementations of `sicmutils.util.permute/{factorial,number-of-combinations}` to be able to handle large inputs. Thanks to @swapneils for the report.