### PR TITLE
Fix CLJS bug with non-compiled definite integrals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [0.21.0]
 
+- #
+
+  - `sicmutils.numerical.quadrature/definite-integral` now coerces the result of
+    non-compiled integrands in cljs to double. This prevents the @kloimhardt bug
+    where certain paths would produce `BigInt` instances and fail in quadrature
+    calls.
+
 - #477:
 
   - Adds tight integration with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## [0.21.0]
 
-- #
-
-  - `sicmutils.numerical.quadrature/definite-integral` now coerces the result of
-    non-compiled integrands in cljs to double. This prevents the @kloimhardt bug
-    where certain paths would produce `BigInt` instances and fail in quadrature
-    calls.
+- #480: `sicmutils.numerical.quadrature/definite-integral` now coerces the
+  result of non-compiled integrands in cljs to double. This prevents the
+  @kloimhardt bug where certain paths would produce `BigInt` instances and fail
+  in quadrature calls.
 
 - #477:
 

--- a/src/sicmutils/numerical/quadrature.cljc
+++ b/src/sicmutils/numerical/quadrature.cljc
@@ -185,7 +185,10 @@
                 info? false}
            :as opts}]
    (if-let [[integrate m] (get-integrator method a b opts)]
-     (let [f      (if compile? (c/compile-fn f 1) f)
+     (let [f      (if compile?
+                    (c/compile-fn f 1)
+                    #?(:cljs (comp u/double f)
+                       :clj f))
            result (integrate f a b m)]
        (if info? result (:result result)))
      (u/illegal (str "Unknown method: " method

--- a/test/sicmutils/mechanics/lagrange_test.cljc
+++ b/test/sicmutils/mechanics/lagrange_test.cljc
@@ -114,9 +114,9 @@
 (deftest action-tests
   (letfn [(path
             [t]
-            (s/up (s/+ (s/* 1 t) 7)
-                  (s/+ (s/* 3 t) 5)
-                  (s/+ (s/* 2 t) 1)))]
+            (up (g/+ (g/* 1 t) 7)
+                (g/+ (g/* 3 t) 5)
+                (g/+ (g/* 2 t) 1)))]
     (is (= 210 (L/Lagrangian-action
                 (L/L-free-particle 3) path 0 10))
         "Fixes a bug where non-compiled functions in CLJS would kick out

--- a/test/sicmutils/mechanics/lagrange_test.cljc
+++ b/test/sicmutils/mechanics/lagrange_test.cljc
@@ -111,6 +111,17 @@
             (simplify
              (m/s->m vs (((g/expt D 2) L1) vs) vs)))))))
 
+(deftest action-tests
+  (letfn [(path
+            [t]
+            (s/up (s/+ (s/* 1 t) 7)
+                  (s/+ (s/* 3 t) 5)
+                  (s/+ (s/* 2 t) 1)))]
+    (is (= 210 (L/Lagrangian-action
+                (L/L-free-particle 3) path 0 10))
+        "Fixes a bug where non-compiled functions in CLJS would kick out
+        BigInts, or some other non-quadrature-compatible numeric type.")))
+
 (deftest lagrange-equations
   (testing "moved-from-simplify"
     (let [xy (up (f/literal-function 'x) (f/literal-function 'y))

--- a/test/sicmutils/mechanics/lagrange_test.cljc
+++ b/test/sicmutils/mechanics/lagrange_test.cljc
@@ -19,6 +19,7 @@
 
 (ns sicmutils.mechanics.lagrange-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]
+            [same :refer [ish?] #?@(:cljs [:include-macros true])]
             [sicmutils.abstract.function :as f #?@(:cljs [:include-macros true])]
             [sicmutils.calculus.derivative :refer [D]]
             [sicmutils.generic :as g]
@@ -117,8 +118,9 @@
             (up (g/+ (g/* 1 t) 7)
                 (g/+ (g/* 3 t) 5)
                 (g/+ (g/* 2 t) 1)))]
-    (is (= 210 (L/Lagrangian-action
-                (L/L-free-particle 3) path 0 10))
+    (is (ish? 210
+              (L/Lagrangian-action
+               (L/L-free-particle 3) path 0 10))
         "Fixes a bug where non-compiled functions in CLJS would kick out
         BigInts, or some other non-quadrature-compatible numeric type.")))
 


### PR DESCRIPTION
Thanks to @kloimhardt for the repro here: https://github.com/kloimhardt/babashka-snipets

- #480: `sicmutils.numerical.quadrature/definite-integral` now coerces the
  result of non-compiled integrands in cljs to double. This prevents the
  @kloimhardt bug where certain paths would produce `BigInt` instances and fail
  in quadrature calls.