### PR TITLE
New sicmutils.algebra.fold namespace, fold improvements all around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+  - TODO note the new `sicmutils.algebra.fold`!
+
   - `kahan-sum` is now `kahan-fold` and has a single arity version that is nice
 
   - ua/sum, ua/scanning-sum can now have custom folds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
   - ua/sum, ua/scanning-sum can now have custom folds
 
-  - new naive-fold, `kahan-babushka-neumaier-fold` aliased as `kbn-fold`
+  - new `naive-fold`, `kahan-babushka-neumaier-fold` aliased as `kbn-fold`...
+    also `kahan-babushka-klein-fold`.
 
   - new `ua/*fold*` that can configure behavior for
     `sicmutils.aggregate/{scanning-sum, sum}`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [unreleased]
 
+  - `kahan-sum` is now `kahan-fold` and has a single arity version that is nice
+
+  - ua/sum, ua/scanning-sum can now have custom folds
+
+  - new naive-fold, `kahan-babushka-neumaier-fold` aliased as `kbn-fold`
+
+  - new `ua/*fold*` that can configure behavior for
+    `sicmutils.aggregate/{scanning-sum, sum}`.
+
+  - three-arity version of `ua/sum` is more efficient, now uses transducers.
+
 - #448:
 
   - new `g/infinite?` generic with implementations for all numeric types,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,94 @@
 
 ## [unreleased]
 
-  - TODO note the new `sicmutils.algebra.fold`!
+- #451:
 
-  - add new fold, scan to bulirsch-stoer rational
+  - new `sicmutils.algebra.fold` namespace:
 
-  - sci supports the `fork` macro in `sicmutils.util.def`... and the rest of
-    that namespace, though there is not much going on.
+    - New folds: `kahan-babushka-neumaier` (aliased as `kbn`),
+      `kahan-babushka-klein` and and `kbk-n` macro for generating higher-order
+      `kahan-babushka-klein` variants. `generic-sum-fold` folds using
+      `sicmutils.generic/+`.
 
-  - `kahan-sum` is now `kahan-fold` and has a single arity version that is nice
+    - `sicmutils.util.aggregate/kahan-fold` now lives here, named `kahan`.
 
-  - ua/sum, ua/scanning-sum can now have custom folds
+    - `fold->sum-fn` and `fold->scan-fn` generate functions like
+      `sicmutils.util.aggregate.{sum,scan}` specialized to the supplied fold.
+      See the docstrings for the multiple arities supported
 
-  - new `naive-fold`, `kahan-babushka-neumaier-fold` aliased as `kbn-fold`...
-    also `kahan-babushka-klein-fold`.
+    - fold primitives: `count`, `constant`, `min`, `max`.
 
-  - new `ua/*fold*` that can configure behavior for
-    `sicmutils.aggregate/{scanning-sum, sum}`.
+    - fold combinator `join` allows compound folds to be built out of primitive
+      folds.
 
-  - three-arity version of `ua/sum` is more efficient, now uses transducers.
+  - Upgrades to `sicmutils.util.aggregate`:
 
-  - remove `halt-at` in favor of `halt-when` in core!
+    - `scanning-sum` renamed to `scan`
+
+    - `halt-at` deleted in favor of the built-in `halt-when` that I didn't know
+      about!
+
+    - `scan` and `sum` now both use a dynamic binding, `*fold*`, to set the fold
+      they use for aggregation. By default, this is set to the new
+      `kahan-babushka-neumaier-fold`.
+
+    - The three-arity version of `sum` now uses transducers, saving a pass over
+      the input range.
+
+    - `pairwise-sum` implements pairwise summation, an error-limiting technique
+      for summing vectors. Use the dynamic binding `*cutoff*` to set where
+      `pairwise-sum` bails out to normal summation.
+
+  - Upgrades to `sicmutils.rational-function.polynomial`:
+
+    - The folds in this namespace now follow the fold contract laid out in
+      `sicmutils.algebra.fold`, implementing all three arities correctly.
+
+    - I realized that the fold implementation here should /not/ return a full
+      row every time it processes a previous row; a far better `present`
+      implementation would return the best estimate so far. Then you could build
+      a `scan` from that fold to see the estimates evolve lazily as new points
+      are added. This has better performance, it turns out, than the original
+      method!
+
+    - added a bunch to the exposition to make the advantages clear.
+
+  - Upgrades to `sicmutils.rational-function.interpolate`:
+
+    - `fold` interface upgraded, similar to the polynomial interpolation notes.
+
+    - New `bulirsch-stoer-fold`, `bulirsch-stoer-sum` and `bulirsch-stoer-scan`
+      functions. These are similar to the `modified-**` versions but use the
+      `bulirsch-stoer` algorithm, instead of `modified-bulirsch-stoer`.
+
+    - `modified-bulirsch-stoer-fold-fn` renamed to
+      `modified-bulirsch-stoer-fold`, to match the naming scheme of other
+      "folds" in the library.
+
+    - `modified-bulirsch-stoer-fold` renamed to `modified-bulirsch-stoer-sum`,
+      to match the convention that "reducing a sequence with a fold" is called
+      "summing" the sequence. I can see this changing down the road...
+
+    See `context-opts` for instructions on how to enable
+    `sicmutils.algebra.fold/kbk-n` in the SCI environment (you'll need to turn
+    on access to `js/Math` or `java.lang.Math`).
+
+  - Fixed a type inference warning in Clojurescript in `sicmutils.complex`.
+
+  - Added support for `sicmutils.util.def` and its `fork` macro to the default
+    SCI environment provided by SICMUtils. Helpful for macro-writing!
+
+  - `sicmutils.numerical.quadrature.adaptive` now uses the dynamically bound
+    `sicmutils.util.aggregate/*fold*` to accumulate its numerical integral
+    pieces, instead of a hardcoded `kahan-sum`.
+
+  - `sicmutils.numerical.quadrature.bulirsch-stoer` now uses the functional scan
+    versions of polynomial and rational function interpolation, as these are a
+    bit faster than the originals!
+
+  - `sicmutils.util.stream/scan` deleted in favor of
+    `sicmutils.util.aggregate/scan` with a dynamic binding for `*fold*` to
+    customize.
 
 - #448:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
   - three-arity version of `ua/sum` is more efficient, now uses transducers.
 
+  - remove `halt-at` in favor of `halt-when` in core!
+
 - #448:
 
   - new `g/infinite?` generic with implementations for all numeric types,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
   - TODO note the new `sicmutils.algebra.fold`!
 
+  - add new fold, scan to bulirsch-stoer rational
+
+  - sci supports the `fork` macro in `sicmutils.util.def`... and the rest of
+    that namespace, though there is not much going on.
+
   - `kahan-sum` is now `kahan-fold` and has a single arity version that is nice
 
   - ua/sum, ua/scanning-sum can now have custom folds

--- a/src/sicmutils/algebra/fold.cljc
+++ b/src/sicmutils/algebra/fold.cljc
@@ -79,8 +79,10 @@
   "Given
 
   - a 0-argument fn `init` that returns some \"empty\" accumulating value
-  - a 2-argument fn `fold` of `(accumulator, x) => x` responsible for merging
-    some value `x` into the ongoing accumulation
+
+  - a 2-argument fn `fold` of `(accumulator, x) => accumulator` responsible for
+    merging some value `x` into the ongoing accumulation
+
   - a 1-argument fn `present` from `accumulator => final-result`
 
   Returns a function with two arities. The first arity takes a sequence `xs` and
@@ -244,8 +246,10 @@
   "Given
 
   - a 0-argument fn `init` that returns some \"empty\" accumulating value
-  - a 2-argument fn `fold` of `(accumulator, x) => x` responsible for merging
-    some value `x` into the ongoing accumulation
+
+  - a 2-argument fn `fold` of `(accumulator, x) => accumulator` responsible for
+    merging some value `x` into the ongoing accumulation
+
   - a 1-argument fn `present` from `accumulator => final-result`
 
   Returns a function with two arities. The first arity takes a sequence `xs` and

