### PR TITLE
Repro of clj-kondo keyword override failure

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,7 @@
 {:config-in-comment
- {:linters {:unresolved-symbol {:level :off}}}
+ {:linters
+  {:unresolved-symbol {:level :off}
+   :sicmutils.pattern/ruleset-args {:level :warning}}}
 
  :config-paths ["../resources/clj-kondo.exports/sicmutils/sicmutils"
                 "com.gfredericks/test.chuck"]

--- a/src/pattern/rule.cljc
+++ b/src/pattern/rule.cljc
@@ -578,3 +578,11 @@
   "Alias for [[rule-simplifier]]."
   [& rules]
   (apply rule-simplifier rules))
+
+;; Here's a repro. Neither the following form, nor the config change, seem to
+;; affect the custom linter.
+
+#_{:clj-kondo/ignore [:sicmutils.rule/ruleset-args]}
+(ruleset
+ (+ (? x) (? y))
+ (fn [m] (- ('?x m) ('?y m))))


### PR DESCRIPTION
Clone the project and try

```
clj-kondo --lint src/pattern/rule.cljc
```

I see:

```
src/pattern/rule.cljc:586:2: error: ruleset requires bindings in groups of 3. Received 2 bindings.
linting took 325ms, errors: 1, warnings: 0
```

I don't seem to be able to disable or modify the warning in my config, or with an inline `#_:kondo/ignore` marker.