### PR TITLE
Allow quotient between inexact equal floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- #474:
+
   - `g/quotient` now supports inexact inputs, as LONG as the inputs are equal up
     to sign. So `(g/quotient 1.2 -1.2)` now returns `-1` instead of throwing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [unreleased]
 
+  - `g/quotient` now supports inexact inputs, as LONG as the inputs are equal up
+    to sign. So `(g/quotient 1.2 -1.2)` now returns `-1` instead of throwing.
+
 - #469:
 
   - `sicmutils.matrix` gains:

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -1123,8 +1123,7 @@
 
         :else
         (letfn [(coeff:div [l r]
-                  (if (= l r)
-                    [(g/quotient l r) (g/remainder l r)]))]
+                  [(g/quotient l r) (g/remainder l r)])]
           (binary-combine u v coeff:div i/div
                           :->poly
                           (fn [a [q r]]

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -1123,7 +1123,8 @@
 
         :else
         (letfn [(coeff:div [l r]
-                  [(g/quotient l r) (g/remainder l r)])]
+                  (if (= l r)
+                    [(g/quotient l r) (g/remainder l r)]))]
           (binary-combine u v coeff:div i/div
                           :->poly
                           (fn [a [q r]]

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -386,6 +386,37 @@
               (is (ish? (g/modulo x y)
                         (g/remainder x y))))
 
+    (testing "quotient, exact-divide error when exact results aren't possible"
+      (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+                   (g/exact-divide 4 1.2)))
+
+      (is (thrown? #?(:clj IllegalArgumentException :cljs js/Error)
+                   (g/quotient 4 1.2))))
+
+    (checking "quotient, remainder with floats" 100
+              [x (gen/such-that (complement v/zero?) sg/real)]
+              (is (= (g/quotient x x)
+                     (g/exact-divide x x))
+                  "exact-divide is fine if passed identical inputs")
+
+              (is (v/= 1 (g/quotient x x))
+                  "x/x == 1")
+
+              (is (v/= 1 (g/quotient (- x) (- x)))
+                  "-x/-x == 1")
+
+              (is (v/= -1 (g/quotient (- x) x))
+                  "-x/x == -1")
+
+              (is (v/= -1 (g/quotient x (- x)))
+                  "x/-x == -1")
+
+              (testing "remainder"
+                (is (v/zero? (g/remainder x x)))
+                (is (v/zero? (g/remainder x (- x))))
+                (is (v/zero? (g/remainder (- x) (- x))))
+                (is (v/zero? (g/remainder (- x) x)))))
+
     (checking "x == y*quot(x,y) + rem(x,y)" 100
               [x (gen-integer 1e4)
                y (nonzero (gen-integer 1e4))]

--- a/test/sicmutils/quaternion_test.cljc
+++ b/test/sicmutils/quaternion_test.cljc
@@ -454,6 +454,13 @@
                    (g/simplify  (g/solve-linear-right x s)))
                 "solve-linear-right scalar matches q*q"))
 
+  (testing "unit tests from failed generative"
+    (let [c #sicm/complex [-1.0 -2.0]
+          x #sicm/quaternion ['a 'b 'c 'd]]
+      (is (= (g/simplify (g/solve-linear (q/make c) x))
+             (g/simplify (g/solve-linear c x)))
+          "solve-linear complex matches q*q unit")))
+
   (checking "complex + quaternion arithmetic matches quaternion-only
             implementations." 100
             [c sg/complex x (sg/quaternion sg/symbol)]


### PR DESCRIPTION
- #474:

  - `g/quotient` now supports inexact inputs, as LONG as the inputs are equal up
    to sign. So `(g/quotient 1.2 -1.2)` now returns `-1` instead of throwing.