### PR TITLE
Add x0 argument to function->

### DIFF
--- a/src/sicmutils/calculus/derivative.cljc
+++ b/src/sicmutils/calculus/derivative.cljc
@@ -476,24 +476,36 @@
 ;; standard ways.
 
 (defn taylor-series
-  "Returns a [[sicmutils.series/Series]] of the coefficients of the taylor series
-  of the function `f` evaluated at `x`, with incremental quantity `dx`.
+  "Returns a [[sicmutils.series/Series]] of the coefficients of the [Taylor
+  series](https://en.wikipedia.org/wiki/Taylor_series) of the function `f`
+  evaluated at `x`, with incremental quantity `dx`.
 
-  NOTE: The `(constantly dx)` term is what allows this to work with arbitrary
-  structures of `x` and `dx`. Without this wrapper, `((g/* dx D) f)` with `dx`
-  == `(up 'dx 'dy)` would expand to this:
+  The typical definition of a Taylor series at the point `x` is
 
-  ```clojure
-  (fn [x] (* (s/up ('dx x) ('dy x))
-             ((D f) x)))
-  ```
+  $$f(x) = f(a) + \\frac{f'(a)}{1!}(x-a) +  \\frac{f''(a)}{2!} (x-a)^2 + \\ldots$$
 
-  `constantly` delays the interpretation of `dx` one step:
+  All derivatives of the original function and this Taylor series match at the
+  point `a`.
 
-  ```clojure
-  (fn [x] (* (s/up 'dx 'dy)
-             ((D f) x)))
-  ```
+  The argument `dx` is instead interpreted as an incremental difference
+  from `(x-a)`. So, passing 0 for `dx` would return the evaluation of the Taylor
+  series at the point `a`.
   "
   [f x dx]
   (((g/exp (g/* (constantly dx) D)) f) x))
+
+;; NOTE: The `(constantly dx)` term is what allows this to work with arbitrary
+;; structures of `x` and `dx`. Without this wrapper, `((g/* dx D) f)` with `dx`
+;; == `(up 'dx 'dy)` would expand to this:
+
+;; ```clojure
+;; (fn [x] (* (s/up ('dx x) ('dy x))
+;;           ((D f) x)))
+;; ```
+;;
+;; `constantly` delays the interpretation of `dx` one step:
+;;
+;; ```clojure
+;; (fn [x] (* (s/up 'dx 'dy)
+;;           ((D f) x)))
+;; ```

--- a/src/sicmutils/series.cljc
+++ b/src/sicmutils/series.cljc
@@ -416,22 +416,32 @@
 
 (defn function->
   "Returns a [[PowerSeries]] representing the [Taylor
-  series](https://en.wikipedia.org/wiki/Taylor_series) expansion of `f` at 0.
+  series](https://en.wikipedia.org/wiki/Taylor_series) expansion of `f` at the
+  value supplied via the keyword argument `:x0`. `:x0` defaults to 0.
 
   The expansion at 0 is also called a 'Maclaurin series'.
+
+  NOTE: The argument of the returned [[PowerSeries]] is interepreted as `dx`,
+  some delta around the supplied point `0`. This differs from the
+  traditional [Taylor series](https://en.wikipedia.org/wiki/Taylor_series)
+  definition, where the returned series would align mostly closely
+  with `(function-> f :x0 <x0>)` when called with `x0` as an argument. We do
+  this because it's not possible to create a [[PowerSeries]] instance with the
+  that bakes in the `x - x0` shift.
 
   NOTE: this function takes derivatives internally, so if you pass a function
   make sure you require [[sicmutils.calculus.derivative]] to install the
   derivative implementation for functions. If you pass some other callable,
   differentiable function-like thing, like a polynomial, this is not necessary."
-  [f]
-  (letfn [(gen [i f fact-n]
-            (lazy-seq
-             (cons (g// (f 0) fact-n)
-                   (gen (inc i)
-                        (g/partial-derivative f [])
-                        (* fact-n i)))))]
-    (->PowerSeries (gen 1 f 1) nil)))
+  [f & {:keys [x0]}]
+  (let [x0 (or x0 0)]
+    (letfn [(gen [i f fact-n]
+              (lazy-seq
+               (cons (g// (f x0) fact-n)
+                     (gen (inc i)
+                          (g/partial-derivative f [])
+                          (* fact-n i)))))]
+      (->PowerSeries (gen 1 f 1) nil))))
 
 ;; ## Application
 ;;

--- a/src/sicmutils/series/impl.cljc
+++ b/src/sicmutils/series/impl.cljc
@@ -343,7 +343,7 @@
 ;; ### Functional Composition
 ;;
 ;; To compose two series $F(x)$ and $G(x)$ means to create a new series
-;; $F(G(x))$. Derive this by substuting $G$ for $x$ in the expansion of $F$:
+;; $F(G(x))$. Derive this by substituting $G$ for $x$ in the expansion of $F$:
 ;;
 ;; $$F(G)=f+G \times F_{1}(G)=f+\left(g+x G_{1}\right) \times F_{1}(G)=\left(f+g F_{1}(G)\right)+x G_{1} \times F_{1}(G)$$
 ;;

--- a/test/sicmutils/series_test.cljc
+++ b/test/sicmutils/series_test.cljc
@@ -329,6 +329,16 @@
                    (v/freeze)))
             "power series expansion of g/sin around 0, evaluated at 'x")
 
+        (is (= '(+ (* (/ 1 6) (expt dx 3) (exp a))
+                   (* (/ 1 2) (expt dx 2) (exp a))
+                   (* dx (exp a))
+                   (exp a))
+               (-> ((s/function-> g/exp :x0 'a) 'dx)
+                   (s/sum 3)
+                   (g/simplify)
+                   (v/freeze)))
+            "power series expansion of g/exp around 'a, evaluated at 'dx")
+
         (letfn [(check [f n]
                   (is (= (take n (g/simplify
                                   ((f s/identity) 'x)))


### PR DESCRIPTION
After some discussion with GJS I feel good adding back the `x0` argument in `sicmutils.series/function->`, along with clarifying comments.