### PR TITLE
Symbolic/complex dot-product, complex fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [unreleased]
 
+  - symbolic `dot-product` and `inner-product`
+
+  - `inner-product` now defaults to `dot-product` for scalar instances. This is
+    correct for all numeric types we currently have, since `complex` is the only
+    tough case, and it has real coefficients. Maybe this would be sketchy for a
+    bicomplex number (TODO link!)
+
+  - complex implementations for `dot-product` between complex and real types
+
+  - simplify now does NOT freeze expressions before simplifying. This allows
+    complex numbers to survive simplification, since they freeze to `(complex
+    <re> <im>)`.
+
+    - big rewrite in `sicmutils.simplify.rules`, to convert all of the frozen
+      matchers like `(complex 1 2)` into matchers that actually bind to a
+      complex number.
+
+    - more rules in `complex-trig`, it can now handle bigger products inside of
+      `sin` and `cos` multiplied by `I`.
+
+  - Fix bug in `sicmutils.calculus.indexed`, in a case where either input was
+    missing an `up` or `down`index type.
+
+  - Fixed a couple of reflection warnings with `ComplexFormat`in complex parsing
+    code
+
+  - complex `zero?` now returns true for `(complex -0.0 -0.0)`, which it did not
+    before!
+
+  - new `-I` (TODO make this happen), also `g/expt` for complex numbers now does
+    the right thing with `I` input, a bit of a hedge.
+
 - #443:
 
   - Implements `IKVReduce` and `Reversible` for structures. This enables `rseq`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## [unreleased]
 
+  - Use `Math/E` instead of `(Math/exp 1)` for euler's constant in
+    `sicmutils.env`.
+
   - symbolic `dot-product` and `inner-product`
 
   - `inner-product` now defaults to `dot-product` for scalar instances. This is
     correct for all numeric types we currently have, since `complex` is the only
-    tough case, and it has real coefficients. Maybe this would be sketchy for a
-    bicomplex number (TODO link!)
+    tough case, and it has real coefficients.
 
   - complex implementations for `dot-product` between complex and real types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,20 @@
 
 ## [unreleased]
 
+- #447 contains a grab-bag of fixes and additions, many related to complex
+  numbers:
+
   - Use `Math/E` instead of `(Math/exp 1)` for euler's constant in
     `sicmutils.env`.
+
+  - Fix bug in `sicmutils.calculus.indexed`, in a case where either input was
+    missing an `up` or `down`index type.
 
   - symbolic `dot-product` and `inner-product`
 
   - `inner-product` now defaults to `dot-product` for scalar instances. This is
     correct for all numeric types we currently have, since `complex` is the only
     tough case, and it has real coefficients.
