### PR TITLE
Return a polynomial instance from characteristic-polynomial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+- #463 adds a new 1-arity to `sicmutils.matrix/characteristic-polynomial` that
+  returns an actual polynomial instance. Creating this polynomial once and
+  calling it many times is much more efficient. Closes #209.
+
 - #449:
 
   - All missing trigonometric functions have been filled in `sicmutils.generic`

--- a/src/sicmutils/matrix.cljc
+++ b/src/sicmutils/matrix.cljc
@@ -29,6 +29,7 @@
   (:require [sicmutils.differential :as d]
             [sicmutils.function :as f]
             [sicmutils.generic :as g]
+            [sicmutils.polynomial :as poly]
             [sicmutils.series :as series]
             [sicmutils.structure :as s]
             [sicmutils.util :as u]
@@ -850,16 +851,29 @@
                    (v/zero? entry))))))
 
 (defn characteristic-polynomial
-  "Compute the characteristic polynomial of the square matrix m, evaluated at `x`.
+  "Returns the [characteristic
+  polynomial](https://en.wikipedia.org/wiki/Characteristic_polynomial) of the
+  square matrix `m`.
+
+  If only `m` is supplied, returns a [[polynomial/Polynomial]] instance
+  representing the matrix `m`'s characteristic polynomial.
+
+  If `x` is supplied, returns the value of the characteristic polynomial of `m`
+  evaluated at `x`.
 
   Typically `x` will be a symbolic variable, but if you wanted to get the value
-  of the characteristic polynomial at some particular numerical point `x'` you
+  of the characteristic polynomial at some particular numerical point `x` you
   could pass that too."
-  [m x]
-  (let [r (num-rows m)
-        c (num-cols m)]
-    (when-not (= r c) (u/illegal "not square"))
-    (determinant (g/- (g/* x (I r)) m))))
+  ([m]
+   (characteristic-polynomial m (poly/identity)))
+  ([m x]
+   (let [r (num-rows m)
+         c (num-cols m)]
+     (when-not (= r c) (u/illegal "not square"))
+     (let [Ix (generate r r (fn [i j]
+                              (if (= i j) x 0)))]
+       (determinant
+        (g/- Ix m))))))
 
 ;; ## Generic Operation Installation
 

--- a/test/sicmutils/matrix_test.cljc
+++ b/test/sicmutils/matrix_test.cljc
@@ -881,3 +881,13 @@
                        (s/down -36 192 -180)
                        (s/down 30 -180 180))
                (g/divide H)))))))
+
+(deftest characteristic-poly-tests
+  (let [M (m/by-rows [1 3 2] [4 5 2] [1 4 5])
+        p (m/characteristic-polynomial M)]
+    (is (= (m/characteristic-polynomial M 12)
+           (p 12))
+        "passing the arg directly has the same result as calling the returned
+        polynomial.")
+
+    (is (= 315 (p 12)))))


### PR DESCRIPTION
- #463 adds a new 1-arity to `sicmutils.matrix/characteristic-polynomial` that
  returns an actual polynomial instance. Creating this polynomial once and
  calling it many times is much more efficient.