### PR TITLE
Generate polynomial by supplying interpolating points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [unreleased]
 
+- #453:
+
+  - Adds `sicmutils.polynomial/from-points` and
+    `sicmutils.rational-function/from-points` for generating `Polynomial` and
+    `RationalFunction` instances from sequences of points.
+
 - #448:
 
   - new `g/infinite?` generic with implementations for all numeric types,

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -31,6 +31,7 @@
             [sicmutils.numsymb :as sym]
             [sicmutils.polynomial.exponent :as xpt]
             [sicmutils.polynomial.impl :as i]
+            [sicmutils.polynomial.interpolate :as pi]
             [sicmutils.series :as series]
             [sicmutils.structure :as ss]
             [sicmutils.util :as u]
@@ -1431,26 +1432,26 @@
                                     (drop-leading-term a))
                               (cont np nq (* 2 nr)
                                     (* v/machine-epsilon
-                                       (+ (- ne (Math/abs np)) ne)))))]
+                                       (+ (- ne (Math/abs ^double np)) ne)))))]
                (cond (= n 1)
                      (let [np (+ (* z p) (leading-coefficient a))
                            nq (+ (* z q) p)
                            nr (+ (* z r) q)
-                           ne (+ (* (Math/abs z) e) (Math/abs np))]
+                           ne (+ (* (Math/abs ^double z) e) (Math/abs ^double np))]
                        (finish np nq nr ne))
                      (= n 2)
                      (let [z-n (* z z)
-                           az-n (Math/abs z-n)
+                           az-n (Math/abs ^double z-n)
                            np (+ (* z-n p) (leading-coefficient a))
                            nq (+ (* z-n q) (* 2 (* z p)))
                            nr (+ (* z-n r) (* 2 z q) p)
-                           ne (+ (* az-n (+ e p)) (Math/abs np))]
+                           ne (+ (* az-n (+ e p)) (Math/abs ^double np))]
                        (finish np nq nr ne))
                      :else
                      (let [z-n-2 (expt z (- n 2))
                            z-n-1 (* z-n-2 z)
                            z-n (* z-n-1 z)
-                           az-n (Math/abs z-n)
+                           az-n (Math/abs ^double z-n)
                            np (+ (* z-n p)
                                  (leading-coefficient a))
                            nq (+ (* z-n q)
@@ -1459,14 +1460,14 @@
                                  (* n z-n-1 q)
                                  (* (/ 1 2) n (- n 1) z-n-2 p))
                            ne (+ (* az-n (+ e (* (- n 1) p)))
-                                 (Math/abs np))]
+                                 (Math/abs ^double np))]
                        (finish np nq nr ne)))))]
      (let [lc (leading-coefficient a)]
        (call (degree a)
              lc
              0
              0
-             (* (/ 1 2) (Math/abs lc))
+             (* (/ 1 2) (Math/abs ^double lc))
              (drop-leading-term a))))))
 
 ;; ## Scale and Shift
@@ -1597,6 +1598,17 @@
          sym->var (zipmap sorted (new-variables arity))
          poly     (x/evaluate expr sym->var operator-table)]
      (cont poly sorted))))
