### PR TITLE
Add bell numbers, Touchard polynomials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [unreleased]
 
+- #468:
+
+  - adds `sicmutils.polynomial/touchard`, implementing a constructor for the
+    type of polynomial known as a "complete Bell polynomial" or ["Touchard
+    polynomial"](https://en.wikipedia.org/wiki/Touchard_polynomials).
+
+  - adds `sicmutils.special.factorial/bell` for computing the nth [Bell
+    number](https://en.wikipedia.org/wiki/Bell_number)
+
+  - `sicmutils.series/bell-series` returns an infinite sequence of bell numbers.
+
 - #276 adds an `integration-opts` to
   `sicmutils.mechanics.lagrange/Lagrangian-action`. All options are passed on to
   `definite-integral`. By default, `parametric-path-action` passes `:compile?

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -32,6 +32,7 @@
             [sicmutils.polynomial.exponent :as xpt]
             [sicmutils.polynomial.impl :as i]
             [sicmutils.polynomial.interpolate :as pi]
+            [sicmutils.special.factorial :as sf]
             [sicmutils.series :as series]
             [sicmutils.structure :as ss]
             [sicmutils.util :as u]
@@ -502,6 +503,20 @@
         :else
         (let [term (i/make-term (xpt/make 0 n) c)]
           (->Polynomial arity [term] nil))))
+
+;; ## Constructors of Special Polynomials
+
+(defn touchard
+  "Returns the nth [Touchard
+  polynomial](https://en.wikipedia.org/wiki/Touchard_polynomials).
+
+  These are also called [Bell
+  polynomials](https://mathworld.wolfram.com/BellPolynomial.html) (in
+  Mathematica, implemented as `BellB`) or /exponential polynomials/."
+  [n]
+  (make
+   (map #(sf/stirling-second-kind n %)
+        (range (inc n)))))
 
 ;; ###  Accessors, Predicates
 ;;

--- a/src/sicmutils/series.cljc
+++ b/src/sicmutils/series.cljc
@@ -687,6 +687,7 @@
 (def fib-series (->Series i/fib nil))
 (def catalan-series (->Series i/catalan nil))
 (def harmonic-series (->Series i/harmonic nil))
+(def bell-series (->Series i/bell nil))
 
 ;; ## Generic Implementations
 ;;

--- a/src/sicmutils/series/impl.cljc
+++ b/src/sicmutils/series/impl.cljc
@@ -22,6 +22,7 @@
   against pure Clojure sequences."
   (:require [sicmutils.generic :as g]
             [sicmutils.numbers]
+            [sicmutils.special.factorial :as sf]
             [sicmutils.util :as u]
             [sicmutils.value :as v]))
 
@@ -704,8 +705,14 @@
   [n]
   (->series (binomial* n)))
 
-;; [Harmonic numbers](https://en.wikipedia.org/wiki/Harmonic_number):
+;;
 
-(def harmonic
+(def ^{:doc "The sequence of [Harmonic
+  numbers](https://en.wikipedia.org/wiki/Harmonic_number), starting from n=1."}
+  harmonic
   (reductions
    g/+ (map g// (iterate inc 1))))
+
+(def ^{:doc "The sequence of [Bell
+  numbers](https://en.wikipedia.org/wiki/Bell_number), starting from n=1."} bell
+  (map sf/bell (iterate inc 1)))

--- a/src/sicmutils/special/factorial.cljc
+++ b/src/sicmutils/special/factorial.cljc
@@ -365,4 +365,16 @@
       (reset! rec (memoize rec*))
       (cond (zero? k) (if (zero? n) 1 0)
             (> k n) 0
-            :else (@rec n k)))))
+            :else (@rec n k))))
+
+  (defn bell
+    "Returns the `n`th [Bell number](https://en.wikipedia.org/wiki/Bell_number), ie,
+  the number of ways a set of `n` elements can be partitioned into nonempty
+  subsets.
+
+  The `n`th Bell number is denoted $B_n$."
+    [n]
+    {:pre [(>= n 0)]}
+    (let [xform (map #(stirling-second-kind n %))
+          ks    (range (inc n))]
+      (transduce xform add ks))))

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -436,6 +436,20 @@
                 "adding on a nonzero term then DROPPING it gives back the same
                 poly as if you'd never added.")))
 
+(deftest special-poly-tests
+  (is (= '[0
+           1
+           x
+           (+ (expt x 2) x)
+           (+ (expt x 3) (* 3 (expt x 2)) x)
+           (+ (expt x 4) (* 6 (expt x 3)) (* 7 (expt x 2)) x)
+           (+ (expt x 5) (* 10 (expt x 4)) (* 25 (expt x 3)) (* 15 (expt x 2)) x)]
+         (map #(-> (p/touchard %)
+                   (p/->expression ['x])
+                   (v/freeze))
+              (range -1 6)))
+      "Touchard matches examples from https://mathworld.wolfram.com/BellPolynomial.html"))
+
 (deftest arithmetic-tests
   (let [coeffs (gen/fmap #(g/modulo % 1000) sg/small-integral)]
     (testing "algebraic laws"

--- a/test/sicmutils/series_test.cljc
+++ b/test/sicmutils/series_test.cljc
@@ -516,7 +516,19 @@
 
   (testing "catalan numbers"
     (is (= [1 1 2 5 14 42 132 429 1430 4862]
-           (take 10 s/catalan-series)))))
+           (take 10 s/catalan-series))))
+
+  (testing "harmonic numbers"
+    (is (= [1
+            #sicm/ratio 3/2
+            #sicm/ratio 11/6
+            #sicm/ratio 25/12
+            #sicm/ratio 137/60]
+           (take 5 s/harmonic-series))))
+
+  (testing "bell numbers"
+    (is (= [1 2 5 15 52 203 877 4140 21147 115975]
+           (take 10 s/bell-series)))))
 
 (deftest series-identity-tests
   (is (->> (g/- s/sin-series

--- a/test/sicmutils/special/factorial_test.cljc
+++ b/test/sicmutils/special/factorial_test.cljc
@@ -286,4 +286,8 @@
 
   (testing "Stirling, second kind"
     (is (= 1 (sf/stirling-second-kind 0 0)))
-    (is (= 25 (sf/stirling-second-kind 5 3)))))
+    (is (= 25 (sf/stirling-second-kind 5 3))))
+
+  (testing "Bell numbers"
+    (is (= [1 1 2 5 15 52 203 877 4140 21147 115975]
+           (map sf/bell (range 11))))))


### PR DESCRIPTION
- #468:

  - adds `sicmutils.polynomial/touchard`, implementing a constructor for the
    type of polynomial known as a "complete Bell polynomial" or ["Touchard
    polynomial"](https://en.wikipedia.org/wiki/Touchard_polynomials).

  - adds `sicmutils.special.factorial/bell` for computing the nth [Bell
    number](https://en.wikipedia.org/wiki/Bell_number)

  - `sicmutils.series/bell-series` returns an infinite sequence of Bell numbers.