### PR TITLE
Complex GCD tests, install generic implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [unreleased]
 
+- #471:
+
+  - installs the complex GCD implementation into the generic system and modifies
+    it to work with real/complex pairs.
+
+  - tweaks the default gcd implementation so that two identical values `x`, even
+    if they are floating point, will return `x` from `(gcd x x)`. (Really this
+    should check on their absolute values...)
+
+- #398 adds a `sicmutils.generic/gcd` implementation for complex numbers,
+  closing the long-standing #58. Thanks to @adamhaber for this!
+
 - #461 adds `sicmutils.quaternion`, with a full arithmetic implementation and
   the beginnings of a rotation API. Quaternions are implemented like vectors of
   length 4, and implement all appropriate Clojure protocols. All arithmetic is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@
     it to work with real/complex pairs.
 
   - tweaks the default gcd implementation so that two identical values `x`, even
-    if they are floating point, will return `x` from `(gcd x x)`. (Really this
-    should check on their absolute values...)
+    if they are floating point, will return `x` from `(gcd x x)`. (default gcd
+    in `sicmutils.euclid` can handle cases now where the terms are equal and of
+    opposite sign.)
+
+  - adds `exact-divide` handling of non-integral numbers when the inputs are
+    either equal or of opposite sign.
 
 - #398 adds a `sicmutils.generic/gcd` implementation for complex numbers,
   closing the long-standing #58. Thanks to @adamhaber for this!

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -206,6 +206,19 @@
 
 ;; ## Complex GCD
 
+(defn ^:no-doc abs-real
+  "Returns a complex or real number with a positive real component. (ie, either z
+  or (* -1 z)), whichever number has a positive real component."
+  [z]
+  (cond (complex? z)
+        (if (neg? (real z))
+          (g/negate z)
+          z)
+
+        (v/real? z) (Math/abs z)
+
+        :else (u/illegal "not supported!")))
+
 (defn ^:no-doc gcd
   "Returns the complex gcd of two complex numbers using the euclidean algorithm.
 
@@ -217,7 +230,7 @@
   [l r]
   (cond (v/zero? l) r
         (v/zero? r) l
-        (v/= l r)   l
+        (v/= l r)   (abs-real l)
         (not (or (gaussian-integer? l)
                  (gaussian-integer? r)))
         (u/illegal "gcd can only be computed for gaussian integers, but
@@ -236,8 +249,9 @@
                             [l r] [r l])]
                 (loop [a (round l)
                        b (round r)]
-                  (if (v/zero? b) a
-                      (recur b (g/sub a (g/mul (round (g/div a b)) b))))))))
+                  (if (v/zero? b)
+                    (abs-real a)
+                    (recur b (g/sub a (g/mul (round (g/div a b)) b))))))))
 
 ;; ## Generic Method Installation
 

