### PR TITLE
atan2 symbolic upgrade, misc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [unreleased]
 
+- #443:
+
+  - Implements `IKVReduce` and `Reversible` for structures. This enables `rseq`
+    and `reduce-kv` to work with structures.
+
+  - Removes a `reduced` shortcut condition in `sicmutils.generic/*` that was
+    causing multiplications of the form `(* 0 0 (up 0 0))` to shortcut and
+    return `0` instead of the appropriate structural form.
+
+  - the `atan` implementation for symbolic numbers is now careful not to return
+    a floating point number in the case of a 0 argument in the second position.
+    Additionally, it now returns symbolic `pi` or 0 in the case of `0` in the y
+    argument for positive and negative `x` argument, respectively, and symbolic
+    `(/ pi 2)` or `(- (/ pi 2))` for a 0 `x` argument and respective positive or
+    negative `y` argument.
+
 - #442 fixes #441 by upgrading the implementations of
   `sicmutils.util.permute/{factorial,number-of-combinations}` to be able to
   handle large inputs. Thanks to @swapneils for the report.

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -73,11 +73,11 @@
   [a]
   (instance? Complex a))
 
-(defn- real [^Complex a]
+(defn ^:no-doc real [^Complex a]
   #?(:clj (.getReal a)
      :cljs (obj/get a "re")))
 
-(defn- imaginary [^Complex a]
+(defn ^:no-doc imaginary [^Complex a]
   #?(:clj (.getImaginary a)
      :cljs (obj/get a "im")))
 
@@ -127,7 +127,7 @@
 
         :else (u/illegal
                (str
-                "Complex literals must be either strings or vectors. Received: "
+                "#sicm/complex takes a string, 2-vector or a number. Received: "
                 x))))
 
 #?(:cljs