-
-  - complex implementations for `dot-product` between complex and real types
 
   - simplify now does NOT freeze expressions before simplifying. This allows
     complex numbers to survive simplification, since they freeze to `(complex
@@ -24,17 +28,20 @@
     - more rules in `complex-trig`, it can now handle bigger products inside of
       `sin` and `cos` multiplied by `I`.
 
-  - Fix bug in `sicmutils.calculus.indexed`, in a case where either input was
-    missing an `up` or `down`index type.
+  - Various improvements to `sicmutils.complex`:
 
-  - Fixed a couple of reflection warnings with `ComplexFormat`in complex parsing
-    code
+    - complex implementations for `dot-product` between complex and real types
 
-  - complex `zero?` now returns true for `(complex -0.0 -0.0)`, which it did not
-    before!
+    - Fixed reflection warnings with `ComplexFormat`in complex parsing code
 
-  - new `-I` (TODO make this happen), also `g/expt` for complex numbers now does
-    the right thing with `I` input, a bit of a hedge.
+    - complex `zero?` now returns true for inputs like `(complex -0.0 -0.0)`,
+      where a negative zero lives in the real or imaginary slots
+
+    - new `sicmutils.complex/-I` binding, set to `(g/negate c/I)`
+
+    - `g/expt` for complex numbers optimizes the inputs equal to `I` by
+      returning exact 1, -1, `I` or `-I` depending on the input. This applies to
+      `g/square` and `g/cube` as well.
 
 - #443:
 

--- a/src/sicmutils/abstract/number.cljc
+++ b/src/sicmutils/abstract/number.cljc
@@ -215,6 +215,8 @@
 (defunary g/magnitude 'magnitude)
 (defunary g/angle 'angle)
 (defunary g/conjugate 'conjugate)
+(defbinary g/dot-product 'dot-product)
+(defbinary g/inner-product 'inner-product)
 
 (defbinary g/gcd 'gcd)
 (defbinary g/lcm 'lcm)
@@ -223,7 +225,7 @@
 (defmethod g/simplify [::x/numeric] [a]
   (literal-number
    (ss/simplify-expression
-    (v/freeze a))))
+    (x/expression-of a))))
 
 (def ^:private memoized-simplify
   (memoize g/simplify))

--- a/src/sicmutils/calculus/indexed.cljc
+++ b/src/sicmutils/calculus/indexed.cljc
@@ -258,8 +258,8 @@
     (assert (seq i2) "No index types registered for T2!")
     (let [{nu1 'up nd1 'down} (frequencies i1)
           {nu2 'up nd2 'down} (frequencies i2)
-          nup (+ nu1 nu2)
-          ndp (+ nd1 nd2)
+          nup (+ (or nu1 0) (or nu2 0))
+          ndp (+ (or nd1 0) (or nd2 0))
           np  (+ nup ndp)
           n1  (+ nup nd1)]
       (letfn [(product [args]

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -178,13 +178,11 @@
   (numerical? [_] true)
 
   v/Value
-  ;; TODO test that 0, -0 gives true here and for identity
   (zero? [c]
     #?(:clj (and (zero? (real c))
                  (zero? (imaginary c)))
        :cljs (.isZero c)))
 
-  ;; TODO test that 1, -0 gives true here and for identity
   (one? [c]
     (and (v/one? (real c))
          (zero? (imaginary c))))

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -177,7 +177,7 @@ constant [Pi](https://en.wikipedia.org/wiki/Pi)."}
   constant [e](https://en.wikipedia.org/wiki/E_(mathematical_constant)),
   sometimes known as Euler's Number."}
   euler
-  (Math/exp 1))
+  Math/E)
 
 (def ^{:doc "The mathematical constant known as the [Euler–Mascheroni
   constant](https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant) and

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -471,7 +471,12 @@
             (real-part z)))))
 
 (defn dot-product
-  "TODO docs!"
+  "Returns the symbolic dot product of the two supplied numbers `z1` and `z2`.
+
+  If both are numbers, defers to [[sicmutils.generic/dot-product]]. Else,
+  returns
+
+  $$\Re(z_1)\Re(z_2) + \Im(z_1)\Im(z_2)$$"
   [z1 z2]
   (cond (and (v/number? z1) (v/number? z2))
         (g/dot-product z1 z2)

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -470,6 +470,20 @@
       (atan (imag-part z)
             (real-part z)))))
 
+(defn dot-product
+  "TODO docs!"
+  [z1 z2]
+  (cond (and (v/number? z1) (v/number? z2))
+        (g/dot-product z1 z2)
+
+        (v/real? z1) (mul z1 (real-part z2))
+        (v/real? z2) (mul (real-part z1) z2)
+        :else (add
+               (mul (real-part z1)
+                    (real-part z2))
+               (mul (imag-part z1)
+                    (imag-part z2)))))
+
 (defn ^:no-doc derivative
   "Returns the symbolic derivative of the expression `expr`, which should
   represent a function like `f`.
@@ -601,6 +615,8 @@
    'imag-part imag-part
    'conjugate conjugate
    'magnitude magnitude
+   'dot-product dot-product
+   'inner-product dot-product
    'angle angle
    'derivative derivative})
 

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -886,7 +886,7 @@
                   struct2))]
     (mapr xform struct1)))
 
-(defn- cross-product
+(defn ^:no-doc cross-product
   "Returns the cross product of structures of length 3. Input orientations are
   ignored; result is an up-tuple."
   [s t]

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -765,7 +765,11 @@
                (* 0.5 y (conjugate x)))
            (v/freeze
             (g/simplify
-             (g/dot-product 'x 'y)))))))
+             (g/dot-product 'x 'y)))))
+
+    (is (= (g/dot-product 'x 'y)
+           (g/inner-product 'x 'y))
+        "identical for abstract complex numbers")))
 
 (deftest symbolic-trig-tests
   (testing "trig shortcuts - sin"

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -227,7 +227,7 @@
                    (g/expt (an/literal-number x) e))))
 
   (checking "abs" 100 [x (sg/inexact-double)]
-            (is (= (an/literal-number (Math/abs x))
+            (is (= (an/literal-number (Math/abs ^double x))
                    (g/abs (an/literal-number x)))))
 
   (checking "sqrt" 100 [x (sg/inexact-double)]
@@ -758,7 +758,14 @@
 
   (checking "magnitude" 100 [z gen/symbol]
             (is (= (g/sqrt (g/mul (g/conjugate z) z))
-                   (g/magnitude z)))))
+                   (g/magnitude z))))
+
+  (testing "dot-product"
+    (is (= '(+ (* 0.5 x (conjugate y))
+               (* 0.5 y (conjugate x)))
+           (v/freeze
+            (g/simplify
+             (g/dot-product 'x 'y)))))))
 
 (deftest symbolic-trig-tests
   (testing "trig shortcuts - sin"

--- a/test/sicmutils/calculus/derivative_test.cljc
+++ b/test/sicmutils/calculus/derivative_test.cljc
@@ -388,8 +388,9 @@
 
 (deftest complex-derivatives
   (let [f (fn [z] (* c/I (sin (* c/I z))))]
-    (is (= '(* -1 (cosh z))
-           (simplify ((D f) 'z))))))
+    (is (= '(* -1.0 (cosh z))
+           (simplify
+            ((D f) 'z))))))
 
 (deftest operator-tests
   (testing "operator multiplication by fn == "

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -245,7 +245,13 @@
     (testing "expt"
       (is (near -1 (g/expt (c/complex 0 1) 2)))
       (is (near (c/complex 16) (g/expt 2 (c/complex 4))))
-      (is (near (c/complex 16) (g/expt (c/complex 2) (c/complex 4)))))
+      (is (near (c/complex 16) (g/expt (c/complex 2) (c/complex 4))))
+
+      (is (= -1 (g/square c/I))
+          "squaring I produces an exact result.")
+
+      (is (= c/-I (g/cube c/I))
+          "cubing has an exact shortcut"))
 
     (testing "negate"
       (is (= (c/complex -10 2)
@@ -258,8 +264,8 @@
       (is (= 5.0 (g/abs (c/complex 3 4)))))
 
     (testing "exp"
-      ;; Euler identity
-      (is (near (c/complex -1) (g/exp (g/mul c/I pi)))))
+      (is (near (c/complex -1) (g/exp (g/mul c/I pi)))
+          "Euler's identity"))
 
     (testing "log"
       (is (= (g/mul c/I pi) (g/log (g/exp (g/mul c/I pi))))))

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -74,17 +74,34 @@
 
 (deftest value-protocol
   (testing "v/Value protocol implementation"
-    (is (v/zero? c/ZERO))
-    (is (v/zero? #sicm/complex "0"))
+    (is (every?
+         v/zero?
+         [(c/complex -0.0 -0.0)
+          (c/complex 0.0 -0.0)
+          (c/complex -0.0 0.0)
+          (c/complex 0.0 0.0)
+          (v/zero-like c/ONE)
+          (v/zero-like (c/complex 100))
+          c/ZERO
+          #sicm/complex "0"])
+        "negative zero doesn't affect zero")
+
     (is (not (v/zero? c/ONE)))
     (is (not (v/zero? (c/complex 1.0))))
-    (is (v/zero? (v/zero-like (c/complex 100))))
     (is (= c/ZERO (v/zero-like (c/complex 2))))
     (is (= c/ZERO (v/zero-like #sicm/complex "0 + 3.14i")))
 
-    (is (v/one? c/ONE))
-    (is (v/one? (c/complex 1.0)))
-    (is (v/one? (v/one-like c/ZERO)))
+    (let [ones [c/ONE
+                (c/complex 1.0)
+                (v/one-like c/ZERO)
+                (c/complex 1.0 0.0)
+                (c/complex 1.0 -0.0)]]
+      (is (every? v/one? ones)
+          "-0 in imaginary does not affect one?")
+
+      (is (every? v/identity? ones)
+          "-0 in imaginary does not affect identity?"))
+
     (is (not (v/one? (c/complex 2))))
     (is (not (v/one? (c/complex 0.0))))
 

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -106,6 +106,15 @@
 
 (let [pi Math/PI]
   (deftest complex-numbers
+    (testing "v/="
+      (is (v/= #sicm/complex "1+0i" #sicm/bigint 1))
+      (is (not (v/= #sicm/complex "1+2i" #sicm/ratio "1/2")))
+
+      #?(:cljs
+         (testing "CLJS can compare complex with non-complex using clojure.core/="
+           (is (= #sicm/complex "1+0i" #sicm/bigint 1))
+           (is (not= #sicm/complex "1+2i" #sicm/ratio "1/2")))))
+
     (testing "complex constructor and predicate"
       (is (c/complex? c/ONE))
       (is (c/complex? c/I))

--- a/test/sicmutils/env_test.cljc
+++ b/test/sicmutils/env_test.cljc
@@ -20,6 +20,7 @@
 (ns sicmutils.env-test
   (:refer-clojure :exclude [+ - * / zero? partial ref])
   (:require [clojure.test :refer [is deftest testing]]
+            [same :refer [ish?] #?@(:cljs [:include-macros true])]
             [sicmutils.complex :as c]
             [sicmutils.env :as e :refer [+ - * / zero? partial ref
                                          complex
@@ -34,6 +35,10 @@
             [sicmutils.matrix :as matrix]
             [sicmutils.operator :as o]
             [sicmutils.value :as v]))
+
+(deftest constant-tests
+  (is (ish? e/euler (e/exp 1))
+      "not quite equal, but close."))
 
 (deftest partial-shim
   (testing "partial also works the way Clojure defines it"

--- a/test/sicmutils/simplify/rules_test.cljc
+++ b/test/sicmutils/simplify/rules_test.cljc
@@ -19,7 +19,10 @@
 
 (ns sicmutils.simplify.rules-test
   (:require [clojure.test :refer [is deftest testing]]
-            [pattern.rule :as pr :refer [rule-simplifier]]
+            [pattern.rule :as pr :refer [rule-simplifier template]
+             #?@(:cljs [:include-macros true])]
+            [sicmutils.complex :as c]
+            [sicmutils.generic :as g]
             [sicmutils.numbers]
             [sicmutils.ratio]
             [sicmutils.simplify.rules :as r]
@@ -164,6 +167,14 @@
       "real numbers and integers get their magnitudes applied, odd exponents
       pulled apart."))
 
+(deftest miscsimp-tests
+  (let [s (r/miscsimp s/*rf-simplify*)]
+    (testing "expt of `i` stays complex"
+      (is (= -1 (s (list 'expt c/I 2))))
+      (is (= (g/- c/I) (s (list 'expt c/I 3))))
+      (is (= 1 (s (list 'expt c/I 4))))
+      (is (= c/I (s (list 'expt c/I 5)))))))
+
 (deftest simplify-square-roots-test
   (let [s (r/simplify-square-roots  s/*rf-simplify*)]
     (testing "even powers"
@@ -241,6 +252,15 @@
       (is (= '(- (sqrt (/ a b)) (sqrt (/ c b)))
              (sqrt-contract
               '(- (/ (sqrt a) (sqrt b)) (/ (sqrt c) (sqrt b)))))))))
+
+(deftest specfun->logexp-test
+  (is (= (template
+          (+ x (/ (- (log (+ 1 (* ~c/I z)))
+                     (log (- 1 (* ~c/I z))))
+                  ~(c/complex 0.0 2.0))))
+         (r/specfun->logexp '(+ x (atan z))))
+      "lame test... but this is meant to show that complex numbers appear in the
+      replacement."))
 
 (deftest divide-numbers-through-test
   (let [d r/divide-numbers-through]
@@ -348,3 +368,54 @@
     (is (= '(((* (expt (partial 0) 2) (partial 1)) f) (up x y z))
            (full-rule expr))
         "The full rule collects products into exponents.")))
+
+(deftest complex-test
+  (testing "complex-trig"
+    (is (= '(cosh 1)
+           (r/complex-trig (list 'cos c/I)))
+        "cos i, no factors")
+
+    (is (= (list '* c/I '(sinh 1))
+           (r/complex-trig (list 'sin c/I)))
+        "sin i, no factors")
+
+    (is (= '(cosh z)
+           (r/complex-trig
+            (template (cos (* z ~c/I))))
+           (r/complex-trig
+            (template (cos (* ~c/I z)))))
+        "cos i, 1 factor")
+
+    (is (= (list '* c/I '(sinh z))
+           (r/complex-trig
+            (template (sin (* z ~c/I))))
+           (r/complex-trig
+            (template (sin (* ~c/I z)))))
+        "sin i, 1 factor")
+
+    (is (= '(cosh (* z x))
+           (r/complex-trig
+            (template (cos (* z ~c/I x))))
+           (r/complex-trig
+            (template (cos (* ~c/I z x))))
+           (r/complex-trig
+            (template (cos (* z x ~c/I)))))
+        "cos of i and more factors")
+
+    (is (= '(cosh (* z x))
+           (r/complex-trig
+            (template (cos (* z ~c/I x))))
+           (r/complex-trig
+            (template (cos (* ~c/I z x))))
+           (r/complex-trig
+            (template (cos (* z x ~c/I)))))
+        "cos of i and more factors")
+
+    (is (= (template (* ~c/I (sinh (* z x))))
+           (r/complex-trig
+            (template (sin (* z ~c/I x))))
+           (r/complex-trig
+            (template (sin (* ~c/I z x))))
+           (r/complex-trig
+            (template (sin (* z x ~c/I)))))
+        "sin of i and more factors")))

--- a/test/sicmutils/simplify_test.cljc
+++ b/test/sicmutils/simplify_test.cljc
@@ -115,9 +115,10 @@
     (is (= '(* (expt (sin a) 2) (expt (sin b) 2)) (simplify-expression X)))))
 
 (deftest complex-units
-  (is (= '(1 (complex 0.0 1.0) -1 (complex 0 -1) 1 (complex 0 1) -1 (complex 0 -1))
+  (is (= (take 8 (cycle [1 c/I -1 (g/- c/I)]))
          (for [n (range 8)]
-           (simplify-expression `(~'expt (~'complex 0.0 1.0) ~n))))))
+           (simplify-expression
+            (list 'expt c/I n))))))
 
 (deftest more-trig
   (is (= '(tan x) (g/simplify (g/tan 'x))))


### PR DESCRIPTION
From the CHANGELOG:

  - Use `Math/E` instead of `(Math/exp 1)` for euler's constant in
    `sicmutils.env`.

  - Fix bug in `sicmutils.calculus.indexed`, in a case where either input was
    missing an `up` or `down`index type.

  - symbolic `dot-product` and `inner-product`

  - `inner-product` now defaults to `dot-product` for scalar instances. This is
    correct for all numeric types we currently have, since `complex` is the only
    tough case, and it has real coefficients.

  - simplify now does NOT freeze expressions before simplifying. This allows
    complex numbers to survive simplification, since they freeze to `(complex
    <re> <im>)`.

    - big rewrite in `sicmutils.simplify.rules`, to convert all of the frozen
      matchers like `(complex 1 2)` into matchers that actually bind to a
      complex number.

    - more rules in `complex-trig`, it can now handle bigger products inside of
      `sin` and `cos` multiplied by `I`.

  - Various improvements to `sicmutils.complex`:

    - complex implementations for `dot-product` between complex and real types

    - Fixed a couple of reflection warnings with `ComplexFormat`in complex
      parsing code

    - complex `zero?` now returns true for `(complex -0.0 -0.0)`, which it did
      not before!

    - new `sicmutils.complex/-I` binding.

    - also `g/expt` for complex numbers now optimiziesthe right thing with `I`
      input, a bit of a hedge.