### PR TITLE
Allow for symbolic rational functions, fix for ->expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [unreleased]
 
+- #458:
+
+  - Default implementation of `g/negative?` returning `false` for literal
+    numbers and symbols. This was required to get `g/abs` working for
+    polynomials and rational functions with symbolic coefficients.
+
+  - Polynomials and rational functions now correctly unwrap `Literal`
+    coefficients in `->expression`. Without this, the resulting expressions
+    would not correctly respond to `simplify` calls.
+
+  - Slight efficiency improvement in
+    `sicmutils.polynomial.gcd/->content+primitive`.
+
+  - `sicmutils.rational-function/from-points` now correctly builds its function.
+    Before, it was unhygienic; if `'x` appeared in the coefficients the results
+    would be incorrect.
+
 - #456:
 
   - `sicmutils.mechanics.lagrange/{Γ,Γ-bar}` are removed in favor of the

--- a/src/sicmutils/abstract/number.cljc
+++ b/src/sicmutils/abstract/number.cljc
@@ -221,6 +221,9 @@
 (defbinary g/gcd 'gcd)
 (defbinary g/lcm 'lcm)
 
+;; We currently default to `false` here; once literals gain metadata saying
+;; whether or not they are negative, we return /something/. Maybe this is
+;; ill-founded, but it was required for some polynomial code.
 (defmethod g/negative? [::x/numeric] [_] false)
 
 (defmethod g/simplify [Symbol] [a] a)

--- a/src/sicmutils/abstract/number.cljc
+++ b/src/sicmutils/abstract/number.cljc
@@ -221,6 +221,8 @@
 (defbinary g/gcd 'gcd)
 (defbinary g/lcm 'lcm)
 
+(defmethod g/negative? [::x/numeric] [_] false)
+
 (defmethod g/simplify [Symbol] [a] a)
 (defmethod g/simplify [::x/numeric] [a]
   (literal-number

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -466,7 +466,8 @@
 
   The degree of the returned polynomial is equal to `(dec (count xs))`."
   [xs]
-  (pi/lagrange xs (identity)))
+  (g/simplify
+   (pi/lagrange xs (identity))))
 
 (declare add)
 
@@ -1187,9 +1188,11 @@
             #?@(:cljs [c (->big c)])]
         (if (< m n)
           [remainder d]
-          (recur (sub (*vn remainder)
-                      (mul (c*xn 1 c (- m n))
-                           v))
+          ;; this handles symbolic coefficients.
+          (recur (g/simplify
+                  (sub (*vn remainder)
+                       (mul (c*xn 1 c (- m n))
+                            v)))
                  (inc d)))))))
 
 ;; ## Polynomial Contraction and Expansion
@@ -1634,7 +1637,9 @@
                            (fn [i v]
                              (let [pow (xpt/monomial-degree expts i)]
                                (expt v pow))))