--- a/src/sicmutils/algebra/fold.cljc
+++ b/src/sicmutils/algebra/fold.cljc
@@ -1,0 +1,487 @@
+;;
+;; Copyright © 2022 Sam Ritchie.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
+
+(ns sicmutils.algebra.fold
+  "Namespace implementing various aggregation functions using the `fold`
+  abstraction and combinators for generating new folds from fold primitives.
+
+  Contains a number of algorithms for [compensated
+  summation](https://en.wikipedia.org/wiki/Kahan_summation_algorithm) of
+  floating-point numbers."
+  (:refer-clojure :rename {count core-count
+                           min core-min
+                           max core-max})
+  (:require [sicmutils.generic :as g]))
+
+;; ## Folds and Scans
+;;
+;; A [fold](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) is a
+;; combination of:
+;;
+;; - some initial value into which you want to aggregate
+;; - a combining function of type (accumulator, x) => accumulator, capable
+;;   of "folding" each element `x` in some sequence of `xs` into the
+;;   accumulating state
+;; - a "present" function that converts the accumulator into a final value.
+;;
+;; NOTE: This also happens to be Clojure's required interface for the reducing
+;; function you pass to [[clojure.core/transduce]]. Any of the folds implemented
+;; in this namespace work well with `transduce` out of the box.
+;;
+;; Here is a simple example of a fold:
+
+(defn generic-sum-fold
+  "Fold-style function. The 2-arity merge operation adds the value `x` into the
+  accumulating stating using [[sicmutils.generic/+]].
+
+  - given 0 arguments, returns an accumulator of 0.0
+  - given a single argument `acc`, acts as identity."
+  ([] 0.0)
+  ([acc] acc)
+  ([acc x]
+   (g/+ acc x)))
+
+;; The accumulator is the floating point 0.0. The `present` function is just...
+;; identity. This might seem pedantic to include, but many interesting folds
+;; need to keep intermediate state around, so please indulge me for now.
+;;
+;; To "fold" a new number into the running total, simply add them together.
+;;
+;; Here is how to use this function to add up the integers from 0 to 9:
+
+#_
+(let [xs (range 10)]
+  (= 45 (generic-sum-fold
+         (reduce generic-sum-fold (generic-sum-fold) xs))))
+
+;; To see how this abstraction is useful, let's first capture this ability to
+;; make "summation" functions out of folds. (Note the docstring's description of
+;; the other arities of `fold->sum-fn`... these allow you to define each of the
+;; arities of a fold in separate functions if you like.)
+
+(defn fold->sum-fn
+  "Given
+
+  - a 0-argument fn `init` that returns some \"empty\" accumulating value
+  - a 2-argument fn `fold` of `(accumulator, x) => x` responsible for merging
+    some value `x` into the ongoing accumulation
+  - a 1-argument fn `present` from `accumulator => final-result`
+
+  Returns a function with two arities. The first arity takes a sequence `xs` and
+  returns the result of accumulating all elements in `xs` using the functions
+  above, then `present`ing the result.
+
+  The second arity takes a transformation function `f`, an inclusive lower bound
+  `low` and an exclusive upper bound `high` and returns the result of
+  accumulating `(map f (range low high))`.
+
+  ## Other Arities
+
+  Given a single argument `fold`, `fold` is passed as each of the 0, 1 and 2
+  arity arguments.
+
+  Given `fold` and `present`, `fold` is used for the 0 and 2 arity arguments,
+  `present` for the 1-arity argument."
+  ([fold]
+   (fold->sum-fn fold fold fold))
+  ([fold present]
+   (fold->sum-fn fold fold present))
+  ([init fold present]
+   (fn ([xs]
+       (present
+        (reduce fold (init) xs)))
+     ([f low high]
+      (let [xs (range low high)]
+        (transduce (map f) fold xs))))))
+
+;; Our example again:
+#_
+(let [sum (fold->sum-fn generic-sum-fold)
+      xs  (range 10)]
+  (= 45 (sum xs)))
+
+;; ### Useful Folds
+;;
+;; This pattern is quite general. Here is example of a fold that (inefficiently)
+;; computes the average of a sequence of numbers:
+
+#_
+(defn average
+  ([] [0.0 0])
+  ([[sum n]] (/ sum n))
+  ([[sum n] x]
+   [(+ sum x) (inc n)]))
+
+;; The average of [0,9] is 4.5:
+
+#_
+(let [sum (fold->sum-fn average)]
+  (= 4.5 (sum (range 10))))
+
+;; (I'm not committing this particular implementation because it can overflow
+;; for large numbers. There is a better implementation in Algebird, used
+;; in [`AveragedValue`](https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/AveragedValue.scala)
+;; that you should port when this becomes important.)
+;;
+;; Here are some more building blocks:
+
+(defn constant
+  "Given some value `const`, returns a fold that ignores all input and returns
+  `const` for a call to any of its arities."
+  [const]
+  (fn [& _] const))
+
+(defn count
+  "Given some predicate `pred`, returns a fold that counts the number of items it
+  encounters that return true when passed to `pred`, false otherwise."
+  ([] (count (fn [] true)))
+  ([pred]
+   (fn ([] 0)
+     ([acc] acc)
+     ([acc _] (inc acc)))))
+
+(defn min
+  "Fold that stores its minimum encountered value in its accumulator, and returns
+  it when called on to present.
+
+  Accumulation initializes with `nil`."
+  ([] nil)
+  ([acc] acc)
+  ([acc x]
+   (if acc
+     (core-min acc x)
+     x)))
+
+(defn max
+  "Fold that stores its maximum encountered value in its accumulator, and returns
+  it when called on to present.
+
+  Accumulation initializes with `nil`."
+  ([] nil)
+  ([acc] acc)
+  ([acc x]
+   (if acc
+     (core-max acc x)
+     x)))
+
+;; NOTE also that any [[sicmutils.util.aggregate/monoid]] instance will work as
+;; a fold out of the box. [[sicmutils.util.aggregate]] has utilities for
+;; generating more explicit folds out of monoids.
+
+;; ## Fold Combinators
+;;
+;; Folds can be "added" together in the following sense; if I have a sequence of
+;; folds, I can run them in parallel across some sequence `xs` by combining them
+;; into a single fold with these properties:
+;;
+;; - the accumulator is a vector of the accumulators of each input fold
+;; - each `x` is merged into each accumulator using the appropriate fold
+;; - `present` is called for every entry in the final vector
+;;
+;; This function is called `join`:
+
+(defn join
+  "Given some number of `folds`, returns a new fold with the following properties:
+
+  - the accumulator is a vector of the accumulators of each input fold
+  - each `x` is merged into each accumulator using the appropriate fold
+  - `present` is called for every entry in the final vector
+
+  Given a single `fold`, acts as identity.
+
+  The no-argument call `(join)` is equivalent to `([[constant]] [])`."
+  ([] (constant []))
+  ([fold] fold)
+  ([fold & folds]
+   (let [folds (cons fold folds)]
+     (fn
+       ([]
+        (mapv (fn [f] (f)) folds))
+       ([accs]
+        (mapv #(%1 %2) folds accs))
+       ([accs x]
+        (mapv (fn [f acc]
+                (f acc x))
+              folds accs))))))
+
+;; For example, the following snippet computes the minimum, maximum and sum
+;; of `(range 10)`:
+
+#_
+(let [fold (join min max generic-sum-fold)
+      process (fold->sum-fn fold)]
+  (= [0 9 45]
+     (process (range 10))))
+
+;; ### Scans
+;;
+;; Before moving on, let's pause and implement a similar transformation of a
+;; fold, called `fold->scan-fn`. This is a generic form of Clojure's
+;; `reductions` function; a "scan" takes a sequence of `xs` and returns a
+;; sequence of all intermediate results seen by the accumulator, all passed
+;; through `present`.
+
+(defn fold->scan-fn
+  "Given
+
+  - a 0-argument fn `init` that returns some \"empty\" accumulating value
+  - a 2-argument fn `fold` of `(accumulator, x) => x` responsible for merging
+    some value `x` into the ongoing accumulation
+  - a 1-argument fn `present` from `accumulator => final-result`
+
+  Returns a function with two arities. The first arity takes a sequence `xs` and
+  returns a lazy sequence of all intermediate results of the summation. For
+  example, given [0 1 2 3], the return sequence would be equivalent to:
+
+  ```clj
+  (def sum-fn (fold->sum-fn init fold present))
+
+  [(sum-fn [0])
+   (sum-fn [0 1])
+   (sum-fn [0 1 2])
+   (sum-fn [0 1 2 3])]
+  ```
+
+  The second arity takes a transformation function `f`, an inclusive lower bound
+  `low` and an exclusive upper bound `high` and returns a lazy sequence of all
+  intermediate results of accumulating `(map f (range low high))`.
+
+  ## Other Arities
+
+  Given a single argument `fold`, `fold` is passed as each of the 0, 1 and 2
+  arity arguments.
+
+  Given `fold` and `present`, `fold` is used for the 0 and 2 arity arguments,
+  `present` for the 1-arity argument."
+  ([fold]
+   (fold->scan-fn fold fold fold))
+  ([fold present]
+   (fold->scan-fn fold fold present))
+  ([init fold present]
+   (fn scan
+     ([xs]
+      (->> (reductions fold (init) xs)
+           (map present)
+           (rest)))
+     ([f low high]
+      (scan
+       (map f (range low high)))))))
+
+;; Here is the previous example, using the fold to scan across `(range 4)`. Each
+;; vector in the returned (lazy) sequence is the minimum, maximum and running
+;; total seen up to that point.
+
+#_
+(let [fold (join min max generic-sum-fold)
+      process (fold->scan-fn fold)]
+  (i [[0 0 0]
+      [0 1 1]
+      [0 2 3]
+      [0 3 6]]
+     (process (range 4))))
+
+;; ## Summing Sequences of Numbers
+;;
+;; This is a fascinating topic, and my explorations have not yet done it
+;; justice. This section implements a number of folds designed to sum up
+;; sequences of numbers in various error-limiting ways.
+;;
+;; Much of the numerical physics simulation code in the library (everything
+;; in [[sicmutils.numerical.quadrature]], for example) depends on the ability to
+;; sum sequences of floating point numbers without the accumulation of error due
+;; to the machine representation of the number.
+;;
+;; Here is the naive way to add up a list of numbers:
+
+#_
+(defn naive-sum [xs]
+  (apply g/+ xs))
+
+;; Simple! But watch it "break":
+
+(comment
+  ;; This should be 1.0...
+  (= 0.9999999999999999
+     (naive-sum [1.0 1e-8 -1e-8])))
+
+;; Algorithms called ['compensated
+;; summation'](https://en.wikipedia.org/wiki/Kahan_summation_algorithm)
+;; algorithms are one way around this problem. Instead of simply accumulating
+;; the numbers as they come, compensated summation keeps track of the piece of
+;; the sum that would get erased from the sum due to lack of precision.
+;;
+;; Aggregation algorithms that require intermediate state as they traverse a
+;; sequence are often excellent matches for the "fold" abstraction.
+;;
+;; The fold implementing Kahan summation tracks two pieces of state:
+;;
+;; - The running sum
+;; - A running compensation term tracking lost low-order bits
+;;
+;; If you add a very small to a very large number, the small number will lose
+;; bits. If you then SUBTRACT a large number and get back down to the original
+;; small number's range, the compensation term can recover those lost bits for
+;; you.
+;;
+;; See
+;; the ['Accuracy'](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Accuracy)
+;; section of the wiki article for a detailed discussion on the error bounds you
+;; can expect with Kahan summation. I haven't grokked this yet, so please open a
+;; PR with more exposition once you get it.
+
+(defn kahan
+  "Fold that tracks the summation of a sequence of floating point numbers, using
+  the [Kahan summation
+  algorithm](https://en.wikipedia.org/wiki/Kahan_summation_algorithm) for
+  maintaining stability in the face of accumulating floating point errors."
+  ([] [0.0 0.0])
+  ([[acc _]] acc)
+  ([[acc c] x]
+   (let [y (- x c)
+         t (+ acc y)]
+     [t (- (- t acc) y)])))
+
+;; From the [wiki
+;; page](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements),
+;; "Neumaier introduced an improved version of Kahan algorithm, which he calls
+;; an 'improved Kahan–Babuška algorithm, which also covers the case when the
+;; next term to be added is larger in absolute value than the running sum,
+;; effectively swapping the role of what is large and what is small."
+;;
+;; This fold is implemented here:
+
+(defn kahan-babushka-neumaier
+  "Implements a fold that tracks the summation of a sequence of floating point
+  numbers, using Neumaier's improvement to [[kahan]].
+
+  This algorithm is more efficient than [[kahan]], handles a wider range of
+  cases (adding in numbers larger than the current running sum, for example) and
+  should be preferred."
+  ([] [0.0 0.0])
+  ([acc] (reduce + acc))
+  ([[acc c] x]
+   (let [acc+x (+ acc x)
+         delta (if (>= (Math/abs ^double acc)
+                       (Math/abs ^double x))
+                 ;; If sum is bigger, low-order digits of `x` are lost.
+                 (+ (- acc acc+x) x)
+
+                 ;; else, low-order digits of `sum` are lost.
+                 (+ (- x acc+x) acc))]
+     [acc+x (+ c delta)])))
+
+(def ^{:doc "Alias for [[kahan-babushka-neumaier]]."}
+  kbn
+  kahan-babushka-neumaier)
+
+;; The [wiki
+;; page](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements)
+;; mentions a "higher-order modification" of [[kahan-babushka-neumaier]], and I
+;; couldn't help implementing the second-order version here:
+
+(defn kahan-babushka-klein
+  "Implements a fold that tracks the summation of a sequence of floating point
+  numbers, using a second-order variation of [[kahan-babushka-neumaier]].
+
+  See [this Wikipedia
+  page](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements)
+  for more information.
+
+  This algorithm was proposed by Klein in ['A Generalized Kahan-Babushka
+  Summation
+  Algorithm'](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.582.288&rep=rep1&type=pdf),
+  along with the higher-order versions implemented by [[kbk-n]]."
+  ([] [0.0 0.0 0.0])
+  ([acc] (reduce + acc))
+  ([[acc cs ccs] x]
+   (let [acc+x (+ acc x)
+         delta (if (>= (Math/abs ^double acc)
+                       (Math/abs ^double x))
+                 (+ (- acc acc+x) x)
+                 (+ (- x acc+x) acc))
+         cs+delta (+ cs delta)
+         cc (if (>= (Math/abs ^double cs)
+                    (Math/abs ^double delta))
+              (+ (- cs cs+delta) delta)
+              (+ (- delta cs+delta) cs))]
+     [acc+x cs+delta (+ ccs cc)])))
+
+;; ### Higher-Order Kahan-Babushka-Klein
+
+;; Now, the repetition above in the second-order version was too glaring to
+;; ignore. Clearly it is possible to write efficient code for as high an order
+;; as you'd like, as described in [Klein's
+;; paper](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.582.288&rep=rep1&type=pdf).
+;;
+;; Because this code needs to be very efficient, I chose to implement the
+;; higher-order fold generator using a macro.
+;;
+;; Each new order stacks three entries into the let-binding of the function
+;; above, and adds a new term to the accumulator. Because all of these terms
+;; live inside a single let-binding, we have to be careful with variable names.
+;; It turns out we can get away with
+;;
+;; - one symbol for each term we're accumulating (`sum` and each compensation
+;;   term)
+;;
+;; - a single symbol `delta` that we can reuse for all deltas generated.
+
+(defn- klein-term
+  "Takes symbolic variables for
+
+  - `acc`, the accumulating term we're compensating for
+  - `delta`, the shared symbol used for deltas
+
+  and generates let-binding entries updating `acc` to `(+ acc delta)` and
+  `delta` to the new compensation amount in `(+ acc delta)`."
+  [acc delta]
+  `[sum# (+ ~acc ~delta)
+    ~delta (if (>= (Math/abs ~(with-meta acc {:tag 'double}))
+                   (Math/abs ~(with-meta delta {:tag 'double})))
+             (+ (- ~acc sum#) ~delta)
+             (+ (- ~delta sum#) ~acc))
+    ~acc sum#])
+
+(defn ^:no-doc kbk-n-body
+  "Given some order `n`, generates the function body of a fold implementing `n`-th
+  order Kahan-Babushka-Klein summation.
+
+  See [[kbk-n]] for more detail."
+  [n]
+  (let [syms   (into [] (repeatedly (inc n) gensym))
+        prefix (pop syms)
+        final  (peek syms)
+        delta  (gensym)]
+    `[([] [~@(repeat (inc n) 0.0)])
+      ([accs#] (reduce + accs#))
+      ([~syms ~delta]
+       (let [~@(mapcat #(klein-term % delta) prefix)]
+         [~@prefix (+ ~final ~delta)]))]))
+
+(defmacro kbk-n
+  "Given some order `n`, returns a fold implementing `n`-th order
+  Kahan-Babushka-Klein summation.
+
+  Given `n` == 0, this is identical to a naive sum.
+  Given `n` == 1, identical to [[kahan-babushka-neumaier]].
+  Given `n` == 2, identical to [[kahan-babushka-klein]].
+
+  `n` > 2 represent new compensated summation algorithms."
+  [n]
+  `(fn ~@(kbk-n-body n)))

--- a/src/sicmutils/algebra/fold.cljc
+++ b/src/sicmutils/algebra/fold.cljc
@@ -155,7 +155,7 @@
 (defn count
   "Given some predicate `pred`, returns a fold that counts the number of items it
   encounters that return true when passed to `pred`, false otherwise."
-  ([] (count (fn [] true)))
+  ([] (count (fn [_] true)))
   ([pred]
    (fn ([] 0)
      ([acc] acc)

--- a/src/sicmutils/algebra/fold.cljc
+++ b/src/sicmutils/algebra/fold.cljc
@@ -26,8 +26,11 @@
   floating-point numbers."
   (:refer-clojure :rename {count core-count
                            min core-min
-                           max core-max})
-  (:require [sicmutils.generic :as g]))
+                           max core-max}
+                  #?@(:cljs [:exclude [min max count]]))
+  (:require [sicmutils.generic :as g]
+            [sicmutils.util.def :as ud
+             #?@(:cljs [:include-macros true])]))
 
 ;; ## Folds and Scans
 ;;
@@ -475,8 +478,11 @@
   `delta` to the new compensation amount in `(+ acc delta)`."
   [acc delta]
   `[sum# (+ ~acc ~delta)
-    ~delta (if (>= (Math/abs ~(with-meta acc {:tag 'double}))
-                   (Math/abs ~(with-meta delta {:tag 'double})))
+    ~delta (if (ud/fork
+                :clj (>= (Math/abs ~(with-meta acc {:tag 'double}))
+                         (Math/abs ~(with-meta delta {:tag 'double})))
+                :cljs (>= (.abs js/Math ~acc)
+                          (.abs js/Math ~delta)))
              (+ (- ~acc sum#) ~delta)
              (+ (- ~delta sum#) ~acc))
     ~acc sum#])

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -52,8 +52,8 @@
 ;; disappear.
 (def ^{:doc "A [[Complex]] value equal to `-i`."}
   -I
-  #?(:clj (.negate ^Complex I)
-     :cljs (.neg ^Complex I)))
+  #?(:clj (.negate Complex/I)
+     :cljs (.neg ^js (obj/get Complex "I"))))
 
 (def ^:no-doc complextype Complex)
 

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -47,6 +47,7 @@
   (:require #?(:clj [potemkin :refer [import-def import-vars]])
             [sicmutils.abstract.function :as af #?@(:cljs [:include-macros true])]
             [sicmutils.abstract.number :as an]
+            [sicmutils.algebra.fold]
             [sicmutils.complex]
             [sicmutils.expression :as x]
             [sicmutils.expression.render :as render]

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -128,6 +128,7 @@
    'sicmutils.sr.boost                       (ns-publics 'sicmutils.sr.boost)
    'sicmutils.sr.frames                      (ns-publics 'sicmutils.sr.frames)
    'sicmutils.util.aggregate                 (ns-publics 'sicmutils.util.aggregate)
+   'sicmutils.util.def                       (ns-publics 'sicmutils.util.def)
    'sicmutils.util.logic                     (ns-publics 'sicmutils.util.logic)
    'sicmutils.util.stream                    (ns-publics 'sicmutils.util.stream)})
 
@@ -145,7 +146,13 @@
   bindings) required to evaluate SICMUtils forms from inside of an SCI
   context. Pass these to `sci/init` to generate an sci context."}
   context-opts
-  {:namespaces namespaces})
+  {:namespaces namespaces
+
+   ;; NOTE that these entries are required if you'd like to call the
+   ;; `sicmutils.algebra.fold/kbk-n` macro, which generates code using
+   ;; `Math/abs`. JVM and js forms are shown.
+   :classes #?(:clj  {'java.lang.Math java.lang.Math}
+               :cljs {'js goog/global :allow :all})})
 
 (def ^{:doc "sci context (currently only `:namespace` bindings) required to
   evaluate SICMUtils forms via SCI"}

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -127,6 +127,7 @@
    'sicmutils.sr.boost                       (ns-publics 'sicmutils.sr.boost)
    'sicmutils.sr.frames                      (ns-publics 'sicmutils.sr.frames)
    'sicmutils.util.aggregate                 (ns-publics 'sicmutils.util.aggregate)
+   'sicmutils.util.fold                      (ns-publics 'sicmutils.util.fold)
    'sicmutils.util.logic                     (ns-publics 'sicmutils.util.logic)
    'sicmutils.util.stream                    (ns-publics 'sicmutils.util.stream)})
 

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -67,6 +67,7 @@
    'pattern.match                            (ns-publics 'pattern.match)
    'pattern.rule                             (ns-publics 'pattern.rule)
    'pattern.syntax                           (ns-publics 'pattern.syntax)
+   'sicmutils.algebra.fold                   (ns-publics 'sicmutils.algebra.fold)
    'sicmutils.complex                        (ns-publics 'sicmutils.complex)
    'sicmutils.differential                   (ns-publics 'sicmutils.differential)
    'sicmutils.env                            (ns-publics 'sicmutils.env)
@@ -127,7 +128,6 @@
    'sicmutils.sr.boost                       (ns-publics 'sicmutils.sr.boost)
    'sicmutils.sr.frames                      (ns-publics 'sicmutils.sr.frames)
    'sicmutils.util.aggregate                 (ns-publics 'sicmutils.util.aggregate)
-   'sicmutils.util.fold                      (ns-publics 'sicmutils.util.fold)
    'sicmutils.util.logic                     (ns-publics 'sicmutils.util.logic)
    'sicmutils.util.stream                    (ns-publics 'sicmutils.util.stream)})
 