--- a/src/sicmutils/function.cljc
+++ b/src/sicmutils/function.cljc
@@ -399,34 +399,34 @@
   ([] [:at-least 0])
   ([a] a)
   ([a b]
-   (let [fail (fn []
-                (if *strict-arity-checks*
-                  (u/illegal (str "Incompatible arities: " a " " b))
-                  [:at-least 0]))]
+   (letfn [(fail []
+             (if *strict-arity-checks*
+               (u/illegal (str "Incompatible arities: " a " " b))
+               [:at-least 0]))]
      ;; since the combination operation is symmetric, sort the arguments
      ;; so that we only have to implement the upper triangle of the
      ;; relation.
-     (if (< 0 (compare (first a) (first b)))
+     (if (pos? (compare (first a) (first b)))
        (combine-arities b a)
        (match [a b]
-         [[:at-least k] [:at-least k2]] [:at-least (max k k2)]
-         [[:at-least k] [:between m n]] (let [m (max k m)]
-                                          (cond (= m n) [:exactly m]
-                                                (< m n) [:between m n]
-                                                :else (fail)))
-         [[:at-least k] [:exactly l]] (if (>= l k)
-                                        [:exactly l]
-                                        (fail))
-         [[:between m n] [:between m2 n2]] (let [m (max m m2)
-                                                 n (min n n2)]
-                                             (cond (= m n) [:exactly m]
-                                                   (< m n) [:between m n]
-                                                   :else (fail)))
-         [[:between m n] [:exactly k]] (if (and (<= m k)
-                                                (<= k n))
-                                         [:exactly k]
-                                         (fail))
-         [[:exactly k] [:exactly l]] (if (= k l) [:exactly k] (fail)))))))
+              [[:at-least k] [:at-least k2]] [:at-least (max k k2)]
+              [[:at-least k] [:between m n]] (let [m (max k m)]
+                                               (cond (= m n) [:exactly m]
+                                                     (< m n) [:between m n]
+                                                     :else (fail)))
+              [[:at-least k] [:exactly l]] (if (>= l k)
+                                             [:exactly l]
+                                             (fail))
+              [[:between m n] [:between m2 n2]] (let [m (max m m2)
+                                                      n (min n n2)]
+                                                  (cond (= m n) [:exactly m]
+                                                        (< m n) [:between m n]
+                                                        :else (fail)))
+              [[:between m n] [:exactly k]] (if (and (<= m k)
+                                                     (<= k n))
+                                              [:exactly k]
+                                              (fail))
+              [[:exactly k] [:exactly l]] (if (= k l) [:exactly k] (fail)))))))
 
 (defn joint-arity
   "Find the most relaxed possible statement of the joint arity of the given sequence of `arities`.

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -186,12 +186,7 @@
            (and numy? (v/one? y)) x
            :else (mul x y))))
   ([x y & more]
-   (reduce (fn [l r]
-             (if (v/zero? l)
-               (reduced l)
-               (* l r)))
-           (* x y)
-           more)))
+   (reduce * (* x y) more)))
 
 (declare div)
 

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -310,7 +310,7 @@
          (v/exact-zero? y)
          (if (v/number? x)
            (if (g/negative? x) 'pi 0)
-           (and (ul/assume! `(~'positive? ~x) 'numsymb-atan)
+           (and (ul/assume! `(~'non-negative? ~x) 'numsymb-atan)
                 0))
 
          (v/exact-zero? x)
@@ -318,7 +318,7 @@
            (if (g/negative? y)
              '(- (/ pi 2))
              '(/ pi 2))
-           (and (ul/assume! `(~'positive? ~y) 'numsymb-atan)
+           (and (ul/assume! `(~'non-negative? ~y) 'numsymb-atan)
                 '(/ pi 2)))
 
          (and (v/number? x)

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -27,7 +27,8 @@
             [sicmutils.ratio]
             [sicmutils.value :as v]
             [sicmutils.util :as u]
-            [sicmutils.util.aggregate :as ua]))
+            [sicmutils.util.aggregate :as ua]
+            [sicmutils.util.logic :as ul]))
 
 (def ^{:dynamic true
        :doc "When bound to a simplifier (a function from symbolic expression =>
@@ -234,7 +235,7 @@
                               (n:pi-mod-2pi? x) -1
                               :else (Math/cos x)))
         (symbol? x) (cond (pi-over-2-mod-pi? x) 0
-                          (zero-mod-2pi? x) +1
+                          (zero-mod-2pi? x) 1
                           (pi-mod-2pi? x) -1
                           :else (list 'cos x))
         :else (list 'cos x)))
@@ -304,23 +305,29 @@
          (list 'atan y)))
      (list 'atan y)))
   ([y x]
-   (if (v/one? x)
-     (atan y)
-     (if (v/number? y)
-       (if (v/exact? y)
-         (if (v/zero? y)
-           0
-           (if (v/number? x)
-             (if (v/exact? x)
-               (if (v/zero? x)
-                 (g/atan y x)
-                 (list 'atan y x))
-               (g/atan y x))
-             (list 'atan y x)))
+   (cond (v/one? x) (atan y)
+
+         (v/exact-zero? y)
          (if (v/number? x)
-           (g/atan y x)
-           (list 'atan y x)))
-       (list 'atan y x)))))
+           (if (g/negative? x) 'pi 0)
+           (and (ul/assume! `(~'positive? ~x) 'numsymb-atan)
+                0))
+
+         (v/exact-zero? x)
+         (if (v/number? y)
+           (if (g/negative? y)
+             '(- (/ pi 2))
+             '(/ pi 2))
+           (and (ul/assume! `(~'positive? ~y) 'numsymb-atan)
+                '(/ pi 2)))
+
+         (and (v/number? x)
+              (v/number? y)
+              (or (not (v/exact? x))
+                  (not (v/exact? y))))
+         (g/atan y x)
+
+         :else (list 'atan y x))))
 
 (defn- cosh [x]
   (if (v/number? x)

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -32,9 +32,9 @@
   #?(:clj
      (:import (clojure.lang Associative
                             AFn IFn
-                            IPersistentVector IReduce
+                            IPersistentVector IReduce IKVReduce
                             IObj
-                            Indexed Sequential))))
+                            Indexed Reversible Sequential))))
 
 (def ^:dynamic *allow-incompatible-multiplication* true)
 
@@ -132,6 +132,12 @@
        IReduce
        (reduce [_ f] (.reduce ^IReduce v f))
        (reduce [_ f start] (.reduce ^IReduce v f start))
+
+       IKVReduce
+       (kvreduce [_ f init] (.kvreduce ^IKVReduce v f init))
+
+       Reversible
+       (rseq [_] (.rseq ^Reversible v))
 
        IFn
        (invoke [_]
@@ -232,6 +238,12 @@
        IReduce
        (-reduce [_ f] (-reduce v f))
        (-reduce [_ f start] (-reduce v f start))
+
+       IKVReduce
+       (-kv-reduce [_ f init] (-kv-reduce v f init))
+
+       IReversible
+       (-rseq [_] (-rseq v))
 
        IFn
        (-invoke [_]
@@ -787,7 +799,7 @@
   (assert (= (count v1) (count v2))
           (str "Not same dimension -- v:dot-product"
                v1 ", " v2))
-  (reduce g/+ (map g/* v1 v2)))
+  (apply g/+ (map g/* v1 v2)))
 
 (defn vector-inner-product
   "Returns the (vector) inner product of `v1` and `v2`; this is equivalent to the

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -409,10 +409,11 @@
               (is (= (cond (and x-one? y-zero?)            0
                            (and x-one? y-exact?)           (list 'atan y)
                            x-one?                          (g/atan y)
-                           (and y-exact? y-zero?)           0
-                           (and y-exact? x-exact? x-zero?) (g/atan y x)
+                           (and y-exact? y-zero?)          (if (neg? x) 'pi 0)
+                           (and x-exact? x-zero?)          (if (neg? y)
+                                                             '(- (/ pi 2))
+                                                             '(/ pi 2))
                            (and y-exact? x-exact?)         (list 'atan y x)
-                           y-exact?                        (g/atan y x)
                            :else                           (g/atan y x))
                      (x/expression-of
                       (g/atan

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -37,54 +37,85 @@
             [sicmutils.util.aggregate :as ua]
             [sicmutils.value :as v]))
 
-(deftest value-protocol-tests
-  (testing "zero?"
-    (is (v/zero? (s/up)))
-    (is (v/zero? (s/down)))
-    (is (v/zero? (s/down 0)))
-    (is (v/zero? (s/up 0 0)))
-    (is (v/zero? (s/up 0)))
-    (is (v/zero? (s/down 0 0)))
-    (is (v/zero? (s/up 0 (s/down (s/up 0 0) (s/up 0 0)))))
-    (is (v/zero? (s/up 0 (u/long 0) (u/int 0)))))
+(deftest interface-tests
+  (checking "Clojure interface definitions" 100
+            [q (sg/structure1 (sg/reasonable-double))]
+            (let [v (vec q)]
+              (is (coll? q))
+              (is (seqable? q))
+              (is (sequential? q))
 
-  (testing "zero-like"
-    (is (v/zero? (v/zero-like (s/up 1 2 3))))
-    (is (= (s/up 0 0 0) (v/zero-like (s/up 1 2 3))))
-    (is (= (s/up) (v/zero-like (s/up))))
-    (is (= (s/down 0 0 0) (v/zero-like (s/down 1 2 3))))
-    (is (= (s/down) (v/zero-like (s/down))))
-    (is (= (s/up 0 (s/down (s/up 0 0) (s/up 0 0)))
-           (v/zero-like (s/up 1 (s/down (s/up 2 3) (s/up 4 5))))))
-    (is (= (s/up (u/long 0) (u/int 0) 0)
-           (v/zero-like (s/up (u/long 1) (u/int 2) 3)))))
+              (is (reversible? q))
+              (is (= (rseq v) (rseq q))
+                  "rseq matches vector impl")
 
-  (testing "one-like"
-    (is (thrown? #?(:clj UnsupportedOperationException :cljs js/Error)
-                 (v/one-like (s/up 1 2 3)))))
+              (is (counted? q))
+              (is (= (count v) (count q))
+                  "count matches vector impl")
 
-  (testing "identity-like"
-    (is (thrown? #?(:clj UnsupportedOperationException :cljs js/Error)
-                 (v/identity-like (s/up 1 2 3)))))
+              (is (associative? q))
+              (is (indexed? q))
+              (is (ifn? q))
 
-  (testing "exact?"
-    (is (v/exact? (s/up 1 2 3 4)))
-    (is (not (v/exact? (s/up 1.2 3 4))))
-    (is (v/exact? (s/up 0 1 #sicm/ratio 3/2)))
-    (is (not (v/exact? (s/up 0 0 0.00001)))))
+              (is (= (reduce-kv + 0 v)
+                     (reduce-kv + 0 q))
+                  "reduce-kv matches vector impl")
 
-  (testing "numerical?"
-    (is (not (v/numerical? (s/up 1 2 3 4)))
-        "no structure is numerical."))
+              (is (= (reduce + 0 v)
+                     (reduce + v)
+                     (reduce + 0 q)
+                     (reduce + q))
+                  "reduce matches vector impl")))
 
-  (testing "freeze"
-    (is (= '(up 1 2 3) (v/freeze (s/up 1 2 3)))))
+  (testing "value protocol"
+    (testing "zero?"
+      (is (v/zero? (s/up)))
+      (is (v/zero? (s/down)))
+      (is (v/zero? (s/down 0)))
+      (is (v/zero? (s/up 0 0)))
+      (is (v/zero? (s/up 0)))
+      (is (v/zero? (s/down 0 0)))
+      (is (v/zero? (s/up 0 (s/down (s/up 0 0) (s/up 0 0)))))
+      (is (v/zero? (s/up 0 (u/long 0) (u/int 0)))))
 
-  (testing "kind"
-    (is (= ::s/up (v/kind (s/up 1 2))))
-    (is (= ::s/down (v/kind (s/down (s/up 1 2)
-                                    (s/up 2 3))))
-        "Kind only depends on the outer wrapper, not on the contents."))
+    (testing "zero-like"
+      (is (v/zero? (v/zero-like (s/up 1 2 3))))
+      (is (= (s/up 0 0 0) (v/zero-like (s/up 1 2 3))))
+      (is (= (s/up) (v/zero-like (s/up))))
+      (is (= (s/down 0 0 0) (v/zero-like (s/down 1 2 3))))
+      (is (= (s/down) (v/zero-like (s/down))))
+      (is (= (s/up 0 (s/down (s/up 0 0) (s/up 0 0)))
+             (v/zero-like (s/up 1 (s/down (s/up 2 3) (s/up 4 5))))))
+      (is (= (s/up (u/long 0) (u/int 0) 0)
+             (v/zero-like (s/up (u/long 1) (u/int 2) 3)))))
+
+    (testing "one-like"
+      (is (thrown? #?(:clj UnsupportedOperationException :cljs js/Error)
+                   (v/one-like (s/up 1 2 3)))))
+
+    (testing "identity-like"
+      (is (thrown? #?(:clj UnsupportedOperationException :cljs js/Error)
+                   (v/identity-like (s/up 1 2 3)))))
+
+    (testing "exact?"
+      (is (v/exact? (s/up 1 2 3 4)))
+      (is (not (v/exact? (s/up 1.2 3 4))))
+      (is (v/exact? (s/up 0 1 #sicm/ratio 3/2)))
+      (is (not (v/exact? (s/up 0 0 0.00001)))))
+
+    (testing "numerical?"
+      (checking "no structure is numerical." 100
+                [s (sg/structure sg/real)]
+                (is (not (v/numerical? s)))))
+
+    (testing "freeze"
+      (is (= '(up 1 2 3) (v/freeze (s/up 1 2 3)))))
+
+    (testing "kind"
+      (is (= ::s/up (v/kind (s/up 1 2))))
+      (is (= ::s/down (v/kind (s/down (s/up 1 2)
+                                      (s/up 2 3))))
+          "Kind only depends on the outer wrapper, not on the contents.")))
 
   (testing "string rep"
     (is (= "(up sin cos tan)" (x/expression->string
@@ -870,6 +901,12 @@
                 "conjugate the left arg!")))
 
 (deftest structure-generics
+  (testing "g/* returns a proper zero"
+    (is (= (s/up 0 0 0)
+           (g/* 0 0 0 (s/up 0 0 0) 0 0))
+        "make sure that leading zeros don't stop the reduction and `g/*`
+        discovers it needs to return a proper structure."))
+
   (testing "up/down +, same kind"
     (is (= (+ (s/up 1 2) (s/up 2 3))
            (s/up 3 5)))


### PR DESCRIPTION
From the CHANGELOG:

  - Implements `IKVReduce` and `Reversible` for structures. This enables `rseq`
    and `reduce-kv` to work with structures.

  - Removes a `reduced` shortcut condition in `sicmutils.generic/*` that was
    causing multiplications of the form `(* 0 0 (up 0 0))` to shortcut and
    return `0` instead of the appropriate structural form.

  - the `atan` implementation for symbolic numbers is now careful not to return
    a floating point number in the case of a 0 argument in the second position.
    Additionally, it now returns symbolic `pi` or 0 in the case of `0` in the y
    argument for positive and negative `x` argument, respectively, and symbolic
    `(/ pi 2)` or `(- (/ pi 2))` for a 0 `x` argument and respective positive or
    negative `y` argument.