--- a/src/sicmutils/euclid.cljc
+++ b/src/sicmutils/euclid.cljc
@@ -50,7 +50,10 @@
   [a b]
   (cond (v/zero? a) (g/abs b)
         (v/zero? b) (g/abs a)
-        (= a b)     (g/abs a)
+
+        (or (v/= a b) (v/= a (g/negate b)))
+        (g/abs a)
+
         (not (and (v/integral? a) (v/integral? b))) 1
         :else (loop [a (g/abs a) b (g/abs b)]
                 (if (v/zero? b)

--- a/src/sicmutils/euclid.cljc
+++ b/src/sicmutils/euclid.cljc
@@ -50,37 +50,14 @@
   [a b]
   (cond (v/zero? a) (g/abs b)
         (v/zero? b) (g/abs a)
+        (= a b)     (g/abs a)
         (not (and (v/integral? a) (v/integral? b))) 1
         :else (loop [a (g/abs a) b (g/abs b)]
                 (if (v/zero? b)
                   a
                   (recur b (g/remainder a b))))))
 
-(defn round-complex [z]
-  "Rounds a complex number the closest complex number whose real and imaginary parts are both integers.
-   See [Gaussian integer](https://en.wikipedia.org/wiki/Gaussian_integer)."
-  (c/complex (Math/round (g/real-part z))
-             (Math/round (g/imag-part z))))
-
-(defn is-gaussian-integer [a]
-  (and (v/almost-integral? (g/real-part a)) (v/almost-integral? (g/imag-part a))))
-
-(defn gcd-complex [a b]
-  "Returns the complex gcd of two complex numbers using the euclidean algorithm.
-   For more details on the algorithm, see:
-   https://web.archive.org/web/20190720160400/http://mathforum.org/library/drmath/view/67068.html
-   Note that the GCD of two complex numbers is determinet up to a factor of ±1 and ±i."
-  (cond (v/zero? a) b
-        (v/zero? b) a
-        (not (or (is-gaussian-integer a) (is-gaussian-integer b))) (throw (Exception. "gcd-complex can only be computed for gaussian integers, but both arguments were not."))
-        (not (is-gaussian-integer a)) (throw (Exception. "gcd-complex can only be computed for gaussian integers, but first argument was not."))
-        (not (is-gaussian-integer b)) (throw (Exception. "gcd-complex can only be computed for gaussian integers, but second argument was not."))
-        :else (let [[a b] (if (< (g/magnitude a) (g/magnitude b)) [a b] [b a])]
-                (loop [a (round-complex a)
-                       b (round-complex b)]
-                  (if (v/zero? b) a
-                      (recur b (g/- a (g/* (round-complex (g// a b)) b))))))))
-
 ;; multimethod implementation for basic numeric types.
+
 (defmethod g/gcd :default [a b]
   (gcd a b))

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -180,8 +180,10 @@
 
 (defmethod g/exact-divide [::v/integral ::v/integral] [b a] (exact-divide b a))
 (defmethod g/exact-divide [::v/scalar ::v/real] [b a]
-  (cond (= a b) (v/one-like a)
-        (v/one? a) b
+  (cond (= a b)               (v/one-like a)
+        (= a (g/negate b))    (g/negate (v/one-like a))
+        (v/one? a)            b
+        (v/one? (g/negate a)) (g/negate b)
         :else (u/illegal
                (str "exact not allowed: " b ", " a))))
 

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -362,8 +362,8 @@
               (is (fourth-power-is-one? (g/gcd (c/complex 1 0) (c/round z)))))
 
     (testing "gcd when args are equal"
-      (is (= (complex 12.2 0)
-             (g/gcd (complex 12.2 0) 12.2))
+      (is (= (c/complex 12.2 0)
+             (g/gcd (c/complex 12.2 0) 12.2))
           "if args are v/= floating point input is okay")
 
       (is (= (c/complex 0 2)

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -344,12 +344,14 @@
 
 (deftest gcd-tests
   (testing "gcd-complex"
-    (checking "GCD of anything with itself is itself." 100
+    (checking "GCD of anything with itself is itself (up to sign)" 100
               [z sg/complex]
               (let [gaussian-z (c/round z)]
-                (is (= gaussian-z (g/gcd gaussian-z gaussian-z))))
+                (is (= (c/abs-real gaussian-z)
+                       (g/gcd gaussian-z gaussian-z))))
 
-              (is (= z (g/gcd z z))
+              (is (= (c/abs-real z)
+                     (g/gcd z z))
                   "also true for non-gaussians, only in this case!"))
 
     (checking "GCD of anything with 0 is itself, also for non-gaussian complex
@@ -384,6 +386,12 @@
                 (let [gaussian-l (c/round l)
                       gaussian-r (c/round r)
                       z (g/gcd gaussian-l gaussian-r)]
+                  (when-not (or (v/zero? gaussian-l)
+                                (v/zero? gaussian-r))
+                    (is (not (neg? (g/real-part z)))
+                        "real part of the GCD is always positive, unless either
+                        side to gcd is 0."))
+
                   (check gaussian-l gaussian-r)
                   (check (g/real-part gaussian-l) gaussian-r)
                   (check gaussian-l (g/real-part gaussian-r)))))))

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -332,6 +332,62 @@
     (testing "arithmetic"
       (is (v/numerical? c/I)))))
 
+(defn fourth-power-is-one?
+  "Checks if x^4 is 1+0i. This is needed because the gcd-complex function returns
+   solutions that are determined up to a factor of ±1 and ±i."
+  [x]
+  (let [x4 (g/expt x 4)
+        re (g/real-part x4)
+        im (g/imag-part x4)]
+    (and (ish? re 1)
+         (ish? im 0))))
+
+(deftest gcd-tests
+  (testing "gcd-complex"
+    (checking "GCD of anything with itself is itself." 100
+              [z sg/complex]
+              (let [gaussian-z (c/round z)]
+                (is (= gaussian-z (g/gcd gaussian-z gaussian-z))))
+
+              (is (= z (g/gcd z z))
+                  "also true for non-gaussians, only in this case!"))
+
+    (checking "GCD of anything with 0 is itself, also for non-gaussian complex
+              numbers (by definition)" 100 [z sg/complex]
+              (is (= z (g/gcd z (c/complex 0 0))))
+              (is (= z (g/gcd (c/complex 0 0) z))))
+
+    (checking "GCD of anything with 1 is 1." 100 [z sg/complex]
+              (is (fourth-power-is-one? (g/gcd (c/round z) (c/complex 1 0))))
+              (is (fourth-power-is-one? (g/gcd (c/complex 1 0) (c/round z)))))
+
+    (testing "gcd when args are equal"
+      (is (= (complex 12.2 0)
+             (g/gcd (complex 12.2 0) 12.2))
+          "if args are v/= floating point input is okay")
+
+      (is (= (c/complex 0 2)
+             (g/gcd (c/complex 24 2) 12)
+             (g/gcd 12 (c/complex 24 2)))
+          "complex + real"))
+
+    (letfn [(check [l r]
+              (let [z (g/gcd l r)]
+                (if (v/zero? z)
+                  (is (and (v/zero? l)
+                           (v/zero? r)))
+                  (is (fourth-power-is-one?
+                       (g/gcd (g// l z)
+                              (g// r z)))))))]
+      (checking "dividing out the GCD gives coprime results" 100
+                [l sg/complex r sg/complex]
+                (let [gaussian-l (c/round l)
+                      gaussian-r (c/round r)
+                      z (g/gcd gaussian-l gaussian-r)]
+                  (check gaussian-l gaussian-r)
+                  (check (g/real-part gaussian-l) gaussian-r)
+                  (check gaussian-l (g/real-part gaussian-r)))))))
+
 (deftest trig-tests
   (testing "sin"
     (is (near (g/sin (c/complex 10))

--- a/test/sicmutils/euclid_test.cljc
+++ b/test/sicmutils/euclid_test.cljc
@@ -50,7 +50,13 @@
       (is (= 1 (e/gcd 8 7)))
       (is (= 1 (e/gcd -8 7) 1))
       (is (= 1 (e/gcd 8 -7) 1))
-      (is (= 1 (e/gcd -8 -7) 1))))
+      (is (= 1 (e/gcd -8 -7) 1))
+
+      (testing "EQUAL floats, each sign combo causes identity result"
+        (is (= 1.2 (e/gcd -1.2 1.2)))
+        (is (= 1.2 (e/gcd -1.2 -1.2)))
+        (is (= 1.2 (e/gcd 1.2 -1.2)))
+        (is (= 1.2 (e/gcd 1.2 1.2))))))
 
   (testing "generic-gcd"
     (is (= (* 2 5 7) (g/gcd (* 2 3 5 7) (* 2 5 7 11))))

--- a/test/sicmutils/euclid_test.cljc
+++ b/test/sicmutils/euclid_test.cljc
@@ -40,16 +40,6 @@
          (= g (g/+ (g/* a x) (g/* b y)))
          g)))
 
-(defn ^:private fourth-power-is-one?
-  "Checks if x^4 is 1+0i. This is needed because the gcd-complex function returns
-   solutions that are determined up to a factor of ±1 and ±i."
-  [x]
-  (let [x4 (g/expt x 4)
-        re (g/real-part x4)
-        im (g/imag-part x4)]
-    (and (ish? re 1)
-         (ish? im 0))))
-
 (deftest euclid-test
   (testing "gcd"
     (let [gcd (fn [x y] (first (e/extended-gcd x y)))]
@@ -78,30 +68,6 @@
     (is (= [2 -9 47] (e/extended-gcd 240 46)))
     (is (= [2 1 0] (e/extended-gcd 2 4))))
 
-  (testing "gcd-complex"
-    (checking "GCD of anything with itself is itself."
-              10 [z sg/complex]
-              (let [gaussian-z (e/round-complex z)]
-                (is (= gaussian-z (e/gcd-complex gaussian-z gaussian-z)))))
-
-    (checking "GCD of anything with 0 is itself, also for non-gaussian complex numbers (by definition)"
-              10 [z sg/complex]
-              (is (= z (e/gcd-complex z (c/complex 0 0))))
-              (is (= z (e/gcd-complex (c/complex 0 0) z))))
-
-    (checking "GCD of anything with 1 is 1."
-              10 [z sg/complex]
-              (is (fourth-power-is-one? (e/gcd-complex (e/round-complex z) (c/complex 1 0))))
-              (is (fourth-power-is-one? (e/gcd-complex (c/complex 1 0) (e/round-complex z)))))
-
-    (checking "dividing out the GCD gives coprime results"
-              10 [l sg/complex r sg/complex]
-              (let [gaussian-l (e/round-complex l)
-                    gaussian-r (e/round-complex r)
-                    z (e/gcd-complex gaussian-l gaussian-r)]
-                (is (fourth-power-is-one? (e/gcd-complex
-                                           (g// gaussian-l z)
-                                           (g// gaussian-r z)))))))
   (testing "lcm"
     (is (= 21 (g/lcm 3 7)))
     (is (= 6 (g/lcm 2 6)))

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -419,6 +419,10 @@
                 (is (= 1 (g/gcd 1 x)))
                 (is (= 1 (g/gcd x 1)))))
 
+    (checking "gcd identities even with real" 100 [x sg/real]
+              (is (= (g/abs x)
+                     (g/gcd x x))))
+
     (letfn [(nonzero [g]
               (gen/fmap (fn [x]
                           (let [small (g/remainder x 10000)]

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -446,7 +446,13 @@
                   (is (= (g/abs z) g)))))
 
     (testing "lcm"
-      (is (zero? (g/lcm 0 0))))))
+      (is (zero? (g/lcm 0 0))))
+
+    (testing "exact-divide floats"
+      (is (= -1.0 (g/exact-divide 1.2 -1.2)))
+      (is (= 1.0 (g/exact-divide -1.2 -1.2)))
+      (is (= -1.0 (g/exact-divide -1.2 1.2)))
+      (is (= 1.0 (g/exact-divide 1.2 1.2))))))
 
 (deftest numeric-trig-tests
   (testing "trig"

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -443,7 +443,11 @@
                   (is (not (g/negative? gxy)))
                   (is (= x (g/exact-divide xz g)))
                   (is (= y (g/exact-divide yz g)))
-                  (is (= (g/abs z) g)))))
+                  (is (= (g/abs z) g))
+
+                  (testing "1, -1 on right is id or negate"
+                    (is (= z (g/exact-divide z 1)))
+                    (is (= (- z) (g/exact-divide z -1)))))))
 
     (testing "lcm"
       (is (zero? (g/lcm 0 0))))


### PR DESCRIPTION
- #471:

  - installs the complex GCD implementation into the generic system and modifies
    it to work with real/complex pairs.

  - tweaks the default gcd implementation so that two identical values `x`, even
    if they are floating point, will return `x` from `(gcd x x)`. (Really this
    should check on their absolute values...)