--- a/src/sicmutils/env/sci/macros.cljc
+++ b/src/sicmutils/env/sci/macros.cljc
@@ -24,7 +24,7 @@
             [pattern.rule :as r]
             [pattern.syntax :as ps]
             [sicmutils.abstract.function :as af]
-            [sicmutils.algebra.fold :as af]
+            [sicmutils.algebra.fold :as fold]
             [sicmutils.calculus.coordinate :as cc]
             [sicmutils.calculus.manifold :as m]
             [sicmutils.calculus.vector-field :as vf]
@@ -78,7 +78,7 @@
 (defn kbk-n
   "Originally defined in `sicmutils.algebra.fold`."
   [_ _ n]
-  `(fn ~@(af/kbk-n-body n)))
+  `(fn ~@(fold/kbk-n-body n)))
 
 ;; ## SICMUtils Macros
 

--- a/src/sicmutils/env/sci/macros.cljc
+++ b/src/sicmutils/env/sci/macros.cljc
@@ -80,6 +80,15 @@
   [_ _ n]
   `(fn ~@(fold/kbk-n-body n)))
 
+(defn fork
+  "Originally defined in `sicmutils.util.def`."
+  [_ _&env & {:keys [cljs clj]}]
+  (if (contains? _&env '&env)
+    `(if (:ns ~'&env) ~cljs ~clj)
+    (if #?(:clj (:ns _&env) :cljs true)
+      cljs
+      clj)))
+
 ;; ## SICMUtils Macros
 
 (defn literal-function
@@ -173,7 +182,8 @@
    'with-literal-functions (tag-as-macro with-literal-functions)
    'let-coordinates        (tag-as-macro let-coordinates)
    'using-coordinates      (tag-as-macro using-coordinates)
-   'define-coordinates     (tag-as-macro define-coordinates)})
+   'define-coordinates     (tag-as-macro define-coordinates)
+   'fork                   (tag-as-macro fork)})
 
 (def pattern-macros
   {'pattern     (tag-as-macro pattern)
@@ -195,4 +205,7 @@
 
    'sicmutils.calculus.coordinate
    (select-keys all ['let-coordinates 'using-coordinates
-                     'define-coordinates])})
+                     'define-coordinates])
+
+   'sicmutils.util.def
+   (select-keys all ['fork])})

--- a/src/sicmutils/env/sci/macros.cljc
+++ b/src/sicmutils/env/sci/macros.cljc
@@ -24,6 +24,7 @@
             [pattern.rule :as r]
             [pattern.syntax :as ps]
             [sicmutils.abstract.function :as af]
+            [sicmutils.algebra.fold :as af]
             [sicmutils.calculus.coordinate :as cc]
             [sicmutils.calculus.manifold :as m]
             [sicmutils.calculus.vector-field :as vf]
@@ -71,6 +72,13 @@
   (let [inputs (partition 3 patterns-and-consequences)
         rules  (map #(apply r/compile-rule %) inputs)]
     `(r/ruleset* ~@rules)))
+
+;; ## Fold Macros
+
+(defn kbk-n
+  "Originally defined in `sicmutils.algebra.fold`."
+  [_ _ n]
+  `(fn ~@(af/kbk-n-body n)))
 
 ;; ## SICMUtils Macros
 
@@ -160,7 +168,8 @@
   (vary-meta f assoc :sci/macro true))
 
 (def all
-  {'literal-function       (tag-as-macro literal-function)
+  {'kbk-n                  (tag-as-macro kbk-n)
+   'literal-function       (tag-as-macro literal-function)
    'with-literal-functions (tag-as-macro with-literal-functions)
    'let-coordinates        (tag-as-macro let-coordinates)
    'using-coordinates      (tag-as-macro using-coordinates)
@@ -180,6 +189,9 @@
 
    'sicmutils.abstract.function
    (select-keys all ['with-literal-functions])
+
+   'sicmutils.algebra.fold
+   (select-keys all ['kbk-n])
 
    'sicmutils.calculus.coordinate
    (select-keys all ['let-coordinates 'using-coordinates

--- a/src/sicmutils/numerical/quadrature/adaptive.cljc
+++ b/src/sicmutils/numerical/quadrature/adaptive.cljc
@@ -140,18 +140,18 @@
                           (closed-integrator f l r opts)
                           (open-integrator f l r opts)))]
         (loop [stack [[a b (:interval opts)]]
-               sum   (ua/kahan-sum)
+               sum   (ua/*fold*)
                iteration 0]
           (if (empty? stack)
             {:converged? true
              :iterations iteration
-             :result (first sum)}
+             :result (ua/*fold* sum)}
             (let [[l r interval] (peek stack)
                   remaining      (pop stack)
                   {:keys [converged? result]} (integrate l r interval)]
               (if converged?
                 (recur remaining
-                       (ua/kahan-sum sum result)
+                       (ua/*fold* sum result)
                        (inc iteration))
                 (let [midpoint (split-point l r (:adaptive-neighborhood-width opts))]
                   (recur (conj remaining

--- a/src/sicmutils/numerical/quadrature/bulirsch_stoer.cljc
+++ b/src/sicmutils/numerical/quadrature/bulirsch_stoer.cljc
@@ -127,8 +127,8 @@
   the `:bs-extrapolator` option."
   [opts]
   (if (= :polynomial (:bs-extrapolator opts))
-    poly/modified-neville
-    rat/modified-bulirsch-stoer))
+    (poly/modified-neville-scan 0)
+    (rat/modified-bulirsch-stoer-scan 0)))
 
 ;; This function exists because we wanted to provide an `open-sequence` and
 ;; `closed-sequence` option below. The logic for both is the same, other than
@@ -157,8 +157,8 @@
            square      (fn [x] (* x x))
            xs          (map square (h-sequence a b n))
            ys          (integrator-seq-fn f a b opts)]
-       (-> (map vector xs ys)
-           (extrapolate 0))))))
+       (extrapolate
+        (map vector xs ys))))))
 
 (def ^{:doc "Returns a (lazy) sequence of successively refined estimates of the
   integral of `f` over the closed interval $[a, b]$ by applying rational

--- a/src/sicmutils/polynomial/gcd.cljc
+++ b/src/sicmutils/polynomial/gcd.cljc
@@ -531,7 +531,7 @@
   If a non-[[p/Polynomial]] is supplied, returns 1."
   [p]
   (if (p/polynomial? p)
-    (transduce (ua/halt-at v/one?)
+    (transduce (halt-when v/one?)
                gcd
                (p/partial-derivatives p))
     1))

--- a/src/sicmutils/polynomial/interpolate.cljc
+++ b/src/sicmutils/polynomial/interpolate.cljc
@@ -22,9 +22,8 @@
   methods for fitting a polynomial of degree `N-1` to `N` points and evaluating
   that polynomial at some different `x`."
   (:require [sicmutils.generic :as g]
-            [sicmutils.util.aggregate :as ua]
-            [sicmutils.util.fold :as uf]
-            [sicmutils.util.stream :as us]))
+            [sicmutils.algebra.fold :as af]
+            [sicmutils.util.aggregate :as ua]))
 
 (defn lagrange
   "Generates a lagrange interpolating polynomial that fits every point in the
@@ -655,11 +654,14 @@
    /
   r
 
+  ;; TODO add present docs
+
   the inputs are of the same form returned by `prepare`. `merge` should return a
   new structure of the same form."
-  [prepare merge]
+  [prepare merge present]
   (fn
     ([] [])
+    ([row] (present row))
     ([prev-row point]
      (reductions merge (prepare point) prev-row))))
 
@@ -676,7 +678,8 @@
   `neville`."
   [x]
   (tableau-fold-fn neville-prepare
-                   (neville-merge x)))
+                   (neville-merge x)
+                   neville-present))
 
 (defn- modified-neville-fold-fn
   "Returns a function that accepts:
@@ -688,7 +691,8 @@
   `modified-neville`."
   [x]
   (tableau-fold-fn mn-prepare
-                   (mn-merge x)))
+                   (mn-merge x)
+                   mn-present))
 
 ;; This final function brings back in the notion of `present`. It returns a
 ;; function that consumes an entire sequence of points, and then passes the
@@ -716,7 +720,7 @@
 ;;
 ;; ## Fold Utilities
 ;;
-;; `uf/fold->scan` will return a function that acts identically to the non-fold,
+;; `af/fold->scan` will return a function that acts identically to the non-fold,
 ;; column-wise version of the interpolators. It does this by folding in one
 ;; point at a time, but processing EVERY intermediate value through the
 ;; presentation function.
@@ -732,8 +736,8 @@
 
   This function uses the [[neville]] algorithm internally."
   [x]
-  (uf/fold->sum-fn (neville-fold-fn x)
-                   neville-present))
+  (af/fold->sum-fn
+   (neville-fold-fn x)))
 
 (defn neville-scan
   "Returns a function that consumes an entire sequence `xs` of points, and returns
@@ -749,8 +753,8 @@
    ...]
   ```"
   [x]
-  (uf/fold->scan-fn (neville-fold-fn x)
-                    neville-present))
+  (af/fold->scan-fn
+   (neville-fold-fn x)))
 
 (defn modified-neville-fold
   "Returns a function that consumes an entire sequence `xs` of points, and returns
@@ -759,8 +763,8 @@
 
   This function uses the [[modified-neville]] algorithm internally."
   [x]
-  (uf/fold->sum-fn (modified-neville-fold-fn x)
-                   ))
+  (af/fold->sum-fn
+   (modified-neville-fold-fn x)))
 
 (defn modified-neville-scan
   "Returns a function that consumes an entire sequence `xs` of points, and returns
@@ -776,8 +780,8 @@
    ...]
   ```"
   [x]
-  (uf/fold->scan-fn (modified-neville-fold-fn x)
-                    mn-present))
+  (af/fold->scan-fn
+   (modified-neville-fold-fn x)))
 
 ;; Next, check out:
 ;;

--- a/src/sicmutils/polynomial/richardson.cljc
+++ b/src/sicmutils/polynomial/richardson.cljc
@@ -348,11 +348,11 @@
 ;; - $P_l(x)$ is the estimate with all points but the first, ie, $P_{bc}(x)$
 ;; - $P_l(x)$ is the estimate with all points but the LAST, ie, $P_{ab}(x)$
 ;;
-;; Fill in $x = 0 and rearrange$:
+;; Fill in $x = 0$ and rearrange:
 ;;
 ;; $$P(0) = [(x_l P_r(0)) - (x_r P_l(x))] \over [x_l - x_r]$$
 ;;
-;; In the richardson extrapolation scheme, one of our parameters was `t`, the
+;; In the Richardson extrapolation scheme, one of our parameters was `t`, the
 ;; ratio between successive elements in the sequence. Now multiply through by $1
 ;; = {1 \over x_r} \over {1 \over x_r}$ so that our formula contains ratios:
 ;;
@@ -363,7 +363,8 @@
 ;;
 ;; $${x_l \over x_r} = {x \over {x \over t^n}} = t^n$$
 ;;
-;; Where $n$ is the difference between the positions of $x_l$ and $x_r$. So the formula simplifies further to:
+;; Where $n$ is the difference between the positions of $x_l$ and $x_r$. So the
+;; formula simplifies further to:
 ;;
 ;; $$P(0) = [({t^n} P_r(0)) - P_l(x)] \over [{t^n} - 1]$$
 ;;

--- a/src/sicmutils/rational_function/interpolate.cljc
+++ b/src/sicmutils/rational_function/interpolate.cljc
@@ -92,6 +92,21 @@
 ;; We can be a bit more clever, if we reuse the idea of the "tableau" described
 ;; in the polynomial namespace.
 
+(defn bs-prepare [[x fx]]
+  [x x 0 fx])
+
+(defn bs-merge [x]
+  (fn [[xl _ _ rl] [_ xr rc rr]]
+    (let [p  (- rr rl)
+          q  (-> (/ (- x xl)
+                    (- x xr))
+                 (* (- 1 (/ p (- rr rc))))
+                 (- 1))]
+      [xl xr rl (+ rr (/ p q))])))
+
+(defn- bs-present [row]
+  (map peek row))
+
 (defn bulirsch-stoer
   "Takes
 
@@ -143,17 +158,9 @@
     - Press's Numerical Recipes (p105), [Section 3.2](http://phys.uri.edu/nigh/NumRec/bookfpdf/f3-2.pdf)"
   ([points x] (bulirsch-stoer points x nil))
   ([points x column]
-   (let [prepare (fn [[x fx]] [x x 0 fx])
-         merge   (fn [[xl _ _ rl] [_ xr rc rr]]
-                   (let [p  (- rr rl)
-                         q  (-> (/ (- x xl)
-                                   (- x xr))
-                                (* (- 1 (/ p (- rr rc))))
-                                (- 1))]
-                     [xl xr rl (+ rr (/ p q))]))
-         present (fn [row] (map (fn [[_ _ _ r]] r) row))
-         tableau (pi/tableau-fn prepare merge points)]
-     (present
+   (let [merge   (bs-merge x)
+         tableau (pi/tableau-fn bs-prepare merge points)]
+     (bs-present
       (if column
         (nth tableau column)
         (pi/first-terms tableau))))))
@@ -166,7 +173,7 @@
 ;; the left and left-up entries in the tableau, just like the modified Neville
 ;; method in `polynomial.cljc`. the algorithm is implemented below.
 
-(defn- bs-prepare
+(defn- mbs-prepare
   "Processes an initial point `[x (f x)]` into the required state:
 
   ```
@@ -176,7 +183,7 @@
   The recursion starts with $C = D = f(x)$."
   [[x fx]] [x x fx fx])
 
-(defn- bs-merge
+(defn- mbs-merge
   "Implements the recursion rules described in Press's Numerical Recipes, [section
   3.2](http://phys.uri.edu/nigh/NumRec/bookfpdf/f3-2.pdf) to generate x_l, x_r,
   C and D for a tableau node, given the usual left and left-up tableau entries.
@@ -220,14 +227,37 @@
   [points x]
   (pi/mn-present
    (pi/first-terms
-    (pi/tableau-fn bs-prepare
-                   (bs-merge x)
+    (pi/tableau-fn mbs-prepare
+                   (mbs-merge x)
                    points))))
 
 ;; ## Rational Interpolation as a Fold
 ;;
 ;; Just like in `polynomial.cljc`, we can write rational interpolation in the
 ;; style of a functional fold:
+
+(defn bulirsch-stoer-fold
+  "Given some point `x`, returns a fold that accumulates rows of a rational
+  function interpolation tableau providing successively better estimates (at the
+  value `x`) of a rational function interpolated to all seen points.
+
+  The 2-arity aggregation step takes:
+
+  - `previous-row`: previous row of an interpolation tableau
+  - a new point of the form `[x_new (f x_new)]`
+
+  Returns a function that accepts:
+
+  - `previous-row`: previous row of an interpolation tableau
+  - a new point of the form `[x (f x)]`
+
+  and returns the next row of the tableau using the algorithm described in
+  [[bulirsch-stoer]]."
+  [x]
+  (pi/tableau-fold-fn bs-prepare
+                      (bs-merge x)
+                      (fn [row]
+                        (peek (last row)))))
 
 (defn modified-bulirsch-stoer-fold
   "Given some point `x`, returns a fold that accumulates rows of a rational
@@ -247,9 +277,32 @@
   and returns the next row of the tableau using the algorithm described in
   [[modified-bulirsch-stoer]]."
   [x]
-  (pi/tableau-fold-fn bs-prepare
-                      (bs-merge x)
+  (pi/tableau-fold-fn mbs-prepare
+                      (mbs-merge x)
                       pi/mn-present-final))
+
+(defn bulirsch-stoer-sum
+  "Returns a function that consumes an entire sequence `xs` of points of the form
+  `[x_i, f(x_i)]` and returns the best approximation of `x` using a rational
+  function fitted to all points in `xs` using the algorithm described
+  in [[modified-bulirsch-stoer]].
+
+  Faster than, but equivalent to, `(last ([[bulirsch-stoer]] xs x))`"
+  [x]
+  (af/fold->sum-fn
+   (bulirsch-stoer-fold x)))
+
+(defn bulirsch-stoer-scan
+  "Returns a function that consumes an entire sequence `xs` of points of the form
+  `[x_i, f(x_i)]` and returns a lazy sequence of successive approximations of
+  `x` using rational functions fitted to the first point, then the first and
+  second points, etc. using the algorithm described
+  in [[modified-bulirsch-stoer]].
+
+  Equivalent to `([[bulirsch-stoer]] xs x)`."
+  [x]
+  (af/fold->scan-fn
+   (bulirsch-stoer-fold x)))
 
 (defn modified-bulirsch-stoer-sum
   "Returns a function that consumes an entire sequence `xs` of points of the form

--- a/src/sicmutils/rational_function/interpolate.cljc
+++ b/src/sicmutils/rational_function/interpolate.cljc
@@ -23,7 +23,7 @@
   them at some value `x`."
   (:require [sicmutils.generic :as g]
             [sicmutils.polynomial.interpolate :as pi]
-            [sicmutils.util.aggregate :as ua]
+            [sicmutils.util.fold :as uf]
             [sicmutils.util.stream :as us]
             [taoensso.timbre :as log]))
 
@@ -248,7 +248,7 @@
   a sequence of successive approximations of `x` using rational functions fitted
   to the points in reverse order."
   [x]
-  (ua/fold->sum-fn
+  (uf/fold->sum-fn
    (modified-bulirsch-stoer-fold-fn x)
    pi/mn-present))
 
@@ -266,6 +266,6 @@
    ...]
   ```"
   [x]
-  (ua/fold->scan-fn
+  (uf/fold->scan-fn
    (modified-bulirsch-stoer-fold-fn x)
    pi/mn-present))

--- a/src/sicmutils/rational_function/interpolate.cljc
+++ b/src/sicmutils/rational_function/interpolate.cljc
@@ -248,7 +248,7 @@
   a sequence of successive approximations of `x` using rational functions fitted
   to the points in reverse order."
   [x]
-  (pi/tableau-fold
+  (ua/fold->sum-fn
    (modified-bulirsch-stoer-fold-fn x)
    pi/mn-present))
 
@@ -266,6 +266,6 @@
    ...]
   ```"
   [x]
-  (pi/tableau-scan
+  (ua/fold->scan-fn
    (modified-bulirsch-stoer-fold-fn x)
    pi/mn-present))

--- a/src/sicmutils/rational_function/interpolate.cljc
+++ b/src/sicmutils/rational_function/interpolate.cljc
@@ -22,9 +22,8 @@
   different methods for fitting rational functions to `N` points and evaluating
   them at some value `x`."
   (:require [sicmutils.generic :as g]
+            [sicmutils.algebra.fold :as af]
             [sicmutils.polynomial.interpolate :as pi]
-            [sicmutils.util.fold :as uf]
-            [sicmutils.util.stream :as us]
             [taoensso.timbre :as log]))
 
 ;; ## Rational Function Interpolation
@@ -239,18 +238,17 @@
   and returns the next row of the tableau using the algorithm described in
   [[modified-bulirsch-stoer]]."
   [x]
-  (pi/tableau-fold-fn
-   bs-prepare
-   (bs-merge x)))
+  (pi/tableau-fold-fn bs-prepare
+                      (bs-merge x)
+                      pi/mn-present))
 
 (defn modified-bulirsch-stoer-fold
   "Returns a function that consumes an entire sequence `xs` of points, and returns
   a sequence of successive approximations of `x` using rational functions fitted
   to the points in reverse order."
   [x]
-  (uf/fold->sum-fn
-   (modified-bulirsch-stoer-fold-fn x)
-   pi/mn-present))
+  (af/fold->sum-fn
+   (modified-bulirsch-stoer-fold-fn x)))
 
 (defn modified-bulirsch-stoer-scan
   "Returns a function that consumes an entire sequence `xs` of points, and returns
@@ -266,6 +264,5 @@
    ...]
   ```"
   [x]
-  (uf/fold->scan-fn
-   (modified-bulirsch-stoer-fold-fn x)
-   pi/mn-present))
+  (af/fold->scan-fn
+   (modified-bulirsch-stoer-fold-fn x)))

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -135,7 +135,8 @@
 ;; summation.
 
 (def ^{:dynamic true
-       :doc "Dynamically bindable value "}
+       :doc "Dynamically bindable size below which [[pairwise-sum]] will defer
+  to [[sum]] to aggregate values."}
   *cutoff*
   128)
 

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -114,8 +114,6 @@
   [l r]
   (reduce *fold* l r))
 
-(def ^:dynamic *monoid* kbn-add)
-
 ;; ## Note that this is a pattern...
 
 ;; reference from wiki pointed here:
@@ -186,7 +184,8 @@
 
 ;; TODO https://hackage.haskell.org/package/math-functions-0.3.4.2/docs/src/Numeric.Sum.html#pairwiseSum
 
-(def ^:dynamic *cutoff* 256)
+;; matches Julia's
+(def ^:dynamic *cutoff* 128)
 
 ;; from that haskell code:
 
@@ -202,8 +201,11 @@
 ;; add notes from wiki about pairwise sum error bounds.
 
 (defn pairwise-sum
+  "https://en.wikipedia.org/wiki/Pairwise_summation
+
+  this works because we are not adding a progressively bigger sum to deltas, but
+  adding numbers of same size."
   ([xs]
-   {:pre [(vector? xs)]}
    (letfn [(f [v]
              (let [n (count v)]
                (if (<= n *cutoff*)
@@ -213,7 +215,9 @@
                        r (subvec v split-idx)]
                    (+ (f l)
                       (f r))))))]
-     (f xs)))
+     (f (if (vector? xs)
+          xs
+          (into [] xs)))))
   ([f low high]
    (pairwise-sum
     (mapv f (range low high)))))

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -18,109 +18,9 @@
 ;;
 
 (ns sicmutils.util.aggregate
-  "Namespace with algorithms for aggregating sequences in various ways.
-
-  Contains a number of algorithms for [compensated
-  summation](https://en.wikipedia.org/wiki/Kahan_summation_algorithm) of
-  floating-point numbers."
-  (:require [sicmutils.generic :as g]))
-
-;; ## Summing Sequences of Numbers
-;;
-;; This is a fascinating topic, and my explorations have not yet done it
-;; justice. This namespace starts with a number of functions designed to sum up
-;; sequences of numbers in an extensible way.
-;;
-;; Much of the numerical physics simulation code in the library (everything
-;; in [[sicmutils.numerical.quadrature]]) depends on the ability to sum up lists
-;; of floating point numbers without the accumulation of error due to the
-;; machine representation of the number.
-;;
-;; Here is the naive way to add up a list of numbers:
-
-#_
-(defn naive-sum [xs]
-  (apply g/+ xs))
-
-;; Simple! But watch it break:
-
-(comment
-  ;; This should be 1.0...
-  (= 0.9999999999999999
-     (naive-sum [1.0 1e-8 -1e-8])))
-
-;; Algorithms called ['compensated
-;; summation'](https://en.wikipedia.org/wiki/Kahan_summation_algorithm)
-;; algorithms are the way around this problem. Instead of simply accumulating
-;; the numbers as they come, compensated summation keeps track of the piece of
-;; the sum that would get erased from the sum due to lack of precision.
-;;
-;; Because there are a few ways to do this, I chose to make the implementation
-;; pluggable by following the `Aggregator` pattern
-;; from [Algebird](https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/Aggregator.scala),
-;;
-;; In sicmutils I've decided to call this abstraction a "fold". I am here
-;;
-;; A fold is a combination of:
-;;
-;; - some initial value into which you want to aggregate
-;; - a combining function of (accumulator, x) => accumulator
-;; - a "present" function that converts the accumulator into a final value
-;;
-;; TODO continue from here... TODO this IS a fold in Algebird, not aggregator!
-;;
-;; TODO also note that I did the same thing for polynomial and rational function
-;; interpolation, same style!! And rewrite those namespaces to use the same
-;; thing? Benchmark?
-
-;; I learned about "Kahan's summation trick" from `rational.scm` in the
-;; `scmutils` package, where it shows up in the `sigma` function.
-
-(defn naive-fold
-  ([] 0.0)
-  ([x] x)
-  ([acc x]
-   (+ acc x)))
-
-;; TODO note that any monoid works!
-;;
-;; TODO
-;;
-;; - make a thing that can generate these.
-;; - Dynamically bind it with nice metadata
-;; - see if we can make
-;;
-;; TODO move these down after.
-
-(defn fold->sum-fn
-  ([fold]
-   (fold->sum-fn fold fold fold))
-  ([fold present]
-   (fold->sum-fn fold fold present))
-  ([init fold present]
-   (fn ([xs]
-       (present
-        (reduce fold (init) xs)))
-     ([f low high]
-      (let [xs (range low high)]
-        (transduce (map f) fold xs))))))
-
-;; TODO is this good? check arities...
-
-(defn fold->scan-fn
-  ([fold]
-   (fold->scan-fn fold fold fold))
-  ([fold present]
-   (fold->scan-fn fold fold present))
-  ([init fold present]
-   (fn scan
-     ([xs]
-      (->> (reductions fold (init) xs)
-           (map present)
-           (rest)))
-     ([f low high]
-      (scan
-       (map f (range low high)))))))
+  "Namespace with algorithms for aggregating sequences in various ways."
+  (:require [sicmutils.generic :as g]
+            [sicmutils.algebra.fold :as af]))
 
 (def ^{:doc "Sums either:
 
@@ -130,128 +30,56 @@
   Using the generic [[sicmutils.generic/+]] function."
        :arglists '([xs], [f low high])}
   generic-sum
-  (fold->sum-fn g/+))
+  (af/fold->sum-fn g/+))
 
-;; ## Compensated Summation Folds
+;; ## Dynamically Bindable Summation
+;;
+;; The following functions allow for fold-agnostic summation. If a user
+;; calls [[sum]] or [[scan]] in some function, they can later tune the way
+;; summations happen deep in their code by binding [[*fold*]].
+;;
+;; For summation functions with explicit folds baked in,
+;; see [[sicmutils.algebra.fold/fold->sum-fn]]
+;; and [[sicmutils.algebra.fold/fold->scan-fn]].
 
-(defn kahan-fold
-  "Implements a fold that tracks the summation of a sequence of floating point
-  numbers, using Kahan's trick for maintaining stability in the face of
-  accumulating floating point errors.
+(def
+  ^{:dynamic true
+    :doc "Fold used to aggregate values encountered by [[sum]] or [[fold]].
 
-  - the 0-arity returns an initial accumulator
-  - the 1-arity version takes an accumulator and returns a final value
-  - the 2-arity version takes an accumulator and a new value and folds the value
-    into the accumulator, returning a new accumulator.
+  Rebind this value to change the behavior of [[sum]] or [[fold]].
 
-  Because of this implementation, [[kahan-fold]] is suitable for use
-  with [[clojure.core/transduce]]."
-  ([] [0.0 0.0])
-  ([[acc _]] acc)
-  ([[acc c] x]
-   (let [y (- x c)
-         t (+ acc y)]
-     [t (- (- t acc) y)])))
-
-(defn kahan-babushka-neumaier-fold
-  "Implements a fold that tracks the summation of a sequence of floating point
-  numbers, using TODO update docs!!
-
-  - the 0-arity returns an initial accumulator
-  - the 1-arity version takes an accumulator and returns a final value
-  - the 2-arity version takes an accumulator and a new value and folds the value
-    into the accumulator, returning a new accumulator.
-
-  Because of this implementation, [[kbn-fold]] is suitable for use
-  with [[clojure.core/transduce]]."
-  ([] [0.0 0.0])
-  ([acc] (reduce + acc))
-  ([[acc c] x]
-   (let [acc+x (+ acc x)
-         delta (if (>= (Math/abs ^double acc)
-                       (Math/abs ^double x))
-                 ;; If sum is bigger, low-order digits of `x` are lost.
-                 (+ (- acc acc+x) x)
-
-                 ;; else, low-order digits of `sum` are lost.
-                 (+ (- x acc+x) acc))]
-     [acc+x (+ c delta)])))
-
-(def ^{:doc "Shorter alias for [[kahan-babushka-neumaier-fold]]."}
-  kbn-fold
-  kahan-babushka-neumaier-fold)
-
-(defn kahan-babushka-klein-fold
-  "Klein: https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements"
-  ([] [0.0 0.0 0.0])
-  ([acc] (reduce + acc))
-  ([[acc cs ccs] x]
-   (let [acc+x (+ acc x)
-         ;; called `c` in the algo...
-         delta (if (>= (Math/abs ^double acc)
-                       (Math/abs ^double x))
-                 (+ (- acc acc+x) x)
-                 (+ (- x acc+x) acc))
-         cs+delta (+ cs delta)
-         cc (if (>= (Math/abs ^double cs)
-                    (Math/abs ^double delta))
-              (+ (- cs cs+delta) delta)
-              (+ (- delta cs+delta) cs))]
-     [acc+x cs+delta (+ ccs cc)])))
-
-;; ## Note that this is a pattern...
-
-;; reference from wiki pointed here:
-;; https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.582.288&rep=rep1&type=pdf
-
-;; ### Macro Version, turbo
-
-(defn- klein-term [acc delta]
-  `[sum# (+ ~acc ~delta)
-    ~delta (if (>= (Math/abs ~(with-meta acc {:tag 'double}))
-                   (Math/abs ~(with-meta delta {:tag 'double})))
-             (+ (- ~acc sum#) ~delta)
-             (+ (- ~delta sum#) ~acc))
-    ~acc sum#])
-
-(defn- kbk-foldn-body
-  "Split out from the macro so we can use it to build SCI macros."
-  [n]
-  (let [syms   (into [] (repeatedly (inc n) gensym))
-        prefix (pop syms)
-        final  (peek syms)
-        delta  (gensym)]
-    `[([] [~@(repeat (inc n) 0.0)])
-      ([accs#] (reduce + accs#))
-      ([~syms ~delta]
-       (let [~@(mapcat #(klein-term % delta) prefix)]
-         [~@prefix (+ ~final ~delta)]))]))
-
-;; TODO docs, implement in SCI.
-
-(defmacro kbk-foldn [n]
-  `(fn ~@(kbk-foldn-body n)))
-
-;; ## Dynamically Bindable Summing
-
-(def ^{:dynamic true
-       :doc "boom, defaults to [[kahan-babushka-neumaier-fold]]."}
+  Defaults to [[sicmutils.algebra.fold/kahan-babushka-neumaier-fold]]."}
   *fold*
-  kahan-babushka-neumaier-fold)
+  af/kahan-babushka-neumaier)
+
+;; The following two functions are identical
+;; to [[sicmutils.algebra.fold/fold->sum-fn]]
+;; and [[sicmutils.algebra.fold/fold->scan-fn]] with [[*fold*]] baked in. I did
+;; this for performance reasons; to use those functions and keep [[*fold*]]
+;; dynamically rebindable I would have to pass the var `#'*fold*`.
+;; De-referencing this var has a performance penalty that is not acceptable,
+;; given that [[sum]] and [[scan]] are used in the inner loops of numerical
+;; integration routines.
 
 (defn sum
-  "Sums either:
+  "Takes either:
 
-  - a series `xs` of numbers, or
-  - the result of mapping function `f` to `(range low high)`
+  - a series `xs` of numbers
+  - A transformation function `f`, an inclusive-lower bound `low` and
+    exclusive-upper bound `upper`
 
-  TODO fix, no longer necessarily using Kahan, note that this is using the
-  dynamically bound `*fold*`.
+  And returns the result of aggregating either `xs` or `(map f (range low
+  high))` using the fold dynamically bound to [[*fold*]].
 
-  Using Kahan's summation trick behind the scenes to keep floating point errors
-  under control.
+  Use `binding` to substitute in a different fold:
 
-  TODO update the docs, say that we use whatever is bound to `*fold*`."
+  ```clj
+  (require '[sicmutils.algebra.fold :as af])
+
+  (binding [*fold* (af/join af/kahan af/min af/max)]
+    (sum inc 0 10))
+  ;;=> [55.0 1 10]
+  ```"
   ([xs]
    (*fold*
     (reduce *fold* (*fold*) xs)))
@@ -259,47 +87,103 @@
    (let [xs (range low high)]
      (transduce (map f) *fold* xs))))
 
-(defn scanning-sum
-  "Returns every intermediate summation from summing either:
+(defn scan
+  "Takes either:
 
-  - a series `xs` of numbers, or
-  - the result of mapping function `f` to `(range low high)`
+  - a series `xs` of numbers
+  - A transformation function `f`, an inclusive-lower bound `low` and
+    exclusive-upper bound `upper`
 
-  Using Kahan's summation trick behind the scenes to keep floating point errors
-  under control."
+  And returns a lazy sequence of all intermediate values seen while aggregating
+  either `xs` or `(map f (range low high))` using the fold dynamically bound
+  to [[*fold*]].
+
+  Use `binding` to substitute in a different fold:
+
+  ```clj
+  (require '[sicmutils.algebra.fold :as af])
+
+  (binding [*fold* (af/join af/kahan af/min af/max)]
+    (scan inc 0 3))
+  ;;=> ([1.0 1 1] [3.0 1 2] [6.0 1 3])
+  ```"
   ([xs]
    (->> (reductions *fold* (*fold*) xs)
         (map *fold*)
         (rest)))
   ([f low high]
-   (sum
+   (scan
     (map f (range low high)))))
 
 ;; ## Pairwise Summation
+;;
+;; In contrast to [compensated summation
+;; algorithms](https://en.wikipedia.org/wiki/Kahan_summation_algorithm), simply
+;; adding up a vector of numbers recursively in pairs can offer great error
+;; reduction with good performance.
+;;
+;; Adding up numbers from left to right usually means that as the accumulated
+;; sum grows, you are adding the smaller numbers in the sequence into a
+;; progressively larger total.
+;;
+;; By pairwise-adding up numbers recursively, you are more likely to be adding
+;; numbers of similar magnitude together.
+;;
+;; [[*cutoff*]] lets you tune your "leaf size". A value of `1` would send you
+;; all the way down to each single value; the default of 128, taken from Julia's
+;; default, means that when you get to 128 elements or fewer you defer to naive
+;; summation.
 
-;; matches Julia's
-(def ^:dynamic *cutoff* 128)
+(def ^{:dynamic true
+       :doc "Dynamically bindable value "}
+  *cutoff*
+  128)
 
-;; TODO https://hackage.haskell.org/package/math-functions-0.3.4.2/docs/src/Numeric.Sum.html#pairwiseSum
-
-;; from that haskell code:
-
+;; The [[pairwise-sum]] implementation below was inspired by the `pairwiseSum`
+;; implementation in
+;; the [`math-functions`](https://hackage.haskell.org/package/math-functions-0.3.4.2/docs/src/Numeric.Sum.html#pairwiseSum)
+;; Haskell package. Those docs state:
+;;
 ;; -- This approach is perhaps 10% faster than 'KBNSum', but has poorer
 ;; -- bounds on its error growth.  Instead of having roughly constant
 ;; -- error regardless of the size of the input vector, in the worst case
 ;; -- its accumulated error grows with /O(log n)/.
-
-;; TODO add notes that we can combine this idea with the fold idea if someone
-;; can figure out page 7 here
-;; https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.582.288&rep=rep1&type=pdf
 ;;
-;; add notes from wiki about pairwise sum error bounds.
+;; NOTE that it might be interesting to combine [[pairwise-sum]] with the
+;; compensated summation algorithms from [[sicmutils.algebra.fold]]. Page 7 of
+;; this [paper by
+;; Klein](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.582.288&rep=rep1&type=pdf)
+;; seems to describe a way to aggregate the intermediate states of compensated
+;; summation up through the binary addition tree (ie, implement a monoid on the
+;; compensated summation state itself); but I couldn't figure out the indices!
 
 (defn pairwise-sum
-  "https://en.wikipedia.org/wiki/Pairwise_summation
+  "Given a vector of numbers, returns the [pairwise
+  summation](https://en.wikipedia.org/wiki/Pairwise_summation) of the vector
+  generated by arranging the vector into a binary tree and summing leaves
+  together all the way up to the root.
 
-  this works because we are not adding a progressively bigger sum to deltas, but
-  adding numbers of same size."
+  If `xs` is /not/ a vector, [[pairwise-sum]] will realize all elements into a
+  vector before operating.
+
+  If the initial vector, or some recursive slice, reaches a count
+  <= [[*cutoff*]], [[pairwise-sum]] defers to `(reduce + xs)`.
+
+  ### Performance Discussion
+
+  [[pairwise-sum]] is perhaps 10% faster than [[sum]]
+  with [[sicmutils.algebra.fold/kbn]] bound to [[*fold*]], but has poorer bounds
+  on its error growth. Instead of having roughly constant error regardless of
+  the size of the input, in the worst case its accumulated error grows with
+  $O(\log n)$.
+
+  This improvement is due to the fact that [[pairwise-sum]] tends to add up
+  numbers of similar magnitude, instead of adding deltas into a progressively
+  larger sum.
+
+  This implementation was inspired by the `pairwiseSum` implementation in
+  the [`math-functions`](https://hackage.haskell.org/package/math-functions-0.3.4.2/docs/src/Numeric.Sum.html#pairwiseSum)
+  Haskell package. The notes above were adapted from that function's docs."
   ([xs]
    (letfn [(f [v]
              (let [n (count v)]
@@ -318,21 +202,24 @@
     (mapv f (range low high)))))
 
 ;; ## Monoids
+;;
+;; This section implements combinators that use various binary functions to
+;; generate n-arity versions of those functions.
 
 (defn- combiner
-  "If `stop?` is false, returns `f`. Else, returns a binary reducing function that
+"If `stop?` is false, returns `f`. Else, returns a binary reducing function that
   returns a `reduced` value if its left argument returns `true` for `stop?`,
   else aggregates with `f`."
-  [f stop?]
-  (if stop?
-    (fn [l r]
-      (if (stop? l)
-        (reduced l)
-        (f l r)))
-    f))
+[f stop?]
+(if stop?
+  (fn [l r]
+    (if (stop? l)
+      (reduced l)
+      (f l r)))
+  f))
 
 (defn monoid
-  "Accepts a binary (associative) aggregation function `plus` and an identity
+"Accepts a binary (associative) aggregation function `plus` and an identity
   element `id` and returns a multi-arity function that will combine its
   arguments via `plus`. A 0-arity call returns `id`.
 
@@ -362,8 +249,9 @@
   - optionally, an `annihilate?` function that should return true for any `x`
     such that `(plus x <any>) == x`.
 
-  ;; TODO fill in actual docs about how this returns a function that will do
-  subtraction.
+  And returns a function that will SUBTRACT elements. Given `x`, `y`, `z`, for
+  example, the returned function will return `(- x y z)`, implemented as `(minus
+  x (plus y z))`
 
   If the `annihilate?` function is supplied, then if the aggregation produces a
   value that returns `(annihilate? true)` at any point, the reduction will
@@ -378,8 +266,6 @@
        ([x y] (minus x y))
        ([x y & more]
         (minus x (reduce acc y more)))))))
-
-;; ## TODO Describe
 
 (defn merge-fn
   "NOTE that the returned function recurs on increasing indices internally instead

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -80,16 +80,6 @@
 ;; reference from wiki pointed here:
 ;; https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.582.288&rep=rep1&type=pdf
 
-(defn boink [acc x]
-  (let [acc+x (gensym)
-        delta (gensym)]
-    `[[~acc+x (+ ~acc ~x)
-       ~delta (if (>= (Math/abs ^double ~acc)
-                      (Math/abs ^double ~x))
-                (+ (- ~acc ~acc+x) ~x)
-                (+ (- ~x ~acc+x) ~acc))]
-      [acc+x delta]]))
-
 (comment
   ;; Some implementations for tests.
   (defn boink [acc x]
@@ -153,22 +143,7 @@
           (let [[~'acc ~delta] ~(boink* 'acc x)
                 [~'c1 ~delta]  ~(boink* 'c1 delta)
                 ~'c2          (+ ~'c2 ~delta)]
-            [~'acc ~'c1 ~'c2])))))
-
-  (defmacro kahan-babushka-klein-fold-macro
-    "Right now this is hardcoded at 3."
-    [n]
-    (let [syms ['acc 'c1 'c2 'c3] #_(repeatedly (inc n) (gensym))
-          x     (gensym)
-          delta (gensym)]
-      `(fn ([] ~(into [] (repeat (inc n) 0.0)))
-         ([acc#] (reduce + acc#))
-         ([~syms ~x]
-          (let [[~'acc ~delta] ~(boink* 'acc x)
-                [~'c1 ~delta]  ~(boink* 'c1 delta)
-                [~'c2 ~delta]  ~(boink* 'c2 delta)
-                ~'c3          (+ ~'c3 ~delta)]
-            [~'acc ~'c1 ~'c2 ~'c3]))))))
+            [~'acc ~'c1 ~'c2]))))))
 
 (defn kahan-babushka-klein-fold
   "Klein: https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements"

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -175,7 +175,7 @@
   with [[sicmutils.algebra.fold/kbn]] bound to [[*fold*]], but has poorer bounds
   on its error growth. Instead of having roughly constant error regardless of
   the size of the input, in the worst case its accumulated error grows with
-  $O(\log n)$.
+  $O(\\log n)$.
 
   This improvement is due to the fact that [[pairwise-sum]] tends to add up
   numbers of similar magnitude, instead of adding deltas into a progressively

--- a/src/sicmutils/util/stream.cljc
+++ b/src/sicmutils/util/stream.cljc
@@ -71,36 +71,6 @@
                         coll)]
     [(persistent! ts) (persistent! fs)]))
 
-(defn scan
-  "Returns a function that accepts a sequence `xs`, and performs a scan by:
-
-  - Aggregating each element of `xs` into
-  - the initial value `init`
-  - transforming each intermediate result by `present` (defaults to `identity`).
-
-  The returned sequence contains every intermediate result, after passing it
-  through `present` (not `init`, though).
-
-  This is what distinguishes a scan from a 'fold'; a fold would return the final
-  result. A fold isn't appropriate for aggregating infinite sequences, while a
-  scan works great.
-
-  Arities:
-
-  - the three-arity version takes `init` value, `f` fold function and `present`.
-  - the two arity version drops `init`, and instead calls `f` with no arguments.
-  The return value is the initial aggregator.
-  - The 1-arity version only takes the `merge` fn and defaults `present` to
-  `identity`.
-    "
-  [f & {:keys [present init]
-        :or {present identity}}]
-  (let [init (or init (f))]
-    (fn [xs]
-      (->> (reductions f init xs)
-           (map present)
-           (rest)))))
-
 ;; ## Convergence Tests
 ;;
 ;; This convergence tester comes from Gerald Sussman's "Abstraction in Numerical

--- a/test/sicmutils/algebra/fold_test.cljc
+++ b/test/sicmutils/algebra/fold_test.cljc
@@ -24,7 +24,8 @@
              #?@(:cljs [:include-macros true])]
             [same :refer [ish?]]
             [sicmutils.numbers]
-            [sicmutils.algebra.fold :as af]))
+            [sicmutils.algebra.fold :as af
+             #?@(:cljs [:include-macros true])]))
 
 (deftest fold-tests
   (is (= 45 (af/generic-sum-fold

--- a/test/sicmutils/algebra/fold_test.cljc
+++ b/test/sicmutils/algebra/fold_test.cljc
@@ -67,9 +67,10 @@
 
   (testing "join and primitive tests"
     (let [fold (af/join af/generic-sum-fold
+                        (af/count)
                         (af/count even?))
           sum (af/fold->sum-fn fold)]
-      (is (= [45 5] (sum (range 10)))
+      (is (= [45 10 5] (sum (range 10)))
           "total sum and the number of even elements."))
 
     (checking "join with no args returns empty vector" 100

--- a/test/sicmutils/algebra/fold_test.cljc
+++ b/test/sicmutils/algebra/fold_test.cljc
@@ -26,100 +26,100 @@
             [sicmutils.numbers]
             [sicmutils.algebra.fold :as af]))
 
-(deftest sum-tests
-  (testing "Naive summation"
-    (binding [ua/*fold* ua/naive-fold]
-      (is (not= 1 (ua/sum [1.0 1e-8 -1e-8]))
-          "Without the summation trick, errors build up.")))
+#_(deftest sum-tests
+    (testing "Naive summation"
+      (binding [ua/*fold* ua/naive-fold]
+        (is (not= 1 (ua/sum [1.0 1e-8 -1e-8]))
+            "Without the summation trick, errors build up.")))
 
-  (testing "Kahan summation"
-    (binding [ua/*fold* ua/kahan-fold]
-      (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
-          "Kahan's summation trick allows us to keep precision.")
-
-      (let [xs [1.0 1e-8 -1e-8]]
-        (is (= [1.0 1.00000001 1.0] (ua/scanning-sum xs)))
-
-        (is (= (ua/scanning-sum xs)
-               ((us/scan ua/kahan-fold :present ua/kahan-fold) xs))
-            "scanning-sum acts just like an actual `scan` call."))))
-
-  (testing "KBN Summation"
-    (binding [ua/*fold* ua/kbn-fold]
-      (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
-          "KBN's summation trick also allows us to keep precision.")
-
-      (let [xs [1.0 1e-8 -1e-8]]
-        (is (= [1.0 1.00000001 1.0] (ua/scanning-sum xs)))
-
-        (is (= (ua/scanning-sum xs)
-               ((us/scan ua/kbn-fold :present ua/kbn-fold) xs))
-            "scanning-sum acts just like an actual `scan` call."))))
-
-  (testing "kbn vs kahan"
-    ;; This example of a difference in behavior comes from
-    ;; https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements.
-    (let [xs [1.0 10.0E100 1.0 -10E100]]
+    (testing "Kahan summation"
       (binding [ua/*fold* ua/kahan-fold]
-        (is (= 0.0 (ua/sum xs))
-            "kahan-fold gets it wrong!"))
+        (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
+            "Kahan's summation trick allows us to keep precision.")
 
+        (let [xs [1.0 1e-8 -1e-8]]
+          (is (= [1.0 1.00000001 1.0] (ua/scanning-sum xs)))
+
+          (is (= (ua/scanning-sum xs)
+                 ((us/scan ua/kahan-fold :present ua/kahan-fold) xs))
+              "scanning-sum acts just like an actual `scan` call."))))
+
+    (testing "KBN Summation"
       (binding [ua/*fold* ua/kbn-fold]
-        (is (= 2.0 (ua/sum xs))
-            "kbn-fold gets the correct answer."))))
+        (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
+            "KBN's summation trick also allows us to keep precision.")
 
-  (testing "investigation from scmutils"
-    ;; When adding up 1/n large-to-small we get a different answer than when
-    ;; adding them up small-to-large, which is more accurate.
-    (let [n 10000000
-          z->n (into [] (range n))
-          n->z (reverse z->n)
-          f #(/ 1.0 (inc %))
-          sum-inverse (fn [xs]
-                        (binding [ua/*fold* ua/naive-fold]
-                          (ua/sum (map f xs))))
-          large->small (sum-inverse z->n)
-          small->large (sum-inverse n->z)]
-      (is (= 16.695311365857272
-             large->small)
-          "Naive summation ")
+        (let [xs [1.0 1e-8 -1e-8]]
+          (is (= [1.0 1.00000001 1.0] (ua/scanning-sum xs)))
 
-      (is (= 16.695311365859965
-             small->large)
-          "second example...")
+          (is (= (ua/scanning-sum xs)
+                 ((us/scan ua/kbn-fold :present ua/kbn-fold) xs))
+              "scanning-sum acts just like an actual `scan` call."))))
 
-      (is (= 2.6929569685307797e-12
-             (- small->large large->small))
-          "error!")
+    (testing "kbn vs kahan"
+      ;; This example of a difference in behavior comes from
+      ;; https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements.
+      (let [xs [1.0 10.0E100 1.0 -10E100]]
+        (binding [ua/*fold* ua/kahan-fold]
+          (is (= 0.0 (ua/sum xs))
+              "kahan-fold gets it wrong!"))
 
-      (binding [ua/*fold* ua/kahan-fold]
-        (is (= 1.1368683772161603e-13
-               (- small->large
-                  (ua/sum f 0 n)))
-            "From GJS: Kahan's compensated summation formula is much better, but
+        (binding [ua/*fold* ua/kbn-fold]
+          (is (= 2.0 (ua/sum xs))
+              "kbn-fold gets the correct answer."))))
+
+    (testing "investigation from scmutils"
+      ;; When adding up 1/n large-to-small we get a different answer than when
+      ;; adding them up small-to-large, which is more accurate.
+      (let [n 10000000
+            z->n (into [] (range n))
+            n->z (reverse z->n)
+            f #(/ 1.0 (inc %))
+            sum-inverse (fn [xs]
+                          (binding [ua/*fold* ua/naive-fold]
+                            (ua/sum (map f xs))))
+            large->small (sum-inverse z->n)
+            small->large (sum-inverse n->z)]
+        (is (= 16.695311365857272
+               large->small)
+            "Naive summation ")
+
+        (is (= 16.695311365859965
+               small->large)
+            "second example...")
+
+        (is (= 2.6929569685307797e-12
+               (- small->large large->small))
+            "error!")
+
+        (binding [ua/*fold* ua/kahan-fold]
+          (is (= 1.1368683772161603e-13
+                 (- small->large
+                    (ua/sum f 0 n)))
+              "From GJS: Kahan's compensated summation formula is much better, but
       slower..."))
 
-      (binding [ua/*fold* ua/kbn-fold]
+        (binding [ua/*fold* ua/kbn-fold]
+          (is (= 1.1368683772161603E-13
+                 (- small->large
+                    (ua/sum f 0 n)))
+              "kbn sum, good, faster by 2x."))
+
         (is (= 1.1368683772161603E-13
                (- small->large
-                  (ua/sum f 0 n)))
-            "kbn sum, good, faster by 2x."))
-
-      (is (= 1.1368683772161603E-13
-             (- small->large
-                (ua/pairwise-sum f 0 n)))
-          "pairwise summation matches that error in this example, and is
+                  (ua/pairwise-sum f 0 n)))
+            "pairwise summation matches that error in this example, and is
           slightly faster (including the time to generate the vector of
           inputs).")))
 
-  ;; TODO anything works with transduce!
-  #_
-  (transduce identity (join min max) [1 2 3])
+    ;; TODO anything works with transduce!
+    #_
+    (transduce identity (join min max) [1 2 3])
 
-  ;; TODO!
-  #_(testing "any monoid works"
-      (is (= [1 2]
-             (binding [*fold* (monoid into [])] (sum [[1] [2]]))))
+    ;; TODO!
+    #_(testing "any monoid works"
+        (is (= [1 2]
+               (binding [*fold* (monoid into [])] (sum [[1] [2]]))))
 
-      (is (= []
-             (binding [*fold* (monoid into [])] (sum []))))))
+        (is (= []
+               (binding [*fold* (monoid into [])] (sum []))))))

--- a/test/sicmutils/env/sci_test.cljc
+++ b/test/sicmutils/env/sci_test.cljc
@@ -86,6 +86,12 @@
       default bindings in `user`.")
 
   (testing "sci-specific macro definitions"
+    (is (= 2.0 (eval
+                '(do (require '[sicmutils.algebra.fold :as af])
+                     (let [sum (af/fold->sum-fn (kbk-n 2))]
+                       (sum [1.0 1e100 1.0 -1e100])))))
+        "compensated summation with a macro inside SCI")
+
     (is (= [true true true true]
            (eval '(let-coordinates [[x y]     R2-rect
                                     [r theta] R2-polar]

--- a/test/sicmutils/polynomial/interpolate_test.cljc
+++ b/test/sicmutils/polynomial/interpolate_test.cljc
@@ -89,20 +89,21 @@
       (is (ish? expected (pi/modified-neville points 1.2))
           "incremental calculation via modified Neville"))
 
-    (testing "folding points in reverse should match column-wise processing."
-      (is (ish? expected ((pi/neville-fold 1.2) (reverse points))))
-      (is (ish? expected ((pi/modified-neville-fold 1.2) (reverse points)))))
-
-    (testing "scan should process successive rows of the tableau; the diagonal
-    of the tableau processed with a fold should match the first row of
+    (testing "folding points should match the best estimate received through
     column-wise processing."
-      (is (ish? expected (map last ((pi/neville-scan 1.2) points))))
-      (is (ish? expected (map last ((pi/modified-neville-scan 1.2) points)))))
+      (is (ish? (last expected) ((pi/neville-sum 1.2) points)))
+      (is (ish? (last expected) ((pi/modified-neville-sum 1.2) points))))
+
+    (testing "the diagonal of the tableau processed with a fold should match the
+    first row of column-wise processing. (Scan produces the diagonal by
+    returning a sequence of the final values in each row.)"
+      (is (ish? expected ((pi/neville-scan 1.2) points)))
+      (is (ish? expected ((pi/modified-neville-scan 1.2) points))))
 
     (testing "the tableau processed with a fold should match the first row of
     column-wise processing."
-      (is (ish? ((pi/neville-fold 1.2) points)
+      (is (ish? ((pi/neville-sum 1.2) points)
                 (last ((pi/neville-scan 1.2) points))))
 
-      (is (ish?  ((pi/modified-neville-fold 1.2) points)
+      (is (ish?  ((pi/modified-neville-sum 1.2) points)
                  (last ((pi/modified-neville-scan 1.2) points)))))))

--- a/test/sicmutils/polynomial/interpolate_test.cljc
+++ b/test/sicmutils/polynomial/interpolate_test.cljc
@@ -78,7 +78,7 @@
           "Lagrange only returns the final value.")
 
       (is (ish? (last expected) (pi/neville-recursive points 1.2))
-          "Lagrange only returns the final value.")
+          "Non-incremental neville.")
 
       (is (ish? expected (pi/neville-incremental* points 1.2))
           "This is the initial, unabstracted version.")

--- a/test/sicmutils/rational_function/interpolate_test.cljc
+++ b/test/sicmutils/rational_function/interpolate_test.cljc
@@ -28,8 +28,8 @@
 
     (testing "The algo can handle a zero denominator case, though I don't get
     what it means!"
-      (is (ish? [4.0 2.6490066225165565 4.0 1.126760563380282]
-                ((ri/modified-bulirsch-stoer-fold 1.2) [[0 1] [0 1] [0 2.5] [8 4]]))))
+      (is (ish? 1.126760563380282
+                ((ri/modified-bulirsch-stoer-sum 1.2) [[0 1] [0 1] [0 2.5] [8 4]]))))
 
     (testing "each function returns a sequence of successive approximations. The
   approximation around 1.2 gets better the more points we add in."
@@ -43,26 +43,17 @@
           "The incremental, modified version works the same way."))
 
     (testing "folding points in reverse should match column-wise processing."
-      (is (ish? expected ((ri/modified-bulirsch-stoer-fold 1.2) (reverse points)))))
+      (is (ish? (last expected) ((ri/modified-bulirsch-stoer-sum 1.2) points))))
 
     (testing "scan should process successive rows of the tableau; the diagonal
     of the tableau processed with a fold should match the first row of
     column-wise processing."
-      (is (ish? expected (map last ((ri/modified-bulirsch-stoer-scan 1.2) points)))))
+      (is (ish? expected ((ri/modified-bulirsch-stoer-scan 1.2) points))))
 
     (testing "the tableau processed with a fold should match the first row of
     column-wise processing."
-      (is (ish? ((ri/modified-bulirsch-stoer-fold 1.2) points)
+      (is (ish? ((ri/modified-bulirsch-stoer-sum 1.2) points)
                 (last ((ri/modified-bulirsch-stoer-scan 1.2) points))))
 
-      (is (ish?  ((ri/modified-bulirsch-stoer-fold 1.2) points)
-                 (last ((ri/modified-bulirsch-stoer-scan 1.2) points))))
-
-      (testing "scan gives you prefixes, reversed!"
-        (is (ish?  (map #(ri/modified-bulirsch-stoer % 1.2)
-                        [[[0 1]]
-                         [[2 1.4] [0 1]]
-                         [[5 2]   [2 1.4] [0 1]]
-                         [[8 10]  [5 2]   [2 1.4] [0 1]]])
-                   ((ri/modified-bulirsch-stoer-scan 1.2)
-                    [[0 1] [2 1.4] [5 2] [8 10]])))))))
+      (is (ish?  ((ri/modified-bulirsch-stoer-sum 1.2) points)
+                 (last ((ri/modified-bulirsch-stoer-scan 1.2) points)))))))

--- a/test/sicmutils/rational_function/interpolate_test.cljc
+++ b/test/sicmutils/rational_function/interpolate_test.cljc
@@ -42,12 +42,21 @@
       (is (ish? expected (ri/modified-bulirsch-stoer points 1.2))
           "The incremental, modified version works the same way."))
 
-    (testing "folding points in reverse should match column-wise processing."
+    (testing "folding points should match the final estimate received through
+              column-wise processing."
       (is (ish? (last expected) ((ri/modified-bulirsch-stoer-sum 1.2) points))))
 
     (testing "scan should process successive rows of the tableau; the diagonal
     of the tableau processed with a fold should match the first row of
     column-wise processing."
+      (is (ish? expected ((ri/modified-bulirsch-stoer-scan 1.2) points))))
+
+    (testing "both folds should get the correct value"
+      (is (ish? (last expected) ((ri/bulirsch-stoer-sum 1.2) points)))
+      (is (ish? (last expected) ((ri/modified-bulirsch-stoer-sum 1.2) points))))
+
+    (testing "both scans should generate the correct sequence of values."
+      (is (ish? expected ((ri/bulirsch-stoer-scan 1.2) points)))
       (is (ish? expected ((ri/modified-bulirsch-stoer-scan 1.2) points))))
 
     (testing "the tableau processed with a fold should match the first row of

--- a/test/sicmutils/util/aggregate_test.cljc
+++ b/test/sicmutils/util/aggregate_test.cljc
@@ -28,19 +28,71 @@
             [sicmutils.util.stream :as us]))
 
 (deftest sum-tests
+  (testing "Naive summation"
+    (binding [ua/*fold* ua/naive-fold]
+      (is (not= 1 (ua/sum [1.0 1e-8 -1e-8]))
+          "Without the summation trick, errors build up.")))
+
   (testing "Kahan summation"
-    (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
-        "Kahan's summation trick allows us to keep precision.")
+    (binding [ua/*fold* ua/kahan-fold]
+      (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
+          "Kahan's summation trick allows us to keep precision.")
 
-    (is (not= 1 (reduce + 0.0 [1.0 1e-8 -1e-8]))
-        "Without the summation trick, errors build up.")
+      (let [xs [1.0 1e-8 -1e-8]]
+        (is (= [1.0 1.00000001 1.0] (ua/scanning-sum xs)))
 
-    (let [xs [1.0 1e-8 -1e-8]]
-      (is (= [1.0 1.00000001 1.0] (ua/scanning-sum xs)))
+        (is (= (ua/scanning-sum xs)
+               ((us/scan ua/kahan-fold :present ua/kahan-fold) xs))
+            "scanning-sum acts just like an actual `scan` call."))))
 
-      (is (= (ua/scanning-sum xs)
-             ((us/scan ua/kahan-sum :present first) xs))
-          "scanning-sum acts just like an actual `scan` call."))))
+  (testing "KBN Summation"
+    (binding [ua/*fold* ua/kbn-fold]
+      (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
+          "KBN's summation trick also allows us to keep precision.")
+
+      (let [xs [1.0 1e-8 -1e-8]]
+        (is (= [1.0 1.00000001 1.0] (ua/scanning-sum xs)))
+
+        (is (= (ua/scanning-sum xs)
+               ((us/scan ua/kbn-fold :present ua/kbn-fold) xs))
+            "scanning-sum acts just like an actual `scan` call."))))
+
+  (testing "investigation from scmutils"
+    ;; When adding up 1/n large-to-small we get a different answer than when
+    ;; adding them up small-to-large, which is more accurate.
+    (let [n    10000000
+          z->n (into [] (range n))
+          n->z (reverse z->n)
+          f    #(/ 1.0 (inc %))
+          sum-inverse (fn [xs]
+                        (binding [ua/*fold* ua/naive-fold]
+                          (ua/sum (map f xs))))
+          large->small (sum-inverse z->n)
+          small->large (sum-inverse n->z)]
+      (is (= 16.695311365857272
+             large->small)
+          "Naive summation ")
+
+      (is (= 16.695311365859965
+             small->large)
+          "second example...")
+
+      (is (= 2.6929569685307797e-12
+             (- small->large large->small))
+          "error!")
+
+      (binding [ua/*fold* ua/kahan-fold]
+        (is (= 1.1368683772161603e-13
+               (- small->large
+                  (ua/sum f 0 n)))
+            "From GJS: Kahan's compensated summation formula is much better, but
+      slower..."))
+
+      (binding [ua/*fold* ua/kbn-fold]
+        (is (= 2.6929569685307797E-12
+               (- small->large
+                  (ua/sum f 0 n)))
+            "kbn sum, seemingly just as bad??")))))
 
 (deftest monoid-group-tests
   (let [plus (ua/monoid (fn [a b] (+ a b)) 0)]

--- a/test/sicmutils/util/aggregate_test.cljc
+++ b/test/sicmutils/util/aggregate_test.cljc
@@ -24,102 +24,92 @@
              #?@(:cljs [:include-macros true])]
             [same :refer [ish?]]
             [sicmutils.numbers]
+            [sicmutils.algebra.fold :as af]
             [sicmutils.util.aggregate :as ua]
             [sicmutils.util.stream :as us]))
 
-#_(deftest sum-tests
+(deftest sum-tests
+  (let [xs [1.0 1e-8 -1e-8]]
     (testing "Naive summation"
-      (binding [ua/*fold* ua/naive-fold]
-        (is (not= 1 (ua/sum [1.0 1e-8 -1e-8]))
-            "Without the summation trick, errors build up.")))
+      (binding [ua/*fold* af/generic-sum-fold]
+        (is (not= 1 (ua/sum xs))
+            "Without the summation trick, errors build up.")
+
+        (is (= (ua/generic-sum xs)
+               (ua/sum xs))
+            "generic-sum matches sum when the binding is generic-sum-fold.")))
 
     (testing "Kahan summation"
-      (binding [ua/*fold* ua/kahan-fold]
-        (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
+      (binding [ua/*fold* af/kahan]
+        (is (= 1.0 (ua/sum xs))
             "Kahan's summation trick allows us to keep precision.")
 
-        (let [xs [1.0 1e-8 -1e-8]]
-          (is (= [1.0 1.00000001 1.0] (ua/scan xs)))
+        (is (= [1.0 1.00000001 1.0] (ua/scan xs)))
 
-          (is (= (ua/scan xs)
-                 ((us/scan ua/kahan-fold :present ua/kahan-fold) xs))
-              "scan acts just like an actual `scan` call."))))
+        (is (= (ua/scan xs)
+               ((af/fold->scan-fn af/kahan) xs))
+            "scan acts just like an actual `scan` call.")))
 
     (testing "KBN Summation"
-      (binding [ua/*fold* ua/kbn-fold]
-        (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
+      (binding [ua/*fold* af/kbn]
+        (is (= 1.0 (ua/sum xs))
             "KBN's summation trick also allows us to keep precision.")
 
-        (let [xs [1.0 1e-8 -1e-8]]
-          (is (= [1.0 1.00000001 1.0] (ua/scan xs)))
+        (is (= [1.0 1.00000001 1.0] (ua/scan xs)))
 
-          (is (= (ua/scan xs)
-                 ((us/scan ua/kbn-fold :present ua/kbn-fold) xs))
-              "scan acts just like an actual `scan` call."))))
+        (is (= (ua/scan xs)
+               ((af/fold->scan-fn af/kbn) xs))
+            "scan acts just like an actual `scan` call."))))
 
-    (testing "kbn vs kahan"
-      ;; This example of a difference in behavior comes from
-      ;; https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements.
-      (let [xs [1.0 10.0E100 1.0 -10E100]]
-        (binding [ua/*fold* ua/kahan-fold]
-          (is (= 0.0 (ua/sum xs))
-              "kahan-fold gets it wrong!"))
+  (testing "investigation from scmutils"
+    ;; When adding up 1/n large-to-small we get a different answer than when
+    ;; adding them up small-to-large, which is more accurate.
+    (let [n 10000000
+          z->n (into [] (range n))
+          n->z (reverse z->n)
+          f #(/ 1.0 (inc %))
+          sum-inverse (fn [xs]
+                        (binding [ua/*fold* af/generic-sum-fold]
+                          (ua/sum (map f xs))))
+          large->small (sum-inverse z->n)
+          small->large (sum-inverse n->z)]
+      (is (= 16.695311365857272
+             large->small)
+          "Naive summation ")
 
-        (binding [ua/*fold* ua/kbn-fold]
-          (is (= 2.0 (ua/sum xs))
-              "kbn-fold gets the correct answer."))))
+      (is (= 16.695311365859965
+             small->large)
+          "second example...")
 
-    (testing "investigation from scmutils"
-      ;; When adding up 1/n large-to-small we get a different answer than when
-      ;; adding them up small-to-large, which is more accurate.
-      (let [n 10000000
-            z->n (into [] (range n))
-            n->z (reverse z->n)
-            f #(/ 1.0 (inc %))
-            sum-inverse (fn [xs]
-                          (binding [ua/*fold* ua/naive-fold]
-                            (ua/sum (map f xs))))
-            large->small (sum-inverse z->n)
-            small->large (sum-inverse n->z)]
-        (is (= 16.695311365857272
-               large->small)
-            "Naive summation ")
+      (is (= 2.6929569685307797e-12
+             (- small->large large->small))
+          "error!")
 
-        (is (= 16.695311365859965
-               small->large)
-            "second example...")
-
-        (is (= 2.6929569685307797e-12
-               (- small->large large->small))
-            "error!")
-
-        (binding [ua/*fold* ua/kahan-fold]
-          (is (= 1.1368683772161603e-13
-                 (- small->large
-                    (ua/sum f 0 n)))
-              "From GJS: Kahan's compensated summation formula is much better, but
+      (binding [ua/*fold* af/kahan]
+        (is (= 1.1368683772161603e-13
+               (- small->large
+                  (ua/sum f 0 n)))
+            "From GJS: Kahan's compensated summation formula is much better, but
       slower..."))
 
-        (binding [ua/*fold* ua/kbn-fold]
-          (is (= 1.1368683772161603E-13
-                 (- small->large
-                    (ua/sum f 0 n)))
-              "kbn sum, good, faster by 2x."))
-
+      (binding [ua/*fold* af/kbn]
         (is (= 1.1368683772161603E-13
                (- small->large
-                  (ua/pairwise-sum f 0 n)))
-            "pairwise summation matches that error in this example, and is
+                  (ua/sum f 0 n)))
+            "kbn sum, good, faster by 2x."))
+
+      (is (= 1.1368683772161603E-13
+             (- small->large
+                (ua/pairwise-sum f 0 n)))
+          "pairwise summation matches that error in this example, and is
           slightly faster (including the time to generate the vector of
           inputs).")))
 
-    ;; TODO!
-    #_(testing "any monoid works"
-        (is (= [1 2]
-               (binding [*fold* (monoid into [])] (sum [[1] [2]]))))
-
-        (is (= []
-               (binding [*fold* (monoid into [])] (sum []))))))
+  (testing "any monoid works as a fold binding, if no `present` beyond identity
+            is needed."
+    (is (= [1 2]
+           (binding [ua/*fold* (ua/monoid into [])]
+             (ua/sum [[1] [2]]))))))
 
 (deftest monoid-group-tests
   (let [plus (ua/monoid (fn [a b] (+ a b)) 0)]

--- a/test/sicmutils/util/aggregate_test.cljc
+++ b/test/sicmutils/util/aggregate_test.cljc
@@ -27,99 +27,99 @@
             [sicmutils.util.aggregate :as ua]
             [sicmutils.util.stream :as us]))
 
-(deftest sum-tests
-  (testing "Naive summation"
-    (binding [ua/*fold* ua/naive-fold]
-      (is (not= 1 (ua/sum [1.0 1e-8 -1e-8]))
-          "Without the summation trick, errors build up.")))
+#_(deftest sum-tests
+    (testing "Naive summation"
+      (binding [ua/*fold* ua/naive-fold]
+        (is (not= 1 (ua/sum [1.0 1e-8 -1e-8]))
+            "Without the summation trick, errors build up.")))
 
-  (testing "Kahan summation"
-    (binding [ua/*fold* ua/kahan-fold]
-      (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
-          "Kahan's summation trick allows us to keep precision.")
-
-      (let [xs [1.0 1e-8 -1e-8]]
-        (is (= [1.0 1.00000001 1.0] (ua/scan xs)))
-
-        (is (= (ua/scan xs)
-               ((us/scan ua/kahan-fold :present ua/kahan-fold) xs))
-            "scan acts just like an actual `scan` call."))))
-
-  (testing "KBN Summation"
-    (binding [ua/*fold* ua/kbn-fold]
-      (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
-          "KBN's summation trick also allows us to keep precision.")
-
-      (let [xs [1.0 1e-8 -1e-8]]
-        (is (= [1.0 1.00000001 1.0] (ua/scan xs)))
-
-        (is (= (ua/scan xs)
-               ((us/scan ua/kbn-fold :present ua/kbn-fold) xs))
-            "scan acts just like an actual `scan` call."))))
-
-  (testing "kbn vs kahan"
-    ;; This example of a difference in behavior comes from
-    ;; https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements.
-    (let [xs [1.0 10.0E100 1.0 -10E100]]
+    (testing "Kahan summation"
       (binding [ua/*fold* ua/kahan-fold]
-        (is (= 0.0 (ua/sum xs))
-            "kahan-fold gets it wrong!"))
+        (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
+            "Kahan's summation trick allows us to keep precision.")
 
+        (let [xs [1.0 1e-8 -1e-8]]
+          (is (= [1.0 1.00000001 1.0] (ua/scan xs)))
+
+          (is (= (ua/scan xs)
+                 ((us/scan ua/kahan-fold :present ua/kahan-fold) xs))
+              "scan acts just like an actual `scan` call."))))
+
+    (testing "KBN Summation"
       (binding [ua/*fold* ua/kbn-fold]
-        (is (= 2.0 (ua/sum xs))
-            "kbn-fold gets the correct answer."))))
+        (is (= 1.0 (ua/sum [1.0 1e-8 -1e-8]))
+            "KBN's summation trick also allows us to keep precision.")
 
-  (testing "investigation from scmutils"
-    ;; When adding up 1/n large-to-small we get a different answer than when
-    ;; adding them up small-to-large, which is more accurate.
-    (let [n 10000000
-          z->n (into [] (range n))
-          n->z (reverse z->n)
-          f #(/ 1.0 (inc %))
-          sum-inverse (fn [xs]
-                        (binding [ua/*fold* ua/naive-fold]
-                          (ua/sum (map f xs))))
-          large->small (sum-inverse z->n)
-          small->large (sum-inverse n->z)]
-      (is (= 16.695311365857272
-             large->small)
-          "Naive summation ")
+        (let [xs [1.0 1e-8 -1e-8]]
+          (is (= [1.0 1.00000001 1.0] (ua/scan xs)))
 
-      (is (= 16.695311365859965
-             small->large)
-          "second example...")
+          (is (= (ua/scan xs)
+                 ((us/scan ua/kbn-fold :present ua/kbn-fold) xs))
+              "scan acts just like an actual `scan` call."))))
 
-      (is (= 2.6929569685307797e-12
-             (- small->large large->small))
-          "error!")
+    (testing "kbn vs kahan"
+      ;; This example of a difference in behavior comes from
+      ;; https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements.
+      (let [xs [1.0 10.0E100 1.0 -10E100]]
+        (binding [ua/*fold* ua/kahan-fold]
+          (is (= 0.0 (ua/sum xs))
+              "kahan-fold gets it wrong!"))
 
-      (binding [ua/*fold* ua/kahan-fold]
-        (is (= 1.1368683772161603e-13
-               (- small->large
-                  (ua/sum f 0 n)))
-            "From GJS: Kahan's compensated summation formula is much better, but
+        (binding [ua/*fold* ua/kbn-fold]
+          (is (= 2.0 (ua/sum xs))
+              "kbn-fold gets the correct answer."))))
+
+    (testing "investigation from scmutils"
+      ;; When adding up 1/n large-to-small we get a different answer than when
+      ;; adding them up small-to-large, which is more accurate.
+      (let [n 10000000
+            z->n (into [] (range n))
+            n->z (reverse z->n)
+            f #(/ 1.0 (inc %))
+            sum-inverse (fn [xs]
+                          (binding [ua/*fold* ua/naive-fold]
+                            (ua/sum (map f xs))))
+            large->small (sum-inverse z->n)
+            small->large (sum-inverse n->z)]
+        (is (= 16.695311365857272
+               large->small)
+            "Naive summation ")
+
+        (is (= 16.695311365859965
+               small->large)
+            "second example...")
+
+        (is (= 2.6929569685307797e-12
+               (- small->large large->small))
+            "error!")
+
+        (binding [ua/*fold* ua/kahan-fold]
+          (is (= 1.1368683772161603e-13
+                 (- small->large
+                    (ua/sum f 0 n)))
+              "From GJS: Kahan's compensated summation formula is much better, but
       slower..."))
 
-      (binding [ua/*fold* ua/kbn-fold]
+        (binding [ua/*fold* ua/kbn-fold]
+          (is (= 1.1368683772161603E-13
+                 (- small->large
+                    (ua/sum f 0 n)))
+              "kbn sum, good, faster by 2x."))
+
         (is (= 1.1368683772161603E-13
                (- small->large
-                  (ua/sum f 0 n)))
-            "kbn sum, good, faster by 2x."))
-
-      (is (= 1.1368683772161603E-13
-             (- small->large
-                (ua/pairwise-sum f 0 n)))
-          "pairwise summation matches that error in this example, and is
+                  (ua/pairwise-sum f 0 n)))
+            "pairwise summation matches that error in this example, and is
           slightly faster (including the time to generate the vector of
           inputs).")))
 
-  ;; TODO!
-  #_(testing "any monoid works"
-      (is (= [1 2]
-             (binding [*fold* (monoid into [])] (sum [[1] [2]]))))
+    ;; TODO!
+    #_(testing "any monoid works"
+        (is (= [1 2]
+               (binding [*fold* (monoid into [])] (sum [[1] [2]]))))
 
-      (is (= []
-             (binding [*fold* (monoid into [])] (sum []))))))
+        (is (= []
+               (binding [*fold* (monoid into [])] (sum []))))))
 
 (deftest monoid-group-tests
   (let [plus (ua/monoid (fn [a b] (+ a b)) 0)]

--- a/test/sicmutils/util/aggregate_test.cljc
+++ b/test/sicmutils/util/aggregate_test.cljc
@@ -104,7 +104,21 @@
         (is (= 1.1368683772161603E-13
                (- small->large
                   (ua/sum f 0 n)))
-            "kbn sum, good, faster by 2x."))))
+            "kbn sum, good, faster by 2x."))
+
+      (is (= 1.1368683772161603E-13
+             (- small->large
+                (ua/pairwise-sum f 0 n)))
+          "pairwise summation matches that error in this example, and is
+          slightly faster (including the time to generate the vector of
+          inputs).")
+
+      (is (= 1.1368683772161603E-13
+             (- small->large
+                (time (ua/pairwise-sum 0 n))))
+          "pairwise summation matches that error in this example, and is
+          slightly faster (including the time to generate the vector of
+          inputs).")))
 
   ;; TODO!
   #_(testing "any monoid works"

--- a/test/sicmutils/util/aggregate_test.cljc
+++ b/test/sicmutils/util/aggregate_test.cljc
@@ -111,13 +111,6 @@
                 (ua/pairwise-sum f 0 n)))
           "pairwise summation matches that error in this example, and is
           slightly faster (including the time to generate the vector of
-          inputs).")
-
-      (is (= 1.1368683772161603E-13
-             (- small->large
-                (time (ua/pairwise-sum 0 n))))
-          "pairwise summation matches that error in this example, and is
-          slightly faster (including the time to generate the vector of
           inputs).")))
 
   ;; TODO!

--- a/test/sicmutils/util/aggregate_test.cljc
+++ b/test/sicmutils/util/aggregate_test.cljc
@@ -57,42 +57,50 @@
                ((us/scan ua/kbn-fold :present ua/kbn-fold) xs))
             "scanning-sum acts just like an actual `scan` call."))))
 
-  (testing "investigation from scmutils"
-    ;; When adding up 1/n large-to-small we get a different answer than when
-    ;; adding them up small-to-large, which is more accurate.
-    (let [n    10000000
-          z->n (into [] (range n))
-          n->z (reverse z->n)
-          f    #(/ 1.0 (inc %))
-          sum-inverse (fn [xs]
-                        (binding [ua/*fold* ua/naive-fold]
-                          (ua/sum (map f xs))))
-          large->small (sum-inverse z->n)
-          small->large (sum-inverse n->z)]
-      (is (= 16.695311365857272
-             large->small)
-          "Naive summation ")
+  #_(testing "investigation from scmutils"
+      ;; When adding up 1/n large-to-small we get a different answer than when
+      ;; adding them up small-to-large, which is more accurate.
+      (let [n 10000000
+            z->n (into [] (range n))
+            n->z (reverse z->n)
+            f #(/ 1.0 (inc %))
+            sum-inverse (fn [xs]
+                          (binding [ua/*fold* ua/naive-fold]
+                            (ua/sum (map f xs))))
+            large->small (sum-inverse z->n)
+            small->large (sum-inverse n->z)]
+        (is (= 16.695311365857272
+               large->small)
+            "Naive summation ")
 
-      (is (= 16.695311365859965
-             small->large)
-          "second example...")
+        (is (= 16.695311365859965
+               small->large)
+            "second example...")
 
-      (is (= 2.6929569685307797e-12
-             (- small->large large->small))
-          "error!")
+        (is (= 2.6929569685307797e-12
+               (- small->large large->small))
+            "error!")
 
-      (binding [ua/*fold* ua/kahan-fold]
-        (is (= 1.1368683772161603e-13
-               (- small->large
-                  (ua/sum f 0 n)))
-            "From GJS: Kahan's compensated summation formula is much better, but
+        (binding [ua/*fold* ua/kahan-fold]
+          (is (= 1.1368683772161603e-13
+                 (- small->large
+                    (ua/sum f 0 n)))
+              "From GJS: Kahan's compensated summation formula is much better, but
       slower..."))
 
-      (binding [ua/*fold* ua/kbn-fold]
-        (is (= 2.6929569685307797E-12
-               (- small->large
-                  (ua/sum f 0 n)))
-            "kbn sum, seemingly just as bad??")))))
+        (binding [ua/*fold* ua/kbn-fold]
+          (is (= 1.1368683772161603E-13
+                 (- small->large
+                    (ua/sum f 0 n)))
+              "kbn sum, good, faster by 2x."))))
+
+  ;; TODO!
+  #_(testing "any monoid works"
+      (is (= [1 2]
+             (binding [*fold* (monoid into [])] (sum [[1] [2]]))))
+
+      (is (= []
+             (binding [*fold* (monoid into [])] (sum []))))))
 
 (deftest monoid-group-tests
   (let [plus (ua/monoid (fn [a b] (+ a b)) 0)]

--- a/test/sicmutils/util/stream_test.cljc
+++ b/test/sicmutils/util/stream_test.cljc
@@ -63,17 +63,6 @@
               (is (and (vector? evens) (vector? odds))
                   "both returned elements are vectors."))))
 
-(deftest scan-tests
-  (testing "intermediate + aggregations, all negated by `present`."
-    (let [f (us/scan + :init 0 :present -)]
-      (is (= [0 -1 -3 -6 -10 -15 -21 -28]
-             (f (range 8))))))
-
-  (testing "intermediate + aggregations, no present, arity-based init."
-    (let [f (us/scan (fn ([] 0) ([l r] (+ l r))))]
-      (is (= [0 1 3 6 10 15 21 28]
-             (f (range 8)))))))
-
 (deftest convergence-tests
   (testing "empty sequence behavior."
     (is (= {:converged? false, :terms-checked 0, :result nil}


### PR DESCRIPTION
This PR started as a simple PR to implement kahan-babushka-neumaier summation, described here: https://en.wikipedia.org/wiki/Kahan_summation_algorithm

But of course I had some realizations about how useful folds could be, and went a little bonkers.

From the CHANGELOG:

  - new `sicmutils.algebra.fold` namespace:

    - New folds: `kahan-babushka-neumaier` (aliased as `kbn`),
      `kahan-babushka-klein` and and `kbk-n` macro for generating higher-order
      `kahan-babushka-klein` variants. `generic-sum-fold` folds using
      `sicmutils.generic/+`.

    - `sicmutils.util.aggregate/kahan-fold` now lives here, named `kahan`.

    - `fold->sum-fn` and `fold->scan-fn` generate functions like
      `sicmutils.util.aggregate.{sum,scan}` specialized to the supplied fold.
      See the docstrings for the multiple arities supported

    - fold primitives: `count`, `constant`, `min`, `max`.

    - fold combinator `join` allows compound folds to be built out of primitive
      folds.

  - Upgrades to `sicmutils.util.aggregate`:

    - `scanning-sum` renamed to `scan`

    - `halt-at` deleted in favor of the built-in `halt-when` that I didn't know
      about!

    - `scan` and `sum` now both use a dynamic binding, `*fold*`, to set the fold
      they use for aggregation. By default, this is set to the new
      `kahan-babushka-neumaier-fold`.

    - The three-arity version of `sum` now uses transducers, saving a pass over
      the input range.

    - `pairwise-sum` implements pairwise summation, an error-limiting technique
      for summing vectors. Use the dynamic binding `*cutoff*` to set where
      `pairwise-sum` bails out to normal summation.

  - Upgrades to `sicmutils.rational-function.polynomial`:

    - The folds in this namespace now follow the fold contract laid out in
      `sicmutils.algebra.fold`, implementing all three arities correctly.

    - I realized that the fold implementation here should /not/ return a full
      row every time it processes a previous row; a far better `present`
      implementation would return the best estimate so far. Then you could build
      a `scan` from that fold to see the estimates evolve lazily as new points
      are added. This has better performance, it turns out, than the original
      method!

    - added a bunch to the exposition to make the advantages clear.

  - Upgrades to `sicmutils.rational-function.interpolate`:

    - `fold` interface upgraded, similar to the polynomial interpolation notes.

    - New `bulirsch-stoer-fold`, `bulirsch-stoer-sum` and `bulirsch-stoer-scan`
      functions. These are similar to the `modified-**` versions but use the
      `bulirsch-stoer` algorithm, instead of `modified-bulirsch-stoer`.

    - `modified-bulirsch-stoer-fold-fn` renamed to
      `modified-bulirsch-stoer-fold`, to match the naming scheme of other
      "folds" in the library.

    - `modified-bulirsch-stoer-fold` renamed to `modified-bulirsch-stoer-sum`,
      to match the convention that "reducing a sequence with a fold" is called
      "summing" the sequence. I can see this changing down the road...

    See `context-opts` for instructions on how to enable
    `sicmutils.algebra.fold/kbk-n` in the SCI environment (you'll need to turn
    on access to `js/Math` or `java.lang.Math`).

  - Fixed a type inference warning in Clojurescript in `sicmutils.complex`.

  - Added support for `sicmutils.util.def` and its `fork` macro to the default
    SCI environment provided by SICMUtils. Helpful for macro-writing!

  - `sicmutils.numerical.quadrature.adaptive` now uses the dynamically bound
    `sicmutils.util.aggregate/*fold*` to accumulate its numerical integral
    pieces, instead of a hardcoded `kahan-sum`.

  - `sicmutils.numerical.quadrature.bulirsch-stoer` now uses the functional scan
    versions of polynomial and rational function interpolation, as these are a
    bit faster than the originals!

  - `sicmutils.util.stream/scan` deleted in favor of
    `sicmutils.util.aggregate/scan` with a dynamic binding for `*fold*` to
    customize.