-                          * c vars)))
+                          *
+                          (x/expression-of c)
+                          vars)))
             high->low (rseq (bare-terms p))]
         (transduce xform + high->low)))))
 

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -1630,7 +1630,7 @@
   by [[sicmutils.expression.analyze/make-analyzer]]."
     [p vars]
     (if-not (polynomial? p)
-      p
+      (x/expression-of p)
       (let [xform (map (fn [[expts c]]
                          (transduce
                           (map-indexed

--- a/src/sicmutils/polynomial/gcd.cljc
+++ b/src/sicmutils/polynomial/gcd.cljc
@@ -240,12 +240,17 @@
   Content'](https://en.wikipedia.org/wiki/Primitive_part_and_content) page for
   more details. "
   [p gcd]
-  (let [content (apply gcd (p/coefficients p))
-        primitive (if (v/one? content)
-                    p
-                    (p/map-coefficients
-                     #(g/exact-divide % content) p))]
-    [content primitive]))
+  (let [coeffs (p/coefficients p)]
+    (if (= 1 (count coeffs))
+      (let [content   (first coeffs)
+            primitive (p/map-coefficients (fn [_] 1) p)]
+        [content primitive])
+      (let [content   (apply gcd coeffs)
+            primitive (if (v/one? content)
+                        p
+                        (p/map-coefficients
+                         #(g/exact-divide % content) p))]
+        [content primitive]))))
 
 (defn- with-content-removed
   "Given a multi-arity `gcd` routine, returns a function of polynomials `u` and

--- a/src/sicmutils/rational_function.cljc
+++ b/src/sicmutils/rational_function.cljc
@@ -20,14 +20,12 @@
 (ns sicmutils.rational-function
   (:require [clojure.set :as set]
             [sicmutils.complex :refer [complex?]]
-            [sicmutils.differential :as sd]
             [sicmutils.expression.analyze :as a]
             [sicmutils.expression :as x]
             [sicmutils.function :as f]
             [sicmutils.generic :as g]
             [sicmutils.numsymb :as sym]
             [sicmutils.polynomial :as p]
-            [sicmutils.polynomial.gcd :as pg]
             [sicmutils.polynomial.impl :as pi]
             [sicmutils.rational-function.interpolate :as ri]
             [sicmutils.ratio :as r]
@@ -348,9 +346,9 @@
   (let [a (check-same-arity u v)
         xform (comp (distinct)
                     (map r/denominator))
-        coefs  (concat
-                (p/coefficients u)
-                (p/coefficients v))
+        coefs (concat
+               (p/coefficients u)
+               (p/coefficients v))
         factor (transduce xform (completing g/lcm) 1 coefs)
         factor (if (= 1 (coef-sgn
                          (p/leading-coefficient v)))
@@ -771,10 +769,8 @@
   "Given a sequence of points of the form `[x, f(x)]`, returns a rational function
   that passes through each input point."
   [xs]
-  (expression->
-   (g/simplify
-    (ri/bulirsch-stoer-recursive xs 'x))
-   (fn [rf _] rf)))
+  (g/simplify
+   (ri/bulirsch-stoer-recursive xs (p/identity))))
 
 (defn ->expression
   "Accepts a [[RationalFunction]] `r` and a sequence of symbols for each indeterminate,

--- a/test/sicmutils/polynomial/gcd_test.cljc
+++ b/test/sicmutils/polynomial/gcd_test.cljc
@@ -56,9 +56,9 @@
             (p/make 2 {[4 3] 15})))))
 
   (testing "inexact coefficients"
-    (is (= 1.0 (g/gcd
-                (p/make [0.2 0.4 0.6])
-                (p/make [0.4 0.6 0.8]))))
+    (is (= 1 (g/gcd
+              (p/make [0.2 0.4 0.6])
+              (p/make [0.4 0.6 0.8]))))
     (is (= (p/make [0 1])
            (g/gcd
             (p/make [0 1])

--- a/test/sicmutils/rational_function_test.cljc
+++ b/test/sicmutils/rational_function_test.cljc
@@ -256,7 +256,12 @@
     (let [f (rf/from-points [[1 1] [2 4] [3 9]])]
       (is (= 1 (f 1)))
       (is (= 4 (f 2)))
-      (is (= 9 (f 3))))))
+      (is (= 9 (f 3)))))
+
+  (testing "symbolic from-points. Only works with two entries so far!"
+    (let [f (rf/from-points '[[x1 y1] [x2 y2]])]
+      (is (v/= 'y1 (g/simplify (f 'x1))))
+      (is (v/= 'y2 (g/simplify (f 'x2)))))))
 
 (deftest rf-as-simplifier
   (let [arity 20]
@@ -291,6 +296,15 @@
                    (g/simplify
                     (g/- (r (g/+ 'x factor))
                          (rf/evaluate shifted ['x])))))))
+
+  (testing "expression-> unwraps internal literals"
+    (is (every?
+         (complement x/literal?)
+         (tree-seq coll? seq
+                   (-> (rf/from-points '[[x y] [x2 y2]])
+                       (rf/->expression ['z]))))
+        "EVEN if the original rf has symbolic coefficients, these are unwrapped
+         in the process of generating the bare expression."))
 
   (testing "expr"
     (let [exp1 (x/expression-of (g/* (g/+ 1 'x) (g/+ -3 'x)))


### PR DESCRIPTION
- #458:

  - Default implementation of `g/negative?` returning `false` for literal
    numbers and symbols. This was required to get `g/abs` working for
    polynomials and rational functions with symbolic coefficients.

  - Polynomials and rational functions now correctly unwrap `Literal`
    coefficients in `->expression`. Without this, the resulting expressions
    would not correctly respond to `simplify` calls.

  - Slight efficiency improvement in
    `sicmutils.polynomial.gcd/->content+primitive`.

  - `sicmutils.rational-function/from-points` now correctly builds its function.
    Before, it was unhygienic; if `'x` appeared in the coefficients the results
    would be incorrect.