### PR TITLE
Fix for pattern matcher accidentally seq-ing structures, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [unreleased]
 
-- In `pattern.match` and all rules, things that respond true to `sequential?`
+- #445 fixes a bug where structures and other seq-able types were interpreted as
+  sequence matchers.
+
+  In `pattern.match` and all rules, things that respond true to `sequential?`
   but not `seq?` or `vector?` (many of the sicmutils types, like structures and
   the upcoming Quaternion type) were being converted to `seq` and treated as
   sequence matchers vs literal matchers. This no longer happens, and structures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [unreleased]
 
+- In `pattern.match` and all rules, things that respond true to `sequential?`
+  but not `seq?` or `vector?` (many of the sicmutils types, like structures and
+  the upcoming Quaternion type) were being converted to `seq` and treated as
+  sequence matchers vs literal matchers. This no longer happens, and structures
+  etc are treated as literal matchers.
+
 - #443:
 
   - Implements `IKVReduce` and `Reversible` for structures. This enables `rseq`

--- a/src/pattern/match.cljc
+++ b/src/pattern/match.cljc
@@ -126,8 +126,8 @@
   "Takes a predicate function `pred` and returns a matcher that succeeds (with no
   new bindings) if its data input passes the predicate, fails otherwise."
   [pred]
-  (fn predicate-match [frame xs succeed]
-    (core:and (pred xs)
+  (fn predicate-match [frame data succeed]
+    (core:and (pred data)
               (succeed frame))))
 
 (defn frame-predicate
@@ -446,7 +446,8 @@
 
         (s/wildcard? pattern) pass
 
-        (sequential? pattern)
+        (core:or (seq? pattern)
+                 (vector? pattern))
         (if (empty? pattern)
           (eq pattern)
           (sequence*

--- a/src/sicmutils/simplify.cljc
+++ b/src/sicmutils/simplify.cljc
@@ -135,7 +135,8 @@
 
           logexp? (rules/occurs-in? #{'log 'exp} syms)
           trig? (rules/occurs-in? #{'sin 'cos 'tan 'cot 'sec 'csc} syms)
-          partials? (rules/occurs-in? #{'partial} syms) simple
+          partials? (rules/occurs-in? #{'partial} syms)
+          simple
           (comp (only-if rules/*divide-numbers-through-simplify?*
                          rules/divide-numbers-through)
 


### PR DESCRIPTION
From the CHANGELOG:

- In `pattern.match` and all rules, things that respond true to `sequential?`
  but not `seq?` or `vector?` (many of the sicmutils types, like structures and
  the upcoming Quaternion type) were being converted to `seq` and treated as
  sequence matchers vs literal matchers. This no longer happens, and structures
  etc are treated as literal matchers.