### PR TITLE
call rest before `map present` in scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+- #455 makes `sicmutils.util.aggregate/scan` and
+  `sicmutils.algebra.fold/fold->scan-fn` slightly more efficient by dropping the
+  first element of the returned sequence before mapping the `present` function.
+
 - #453:
 
   - Adds `sicmutils.polynomial/from-points` and

--- a/src/sicmutils/algebra/fold.cljc
+++ b/src/sicmutils/algebra/fold.cljc
@@ -287,8 +287,8 @@
    (fn scan
      ([xs]
       (->> (reductions fold (init) xs)
-           (map present)
-           (rest)))
+           (rest)
+           (map present)))
      ([f low high]
       (scan
        (map f (range low high)))))))

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -109,8 +109,8 @@
   ```"
   ([xs]
    (->> (reductions *fold* (*fold*) xs)
-        (map *fold*)
-        (rest)))
+        (rest)
+        (map *fold*)))
   ([f low high]
    (scan
     (map f (range low high)))))

--- a/test/sicmutils/rational_function_test.cljc
+++ b/test/sicmutils/rational_function_test.cljc
@@ -253,7 +253,7 @@
       (is (= 4 (f 2)))))
 
   (testing "from-points with three points"
-    (let [f (p/from-points [[1 1] [2 4] [3 9]])]
+    (let [f (rf/from-points [[1 1] [2 4] [3 9]])]
       (is (= 1 (f 1)))
       (is (= 4 (f 2)))
       (is (= 9 (f 3))))))


### PR DESCRIPTION
Slight performance improvement. Also fixed a test in rational function...