+
+(defn from-points
+  "Given a sequence of points of the form `[x, f(x)]`, returns a univariate
+  polynomial that passes through each input point.
+
+  The degree of the returned polynomial is equal to `(dec (count xs))`."
+  [xs]
+  (expression->
+   (g/simplify
+    (pi/lagrange xs 'x))
+   (fn [p _] p)))
 
 (let [* (sym/symbolic-operator '*)
       + (sym/symbolic-operator '+)

--- a/src/sicmutils/rational_function.cljc
+++ b/src/sicmutils/rational_function.cljc
@@ -29,6 +29,7 @@
             [sicmutils.polynomial :as p]
             [sicmutils.polynomial.gcd :as pg]
             [sicmutils.polynomial.impl :as pi]
+            [sicmutils.rational-function.interpolate :as ri]
             [sicmutils.ratio :as r]
             [sicmutils.structure :as ss]
             [sicmutils.util :as u]
@@ -765,6 +766,15 @@
          sym->var (zipmap sorted (p/new-variables arity))
          rf       (x/evaluate expr sym->var operator-table)]
      (cont rf sorted))))
+
+(defn from-points
+  "Given a sequence of points of the form `[x, f(x)]`, returns a rational function
+  that passes through each input point."
+  [xs]
+  (expression->
+   (g/simplify
+    (ri/bulirsch-stoer-recursive xs 'x))
+   (fn [rf _] rf)))
 
 (defn ->expression
   "Accepts a [[RationalFunction]] `r` and a sequence of symbols for each indeterminate,

--- a/src/sicmutils/rational_function/interpolate.cljc
+++ b/src/sicmutils/rational_function/interpolate.cljc
@@ -82,8 +82,8 @@
                         rr (evaluate r-branch x)
                         rc (evaluate center x)
                         p  (g/- rr rl)
-                        q  (-> (/ (g/- x xl)
-                                  (g/- x xr))
+                        q  (-> (g// (g/- x xl)
+                                    (g/- x xr))
                                (g/* (g/- 1 (g// p (g/- rr rc))))
                                (g/- 1))]
                     (g/+ rr (g// p q)))))]

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -1078,13 +1078,23 @@
              fx sg/any-integral]
             (is (= fx (p/from-points [[x fx]]))))
 
-  (is (= (g/- (g/* 3 (p/identity)) 2)
-         (p/from-points [[1 1] [2 4]]))
-      "matching polynomial == 3x-2")
+  (let [poly (p/from-points [[1 1] [2 4]])]
+    (is (p/polynomial? poly))
+    (is (= (g/- (g/* 3 (p/identity)) 2)
+           poly)
+        "matching polynomial == 3x-2")
+    (is (= 1 (poly 1)))
+    (is (= 4 (poly 2))))
 
-  (is (= (g/square (p/identity))
-         (p/from-points [[1 1] [2 4] [3 9]]))
-      "matching polynomial == x^2"))
+  (let [poly (p/from-points [[1 1] [2 4] [3 9]])]
+    (is (= (g/square (p/identity))
+           poly)
+        "matching polynomial == x^2")
+    (is (= 1 (poly 1)))
+    (is (= 4 (poly 2)))
+    (is (= 9 (poly 3)))
+    (is (= 16 (poly 4))
+        "just for fun...")))
 
 (deftest analyzer-tests
   (let [new-analyzer (fn [] (a/make-analyzer

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -1069,7 +1069,24 @@
                     (p/evaluate q xs))
              (p/evaluate (g/mul p q) xs))))))
 
-(deftest analyzer-test
+(deftest from-points-tests
+  (is (zero? (p/from-points []))
+      "no points returns a 0")
+
+  (checking "single point polynomial is a constant" 100
+            [x  sg/any-integral
+             fx sg/any-integral]
+            (is (= fx (p/from-points [[x fx]]))))
+
+  (is (= (g/- (g/* 3 (p/identity)) 2)
+         (p/from-points [[1 1] [2 4]]))
+      "matching polynomial == 3x-2")
+
+  (is (= (g/square (p/identity))
+         (p/from-points [[1 1] [2 4] [3 9]]))
+      "matching polynomial == x^2"))
+
+(deftest analyzer-tests
   (let [new-analyzer (fn [] (a/make-analyzer
                             p/analyzer
                             (a/monotonic-symbol-generator "k%08d")))

--- a/test/sicmutils/rational_function_test.cljc
+++ b/test/sicmutils/rational_function_test.cljc
@@ -237,6 +237,27 @@
             (rf/->expression a b))]
     (rf/expression-> expr cont)))
 
+(deftest from-points-tests
+  (is (zero? (rf/from-points []))
+      "no points returns a 0")
+
+  (checking "single point rational function is a constant" 100
+            [x  sg/any-integral
+             fx sg/any-integral]
+            (is (= fx (rf/from-points [[x fx]]))))
+
+  (testing "from-points with two points"
+    (let [f (rf/from-points [[1 1] [2 4]])]
+      (is (rf/rational-function? f))
+      (is (= 1 (f 1)))
+      (is (= 4 (f 2)))))
+
+  (testing "from-points with three points"
+    (let [f (p/from-points [[1 1] [2 4] [3 9]])]
+      (is (= 1 (f 1)))
+      (is (= 4 (f 2)))
+      (is (= 9 (f 3))))))
+
 (deftest rf-as-simplifier
   (let [arity 20]
     (checking "evaluate matches ->expression" test-limit


### PR DESCRIPTION
From the CHANGELOG:

- #453:

  - Adds `sicmutils.polynomial/from-points` and
    `sicmutils.rational-function/from-points` for generating `Polynomial` and
    `RationalFunction` instances from sequences of points.