### PR TITLE
Get Clerk working for many namespaces

### DIFF
--- a/.github/workflows/cljs.yaml
+++ b/.github/workflows/cljs.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node.js for cljs
-        uses: actions/setup-node@v2.1.1
+        uses: actions/setup-node@v2
         with:
           node-version: '16'
 

--- a/.github/workflows/cljs.yaml
+++ b/.github/workflows/cljs.yaml
@@ -13,11 +13,14 @@ jobs:
 
       - name: Setup Node.js for cljs
         uses: actions/setup-node@v2.1.1
-
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          node-version: '16'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,10 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: '17'
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.github/workflows/kondo.yml
+++ b/.github/workflows/kondo.yml
@@ -12,6 +12,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
       - name: Install clj-kondo
         run: sudo ./bin/install-clj-kondo
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: '17'
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,10 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: '17'
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 package-lock.json
 public/
 .clj-kondo/.cache
+.clerk/cache

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ node_modules
 package-lock.json
 public/
 .clj-kondo/.cache
-.clerk/cache
+.clerk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## unreleased
 
+- #485:
+
+  - Bumps the JDK version for Github Actions to 17 from 8.
+
+  - Adds a development dependency on Nextjournal's
+    [Clerk](https://github.com/nextjournal/clerk) library, and begins the
+    process of massaging various namespaces into proper literate essays
+    display-able with Clerk. To run these, start a REPL and follow the
+    instructions in `dev/user.clj`.
+
+    - `sicmutils.calculus.derivative` and `sicmutils.differential` are now
+
+  - Bumps the shadow-cljs dependency to version `2.17.4`, and the included
+    `cljs` version to `1.11.4`. `sicmutils.collection` properly handles the new
+    cljs `IntegerRange` class.
+
+  - `sicmutils.polynomial.factor` now memoizes `poly->factored-expression` by
+    default. If polynomial GCD fails inside that function the computation now
+    proceeds with a warning instead of failing.
+
 - #492 updates the `clj-kondo` linters to emit custom warnings with _all_
   metadata from the original token, not just `:row` and `:col`. This fixes the
   ability to override or ignore individual warnings.

--- a/demo.clj
+++ b/demo.clj
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.demo
   (:refer-clojure :exclude [+ - * / zero? ref compare])

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,11 @@
 {:aliases
- {:clj-kondo
+ {:dev
+  {:extra-paths ["dev"]
+   :extra-deps
+   {io.github.nextjournal/clerk
+    {:git/sha "a44f021a5f90defe877f3cfec81e164a844f7b39"}}}
+
+  :clj-kondo
   {:replace-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}
    :main-opts ["-m" "clj-kondo.main"]}}
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,12 @@
+(ns user)
+#_#_(ns user
+      (:require [nextjournal.clerk :as clerk]
+                [sicmutils.env]))
+
+(clerk/serve!
+ {:browse? true :port 7778})
+
+(comment
+  ;; call clerk/show on files to be rendered
+  (clerk/show! "src/sicmutils/calculus/derivative.cljc")
+  (clerk/show! "src/sicmutils/differential.cljc"))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -2,8 +2,9 @@
   (:require [nextjournal.clerk :as clerk]
             [sicmutils.env]))
 
-(clerk/serve!
- {:browse? true :port 7778})
+(comment
+  (clerk/serve!
+   {:browse? true :port 7778}))
 
 (comment
   ;; call clerk/show on files to be rendered

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,7 +1,6 @@
-(ns user)
-#_#_(ns user
-      (:require [nextjournal.clerk :as clerk]
-                [sicmutils.env]))
+(ns user
+  (:require [nextjournal.clerk :as clerk]
+            [sicmutils.env]))
 
 (clerk/serve!
  {:browse? true :port 7778})

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -3,10 +3,11 @@
             [sicmutils.env]))
 
 (comment
+  ;; Activate this line to start the clerk server.
   (clerk/serve!
    {:browse? true :port 7778}))
 
 (comment
-  ;; call clerk/show on files to be rendered
+  ;; call clerk/show on files to be rendered:
   (clerk/show! "src/sicmutils/calculus/derivative.cljc")
   (clerk/show! "src/sicmutils/differential.cljc"))

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -73,7 +73,7 @@ Imported config to .clj-kondo/sicmutils/sicmutils. To activate, add "sicmutils/s
 5. As instructed, either create or edit `.clj-kondo/config.edn` so that it contains a `:config-paths` entry with `"sicmutils/sicmutils"`:
 
 ```clj
-{:config-paths ["clj-kondo/claypoole"]}
+{:config-paths ["sicmutils/sicmutils"]}
 ```
 
 6. Check the imported files into source control in your project.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "complex.js": "^2.0.11",
     "fraction.js": "^4.0.12",
     "odex": "^2.0.4",
-    "shadow-cljs": "2.11.6"
+    "shadow-cljs": "2.17.4"
   },
   "engines": {
     "npm": "6.14.8"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "npm": "6.14.8"
   },
   "devDependencies": {
+    "markdown-it": "12.2.0",
+    "markdown-it-block-image": "0.0.3",
+    "markdown-it-sidenote": "github:gerwitz/markdown-it-sidenote",
+    "markdown-it-texmath": "0.9.1",
+    "markdown-it-toc-done-right": "4.2.0",
     "source-map-support": "^0.5.20"
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (defproject sicmutils "0.21.1"
   :description "A port of the scmutils computer algebra/mechanics system to Clojure."

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
   :license {:name "GPLv3"
             :url "http://www.opensource.org/licenses/GPL-3.0"}
   :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
-                 [org.clojure/clojurescript "1.10.773" :scope "provided"]
+                 [org.clojure/clojurescript "1.11.4" :scope "provided"]
                  [org.clojure/core.match "1.0.0"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [borkdude/sci "0.2.7"]
@@ -48,16 +48,19 @@
                    :benchmark :benchmark}
   :profiles {:dev
              {:plugins [[lein-cloverage "1.2.1"]]
+              :source-paths ["dev"]
               :jvm-opts ["-Xms6g" "-Xmx8g" "-server"]
               :repl-options {:nrepl-middleware
                              [cider.piggieback/wrap-cljs-repl]}
               :dependencies [[org.clojure/test.check "1.1.0"]
-                             [cider/piggieback "0.5.0"]
+                             [cider/piggieback "0.5.3"]
                              [com.taoensso/tufte "2.2.0"]
                              [com.gfredericks/test.chuck "0.2.13"]
-                             [nrepl "0.7.0"]
+                             [io.github.nextjournal/clerk "0.5.346"
+                              :exclusions [org.clojure/tools.deps.alpha]]
+                             [nrepl "0.9.0"]
                              [same/ish "0.1.4"]
-                             [thheller/shadow-cljs "2.11.6"]]}}
+                             [thheller/shadow-cljs "2.17.4"]]}}
   :deploy-repositories [["clojars"
                          {:url "https://repo.clojars.org"
                           :username :env/clojars_username

--- a/src/pattern/consequence.cljc
+++ b/src/pattern/consequence.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns pattern.consequence
   "Code for defining and compiling 'consequence' functions, ie, functions from a

--- a/src/pattern/match.cljc
+++ b/src/pattern/match.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns pattern.match
   "Implementation of a pattern matching system inspired by [Gerald Jay Sussman's

--- a/src/pattern/rule.cljc
+++ b/src/pattern/rule.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns pattern.rule
   "This namespace provides an API for building rules out of the matchers and

--- a/src/pattern/syntax.cljc
+++ b/src/pattern/syntax.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns pattern.syntax
   "The syntax namespace defines the default syntax for patterns corresponding to

--- a/src/sicmutils/abstract/function.cljc
+++ b/src/sicmutils/abstract/function.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.abstract.function
   "Implementation of a [[literal-function]] constructor. Literal functions can be

--- a/src/sicmutils/abstract/number.cljc
+++ b/src/sicmutils/abstract/number.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.abstract.number
   "Symbolic expressions in SICMUtils are created through the [[literal-number]]

--- a/src/sicmutils/algebra/fold.cljc
+++ b/src/sicmutils/algebra/fold.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2022 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.algebra.fold
   "Namespace implementing various aggregation functions using the `fold`

--- a/src/sicmutils/calculus/basis.cljc
+++ b/src/sicmutils/calculus/basis.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.basis
   (:require [sicmutils.calculus.form-field :as ff]

--- a/src/sicmutils/calculus/connection.cljc
+++ b/src/sicmutils/calculus/connection.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.connection
   (:require [sicmutils.calculus.basis :as b]

--- a/src/sicmutils/calculus/coordinate.cljc
+++ b/src/sicmutils/calculus/coordinate.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.coordinate
   (:require [sicmutils.calculus.form-field :as ff]

--- a/src/sicmutils/calculus/covariant.cljc
+++ b/src/sicmutils/calculus/covariant.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.covariant
   (:require [sicmutils.calculus.basis :as b]

--- a/src/sicmutils/calculus/curvature.cljc
+++ b/src/sicmutils/calculus/curvature.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.curvature
   (:require [sicmutils.calculus.basis :as b]

--- a/src/sicmutils/calculus/derivative.cljc
+++ b/src/sicmutils/calculus/derivative.cljc
@@ -49,20 +49,20 @@
 ;;
 ;; How do we interpret the case where `((D f) x)` produces a _function_?
 ;;
-;; [Manzyuk et al. 2019](https://arxiv.org/pdf/1211.4892.pdf) extends =D= to
-;; functions =f= of type $\mathbb{R}^n \rightarrow \alpha$, where
+;; [Manzyuk et al. 2019](https://arxiv.org/pdf/1211.4892.pdf) extends `D` to
+;; functions `f` of type $\mathbb{R}^n \rightarrow \alpha$, where
 ;;
 ;; $$\alpha::=\mathbb{R}^m \mid \alpha_{1} \rightarrow \alpha_{2}$$
 ;;
 ;; By viewing
 ;;
-;; - =f= as a (maybe curried) multivariable function that /eventually/ must
+;; - `f` as a (maybe curried) multivariable function that _eventually_ must
 ;;   produce an $\mathbb{R}^m$
-;; - The derivative =(D f)= as the partial derivative with respect to the first
-;;   argument of =f=
+;; - The derivative `(D f)` as the partial derivative with respect to the first
+;;   argument of `f`
 ;;
-;; A 3-level nest of functions will respond to =D= just like the flattened,
-;; non-higher-order version would respond to =(partial 0)=. In other words,
+;; A 3-level nest of functions will respond to `D` just like the flattened,
+;; non-higher-order version would respond to `(partial 0)`. In other words,
 ;; these two forms should evaluate to equivalent results:
 
 (comment
@@ -70,12 +70,14 @@
             (fn [y]
               (fn [z]
                 (g/* x y z))))]
-    ((((D f) 'x) 'y) 'z)))
-;;=> (* y z)
+    ((((D f) 'x) 'y) 'z))
+  ;;=> (* y z)
+  )
 
 (comment
-  (((partial 0) g/*) 'x 'y 'z))
-;;=> (* y z)
+  (((partial 0) g/*) 'x 'y 'z)
+  ;;=> (* y z)
+  )
 
 ;; To `extract-tangent` from a function, we need to compose the
 ;; `extract-tangent` operation with the returned function.
@@ -109,12 +111,12 @@
 ;; instances meet (multiply, say) - should final return value treat them as the
 ;; /same/ instance?
 ;;
-;; Manzyuk et al. says /NO!/. If `((D f) x)` returns a function, that function
+;; Manzyuk et al. says _NO!_. If `((D f) x)` returns a function, that function
 ;; closes over:
 ;;
 ;; - the value of `x`
 ;; - an _intention_ to start the derivative-taking process on that isolated copy
-;;   of =x= once the final argument is supplied.
+;;   of `x` once the final argument is supplied.
 ;;
 ;; How does the implementation keep the values separate?
 ;;

--- a/src/sicmutils/calculus/derivative.cljc
+++ b/src/sicmutils/calculus/derivative.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.derivative
   "This namespace implements a number of differential operators like [[D]], and

--- a/src/sicmutils/calculus/form_field.cljc
+++ b/src/sicmutils/calculus/form_field.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.form-field
   "This namespace implements a form field operator and a number of functions for

--- a/src/sicmutils/calculus/frame.cljc
+++ b/src/sicmutils/calculus/frame.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.frame
   (:require [sicmutils.util :as u]))

--- a/src/sicmutils/calculus/hodge_star.cljc
+++ b/src/sicmutils/calculus/hodge_star.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.hodge-star
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/calculus/indexed.cljc
+++ b/src/sicmutils/calculus/indexed.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.indexed
   "This namespace implements minimal support for indexed objects and typed

--- a/src/sicmutils/calculus/manifold.cljc
+++ b/src/sicmutils/calculus/manifold.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.manifold
   "This namespace defines a functional API for:

--- a/src/sicmutils/calculus/map.cljc
+++ b/src/sicmutils/calculus/map.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.map
   "Various definitions and utilities for working with maps between manifolds."

--- a/src/sicmutils/calculus/metric.cljc
+++ b/src/sicmutils/calculus/metric.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.metric
   (:require [sicmutils.calculus.basis :as b]

--- a/src/sicmutils/calculus/vector_calculus.cljc
+++ b/src/sicmutils/calculus/vector_calculus.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.vector-calculus
   "This namespace contains vector calculus operators, in versions built on top

--- a/src/sicmutils/calculus/vector_field.cljc
+++ b/src/sicmutils/calculus/vector_field.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.vector-field
   "This namespace implements a vector field operator and a number of functions for

--- a/src/sicmutils/collection.cljc
+++ b/src/sicmutils/collection.cljc
@@ -81,7 +81,8 @@
   (map g/simplify a))
 
 #_{:clj-kondo/ignore [:redundant-do]}
-(#?@(:clj [do] :cljs [doseq [klass [Cons IndexedSeq LazySeq List Range]]])
+(#?@(:clj [do]
+     :cljs [doseq [klass [Cons IndexedSeq LazySeq List Range IntegerRange]]])
  (extend-type #?(:clj ISeq :cljs klass)
    v/Value
    (zero? [_] false)

--- a/src/sicmutils/collection.cljc
+++ b/src/sicmutils/collection.cljc
@@ -1,21 +1,20 @@
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
 
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
 
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
 
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.collection
   "This namespace contains implementations of various SICMUtils protocols for

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.complex
   "This namespace provides a number of functions and constructors for working

--- a/src/sicmutils/differential.cljc
+++ b/src/sicmutils/differential.cljc
@@ -34,7 +34,7 @@
             [sicmutils.util.vector-set :as uv]
             [sicmutils.value :as v]))
 
-;; Differentials, Dual Numbers and Automatic Differentiation
+;; ## Differentials, Dual Numbers and Automatic Differentiation
 ;;
 ;; This namespace develops an implementation of a type called [[Differential]].
 ;; A [[Differential]] is a generalization of a type called a ["dual
@@ -165,7 +165,7 @@
 ;; series expansion of $f$, the $\varepsilon$ multiplication rule will erase all
 ;; higher-order terms, leaving us with:
 ;;
-;; $$f(x+x'\varepsilon, y+y'\varepsilon) = f(x,y) + \[\partial_1 f(x,y)x' + \partial_2 f(x,y)y'\]\varepsilon$$
+;; $$f(x+x'\varepsilon, y+y'\varepsilon) = f(x,y) + \left[\partial_1 f(x,y)x' + \partial_2 f(x,y)y'\right]\varepsilon$$
 ;;
 ;; NOTE: See [[lift-2]] for an implementation of this idea.
 ;;
@@ -197,7 +197,7 @@
 ;; $$
 ;; \begin{aligned}
 ;; (x+ x'\varepsilon)*(y+y'\epsilon) &= xy+(xy')\varepsilon+(x'y)\varepsilon+(x'y')\epsilon^2 \\
-;; &= xy+(xy'+y'x)\varepsilon
+;; &= xy+(xy'+x'y)\varepsilon
 ;; \end{aligned}
 ;; $$
 ;;
@@ -240,8 +240,8 @@
 ;; the `x` received by `inner-d` will ALREADY be a dual number $x+\varepsilon$!
 ;; This will cause two immediate problems:
 ;;
-;; - `(make-dual x 1)` will return $(x+\varepsilon)+\varepsilon =
-;;   x+2\varepsilon$, which is not what we we want
+;; - `(make-dual x 1)` will return $(x+\varepsilon)+\varepsilon = x+2\varepsilon$,
+;;    which is not what we we want
 
 ;; - The `extract-tangent` call inside `inner-d` will return the `Df(x)`
 ;;   component of the dual number... which, remember, is no longer a dual
@@ -310,18 +310,20 @@
         (g (+ x offset))))))
 
 ;; `(derivative offset-fn)` here returns a function! Manzyuk et al. 2019 makes
-;; the reasonable claim that, if =(f x)= returns a function, then =(derivative
-;; f)= should treat =f= as a multi-argument function with its first argument
+;; the reasonable claim that, if `(f x)` returns a function, then `(derivative
+;; f)` should treat `f` as a multi-argument function with its first argument
 ;; curried.
 ;;
-;; Let's say =f= takes a number =x= and returns a function =g= that maps number
-;; => number. =(((derivative f) x) y)= should act just like the partial
+;; Let's say `f` takes a number `x` and returns a function `g` that maps number
+;; => number. `(((derivative f) x) y)` should act just like the partial
 ;; derivative of the equivalent multi-argument function, with respect to the
 ;; first argument:
 ;;
-;; =(((partial 0) f-flattened) x y)=
+;;```clj
+;;(((partial 0) f-flattened) x y)
+;;```
 ;;
-;; In other words, =(derivative offset-fn)= should act just like:
+;; In other words, `(derivative offset-fn)` should act just like:
 
 (comment
   (derivative

--- a/src/sicmutils/differential.cljc
+++ b/src/sicmutils/differential.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.differential
   "This namespace contains an implementation of [[Differential]], a generalized

--- a/src/sicmutils/differential.cljc
+++ b/src/sicmutils/differential.cljc
@@ -16,6 +16,7 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this code; if not, see <http://www.gnu.org/licenses/>."
 
+^{:nextjournal.clerk/visibility #{:hide-ns}}
 (ns sicmutils.differential
   "This namespace contains an implementation of [[Differential]], a generalized
   dual number type that forms the basis for the forward-mode automatic

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.env
   "Batteries-included namespace for the [SICMUtils](https://github.com/sicmutils/sicmutils/) library.

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.env.sci
   (:refer-clojure :exclude [ns-map])

--- a/src/sicmutils/env/sci/macros.cljc
+++ b/src/sicmutils/env/sci/macros.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.env.sci.macros
   "This namespace contains reimplementations of various macros from sicmutils,

--- a/src/sicmutils/euclid.cljc
+++ b/src/sicmutils/euclid.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.euclid
   "Implementations of various [greatest common

--- a/src/sicmutils/examples/central_potential.cljc
+++ b/src/sicmutils/examples/central_potential.cljc
@@ -16,150 +16,53 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this code; if not, see <http://www.gnu.org/licenses/>."
 
-^{:nextjournal.clerk/visibility #{:hide-ns}}
 (ns sicmutils.examples.central-potential
   (:refer-clojure :exclude [+ - * /])
-  (:require [nextjournal.clerk :as clerk]
-            [sicmutils.env :as e :refer [abs square up + - * /]]
-            [taoensso.timbre :as log]))
-
-;; ## Central Potential!!
-;;
-;; This notebook implements this paper: https://arxiv.org/pdf/math/0011268.pdf
-;;
-;; Using a variational method, we exhibit a surprisingly simple periodic orbit
-;; for the newtonian problem of three equal masses in the plane.
-
-;; ### Simó's initial data
-
-;; $$
-;; x_1= −x_2 = 0.97000436−0.24308753i, \\
-;; x3=0; \\
-;; \vec{V} = \dot{x}_3 = −2\dot{x}_1 = −2\dot{x}_2 = −0.93240737−0.86473146i \\
-;; \bar{T} =12T =6.32591398, I(0)=2, m_1 = m_2 = m_3 = 1
-;; $$
-
-;; Note that we could have used [[sicmutils.util.permute/combinations]].
-;;
-;; TODO get this running, actually animating, in MathBox. Can we freaking do
-;; that? How awesome would that be? I think it will be possible... by opting in
-;; to the JS stuff.
+  (:require [sicmutils.env :as e :refer [abs square up + - * /]]
+            #?@(:clj
+                [[taoensso.timbre :as log]
+                 [hiccup.core :refer [html]]
+                 [hiccup.page :refer [html5]]])))
 
 (defn- pairs
-  "Return a sequence of each distinct pairing of different elements from the given
-  sequence."
+  "Return a sequence of pairs of different elements from the given sequence."
   [[x & xs]]
   (when xs
-    (concat (for [y xs] [x y])
-            (pairs xs))))
-
-;; for V we want each distinct pair, funky way to do it:
+    (concat
+     (for [y xs] [x y])
+     (pairs xs))))
 
 (defn V [& masses]
+  ;; for V we want each distinct pair
   (fn [[_ x _]]
-    (let [mass-position-pairs
-          (->> (partition 2 x)
-               (map (fn [m [x y]] [m (up x y)])
-                    masses)
-               (pairs))]
+    (let [mass-position-pairs (->> (partition 2 x)
+                                   (map (fn [m [x y]] [m (up x y)])
+                                        masses)
+                                   (pairs))]
       (reduce - 0 (map (fn [[[m1 p1] [m2 p2]]]
                          (/ (* m1 m2)
                             (abs (- p1 p2))))
                        mass-position-pairs)))))
 
-(defn T [& masses]
+(defn T
+  [& masses]
   (fn [[_ _ v]]
     (let [velocities (->> (partition 2 v)
                           (map (fn [[vx vy]]
                                  (up vx vy))))]
-      (apply + (map (fn [m v]
-                      (* (/ 1 2) m (square v)))
-                    masses
-                    velocities)))))
+      (reduce + (map (fn [m v]
+                       (* (/ 1 2) m (square v)))
+                     masses
+                     velocities)))))
 
 (def L (- T V))
 
-(def state-derivative
-  (comp e/Lagrangian->state-derivative L))
-
-(defn my-evolver
-  [kick {:keys [t dt]
-         :or {t 1 dt 1}}]
-  (let [initial-state (up 0.0
-                          (+ kick (up 0.97000436
-                                      -0.24308753
-                                      -0.97000436
-                                      0.24308753
-                                      0
-                                      0))
-                          (up (/ -0.93240737 -2)
-                              (/ -0.86473146 -2)
-                              (/ -0.93240737 -2)
-                              (/ -0.86473146 -2)
-                              -0.93240737
-                              -0.86473146))]
-    (e/integrate-state-derivative
-     state-derivative [1 1 1] initial-state t dt)))
-
-(defn equations
+(defn state-derivative
   [m M]
-  (e/->TeX
-   (e/simplify
-    ((state-derivative m M)
-     (up 't
-         (up 'x_0 'y_0 'x_1 'y_1)
-         (up 'xdot_0 'ydot_0 'xdot_1 'ydot_1))))))
-
-#_
-(clerk/tex
- (equations 'm 'M))
-
-(defn ^:no-doc to-svg
-  ([evolution]
-   (to-svg evolution {}))
-  ([evolution {:keys [scale] :or {scale 1}}]
-   [:svg {:width 700 :height 480}
-    [:rect {:width 700 :height 480 :fill "#330033"}]
-    [:g {:transform
-         (str "translate(350,240) scale(" scale ")")}
-     (mapcat
-      (fn [[_ q]]
-        (map (fn [[x y] color]
-               [:circle {:fill color :stroke "none"
-                         :r (/ 1 scale)
-                         :cx x
-                         :cy y}])
-             (partition 2 q)
-             ["red" "green" "blue" "indigo" "violet"]))
-      evolution)]]))
-
-(clerk/html
- (to-svg
-  (my-evolver (up 0.0 0.0 0.0 0.0 0.0 0.0) {:t 20 :dt 0.01})
-  {:scale 200}))
-
-(clerk/html
- (to-svg
-  (my-evolver (up 0.002 0.0 0.0 0.0 0.0 0.0) {:t 20 :dt 0.01})
-  {:scale 200}))
-
-(clerk/html
- (to-svg
-  (my-evolver (up 0.010 0.0 0.0 0.0 0.0 0.0) {:t 20 :dt 0.01})
-  {:scale 200}))
-
-(clerk/html
- (to-svg
-  (my-evolver (up 0.010 0.0 0.0 0.01 0.01 0.0) {:t 20 :dt 0.01})
-  {:scale 200}))
-
-(clerk/html
- (to-svg
-  (my-evolver (up 0.010 0.01 0.0 0.01 0.01 0.0) {:t 20 :dt 0.01})
-  {:scale 200}))
+  (e/Lagrangian->state-derivative (L m M)))
 
 (defn evolver
-  [{:keys [t dt m M x_0 y_0 xdot_0 ydot_0]
+  [{:keys [t dt m M x_0 y_0 xdot_0 ydot_0 observe]
     :or {t 1
          dt 1
          m 1
@@ -171,26 +74,49 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   (let [initial-state (up 0.0
                           (up x_0    y_0    0 0)
                           (up xdot_0 ydot_0 0 0))]
-    (e/integrate-state-derivative
-     state-derivative
-     [m M] initial-state t dt)))
+    ((e/evolve state-derivative m M)
+     initial-state
+     dt
+     t
+     {:compile? true
+      :epsilon 1.0e-6
+      :observe observe})))
 
-(defn ^:no-doc generate-svgs []
-  [:div
-   (for [dy (take 2 (range -10 -1 (/ 1 10)))]
-     (let [svg (to-svg
-                (evolver
-                 {:t 100
-                  :dt (/ 1 3)
-                  :M 500
-                  :m 500
-                  :x_0 50
-                  :y_0 50
-                  :xdot_0 0
-                  :ydot_0 dy}))]
-       (log/info (str "dy " dy))
-       svg))])
+(defn equations
+  []
+  (e/simplify ((state-derivative 'm 'M)
+               (up 't
+                   (up 'x_0 'y_0 'x_1 'y_1)
+                   (up 'xdot_0 'ydot_0 'xdot_1 'ydot_1)))))
 
-(def runner
-  (clerk/html
-   (generate-svgs)))
+(defn ^:no-doc to-svg
+  [evolution]
+  [:svg {:width 480 :height 480}
+   [:rect {:width 480 :height 480 :fill "#330033"}]
+   [:g {:transform "translate(240,240)"}
+    ;;[:circle {:fill "green" :stroke "none" :r 5 :cx 0 :cy 0}]
+    ;;[:circle {:fill "green" :stroke "none" :r 5 :cx 20 :cy 0}]
+    ;;[:circle {:fill "green" :stroke "none" :r 5 :cx 0 :cy 20}]
+    (for [[_ x y _ _] evolution]
+      [:circle {:fill "orange" :stroke "none" :r 1 :cx x :cy y}]
+      )
+    (for [[_ _ _ X Y] evolution]
+      [:circle {:fill "green" :stroke "none" :r 1 :cx X :cy Y}])]])
+
+;; Simó's initial data
+;; x_1=−x2=0.97000436−0.24308753i,x3=0; V~ = ˙x3=−2 ˙x_1=−2 ˙x2=−0.93240737−0.86473146i
+;; T =12T =6.32591398, I(0)=2, m1=m2=m3=1
+
+#?(:clj
+   (defn ^:no-doc -main
+     [& _]
+     (let [head [:head {:title "foo"}]
+           counter (atom 0)
+           body [:body
+                 (for [dy (range -10 -1 1/10)]
+                   (let [svg (to-svg (evolver {:t 100 :dt 1/3 :M 500 :m 500 :x_0 50 :y_0 50 :xdot_0 0 :ydot_0 dy}))]
+                     (log/info (str "dy " dy))
+                     (spit (format "%03d.svg" @counter) (html svg))
+                     (swap! counter inc)
+                     svg))]]
+       (println (html5 head body)))))

--- a/src/sicmutils/examples/central_potential.cljc
+++ b/src/sicmutils/examples/central_potential.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.central-potential
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/examples/double_pendulum.cljc
+++ b/src/sicmutils/examples/double_pendulum.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.double-pendulum
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/examples/double_pendulum.cljc
+++ b/src/sicmutils/examples/double_pendulum.cljc
@@ -16,15 +16,9 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this code; if not, see <http://www.gnu.org/licenses/>."
 
-^{:nextjournal.clerk/visibility #{:hide-ns}}
 (ns sicmutils.examples.double-pendulum
   (:refer-clojure :exclude [+ - * /])
-  (:require [nextjournal.clerk :as clerk]
-            [sicmutils.env :as e :refer [up square cos + - * /]]))
-
-;; ## Double Pendulum
-
-(def ->tex (comp clerk/tex e/->TeX))
+  (:require [sicmutils.env :as e :refer [up square cos + - * /]]))
 
 (defn V
   [m1 m2 l1 l2 g]
@@ -44,7 +38,8 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
                           v2sq
                           (* 2 l1 l2 θdot φdot (cos (- θ φ)))))))))
 
-(def L (- T V))
+(def L
+  (- T V))
 
 (defn state-derivative [m1 m2 l1 l2 g]
   (e/Lagrangian->state-derivative
@@ -85,41 +80,3 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
     (up 't
         (up 'θ_0 'φ_0)
         (up 'θdot_0 'φdot_0)))))
-
-
-;; Equations of motion:
-
-(->tex (equations))
-
-(defn ^:no-doc to-svg
-  ([evolution]
-   (to-svg evolution {}))
-  ([evolution {:keys [t-scale scale] :or {t-scale 1 scale 1}}]
-   [:svg {:width 700 :height 480}
-    [:rect {:width 700 :height 480 :fill "#330033"}]
-    [:g {:transform "translate(0,240)"}
-     (mapcat (fn [[t [theta phi]]]
-               [[:circle {:fill "red" :stroke "none"
-                          :r 1
-                          :cx (* t-scale t)
-                          :cy (* scale (- theta))}]
-                [:circle {:fill "blue" :stroke "none"
-                          :r 1
-                          :cx (* t-scale t)
-                          :cy (* scale (- phi))}]])
-             evolution)]]))
-
-(defn to-view []
-  (let [o (atom (transient []))
-        observe (fn [_ q] (swap! o conj! q))]
-    (evolver {:t 100 :dt (/ 1 60) :observe observe})
-    (let [result (persistent! @o)]
-      (to-svg result {:t-scale 10
-                      :scale 40}))))
-
-;; TODO: instead of generating an SVG, OBVIOUSLY what I want to do is use
-;; vega-lite to view this stuff. Generate the dataset once. In fact I already
-;; did that a while back.
-
-(clerk/html
- (to-view))

--- a/src/sicmutils/examples/driven_pendulum.cljc
+++ b/src/sicmutils/examples/driven_pendulum.cljc
@@ -1,27 +1,26 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+;;
+;; Copyright © 2017 Colin Smith.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
 
 (ns sicmutils.examples.driven-pendulum
   (:refer-clojure :exclude [+ - * /])
   (:require [sicmutils.env :as e :refer [cos up + * /]]
             [sicmutils.examples.pendulum :as pendulum]))
-
-;; ## Driven Pendulum
 
 (defn vertical-periodic-drive
   [amplitude frequency phase]

--- a/src/sicmutils/examples/driven_pendulum.cljc
+++ b/src/sicmutils/examples/driven_pendulum.cljc
@@ -21,6 +21,8 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   (:require [sicmutils.env :as e :refer [cos up + * /]]
             [sicmutils.examples.pendulum :as pendulum]))
 
+;; ## Driven Pendulum
+
 (defn vertical-periodic-drive
   [amplitude frequency phase]
   (fn [t]

--- a/src/sicmutils/examples/driven_pendulum.cljc
+++ b/src/sicmutils/examples/driven_pendulum.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.driven-pendulum
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/examples/pendulum.cljc
+++ b/src/sicmutils/examples/pendulum.cljc
@@ -23,8 +23,6 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   (:refer-clojure :exclude [+ - * / zero? partial ref])
   (:require [sicmutils.env :as e :refer [D sin cos square + - * / ref]]))
 
-;; ## Pendulum
-
 (defn T
   [m l _ x]
   (let [v (D x)]

--- a/src/sicmutils/examples/pendulum.cljc
+++ b/src/sicmutils/examples/pendulum.cljc
@@ -23,6 +23,8 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   (:refer-clojure :exclude [+ - * / zero? partial ref])
   (:require [sicmutils.env :as e :refer [D sin cos square + - * / ref]]))
 
+;; ## Pendulum
+
 (defn T
   [m l _ x]
   (let [v (D x)]

--- a/src/sicmutils/examples/pendulum.cljc
+++ b/src/sicmutils/examples/pendulum.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 ;; The simple pendulum supported at the point x (in the plane; x should
 ;; be a function of t returning an up-tuple (up xt yt).

--- a/src/sicmutils/examples/rigid_rotation.cljc
+++ b/src/sicmutils/examples/rigid_rotation.cljc
@@ -20,6 +20,8 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   (:require [sicmutils.env :as e :refer [up]]
             [sicmutils.mechanics.rigid :as r]))
 
+;; ## Rigid Rotation
+
 (defn evolver
   [t dt A B C θ0 φ0 ψ0 θdot0 φdot0 ψdot0]
   (let [state-history (atom [])

--- a/src/sicmutils/examples/rigid_rotation.cljc
+++ b/src/sicmutils/examples/rigid_rotation.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.rigid-rotation
   (:require [sicmutils.env :as e :refer [up]]

--- a/src/sicmutils/examples/rigid_rotation.cljc
+++ b/src/sicmutils/examples/rigid_rotation.cljc
@@ -20,8 +20,6 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   (:require [sicmutils.env :as e :refer [up]]
             [sicmutils.mechanics.rigid :as r]))
 
-;; ## Rigid Rotation
-
 (defn evolver
   [t dt A B C θ0 φ0 ψ0 θdot0 φdot0 ψdot0]
   (let [state-history (atom [])

--- a/src/sicmutils/examples/top.cljc
+++ b/src/sicmutils/examples/top.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.top
   (:refer-clojure :exclude [- *])

--- a/src/sicmutils/examples/top.cljc
+++ b/src/sicmutils/examples/top.cljc
@@ -21,6 +21,8 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   (:require [sicmutils.env :as e :refer [cos up - *]]
             [sicmutils.mechanics.rigid :as rigid]))
 
+;;## Axisymmetric Top
+
 (defn L
   [A B C gMR]
   (let [T (rigid/T-rigid-body A B C)

--- a/src/sicmutils/examples/top.cljc
+++ b/src/sicmutils/examples/top.cljc
@@ -21,8 +21,6 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   (:require [sicmutils.env :as e :refer [cos up - *]]
             [sicmutils.mechanics.rigid :as rigid]))
 
-;;## Axisymmetric Top
-
 (defn L
   [A B C gMR]
   (let [T (rigid/T-rigid-body A B C)

--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.expression
   "This namespace contains a number of functions and utilities for manipulating

--- a/src/sicmutils/expression/analyze.cljc
+++ b/src/sicmutils/expression/analyze.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with thixs code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with thixs code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.expression.analyze
   "This namespace defines an API for working with 'expression analyzers' and

--- a/src/sicmutils/expression/compile.cljc
+++ b/src/sicmutils/expression/compile.cljc
@@ -1,20 +1,20 @@
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
 
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
 
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
 
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.expression.compile
   "This namespace contains tools for compiling functions implemented with the

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;;; it under the terms of the GNU General Public License as published by
-;;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.expression.render
   "Functions and utilities for rendering symbolic expressions to various backends

--- a/src/sicmutils/function.cljc
+++ b/src/sicmutils/function.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.function
   "Procedures that act on Clojure's function and multimethod types, along with

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.generic
   "The home of most of the SICMUtils extensible generic operations. The bulk of

--- a/src/sicmutils/matrix.cljc
+++ b/src/sicmutils/matrix.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.matrix
   "This namespace contains an implementation of a [[Matrix]] datatype and various

--- a/src/sicmutils/mechanics/hamilton.cljc
+++ b/src/sicmutils/mechanics/hamilton.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.mechanics.hamilton
   (:refer-clojure :exclude [+ - * /  partial])

--- a/src/sicmutils/mechanics/lagrange.cljc
+++ b/src/sicmutils/mechanics/lagrange.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.mechanics.lagrange
   (:refer-clojure :exclude [+ - * / partial])

--- a/src/sicmutils/mechanics/rigid.cljc
+++ b/src/sicmutils/mechanics/rigid.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.mechanics.rigid
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/mechanics/rotation.cljc
+++ b/src/sicmutils/mechanics/rotation.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2022 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.mechanics.rotation
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/modint.cljc
+++ b/src/sicmutils/modint.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.modint
   "This namespace contains an implementation of a [[ModInt]] datatype and various

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numbers
   "This namespace extends of all appropriate SICMUtils generic operations

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -369,7 +369,7 @@
      ;; https://github.com/clojure/math.numeric-tower/blob/master/src/main/clojure/clojure/math/numeric_tower.clj#L72
      (letfn [(long-expt [base pow]
                (loop [^Long n pow
-                      ^Long y (.getOne Long)
+                      ^Long y (Long/getOne)
                       ^Long z base]
                  (let [t (not (.isOdd n))
                        n ^Long (.shiftRight n 1)]
@@ -387,10 +387,10 @@
      ;; number.
      (doseq [op [g/add g/mul g/sub g/gcd g/lcm g/expt g/remainder g/quotient]]
        (defmethod op [Long ::v/native-integral] [a b]
-         (op a (.fromNumber Long b)))
+         (op a (Long/fromNumber b)))
 
        (defmethod op [::v/native-integral Long] [a b]
-         (op (.fromNumber Long a) b))
+         (op (Long/fromNumber a) b))
 
        ;; If this type encounters a floating point type it should lose
        ;; precision.
@@ -429,10 +429,10 @@
      ;; number.
      (doseq [op [g/add g/mul g/sub g/gcd g/lcm g/expt g/remainder g/quotient]]
        (defmethod op [Integer ::v/native-integral] [a b]
-         (op a (.fromNumber Integer b)))
+         (op a (Integer/fromNumber b)))
 
        (defmethod op [::v/native-integral Integer] [a b]
-         (op (.fromNumber Integer a) b))
+         (op (Integer/fromNumber a) b))
 
        ;; If this type encounters a floating point type it should lose
        ;; precision.
@@ -445,10 +445,10 @@
        ;; When they encounter each other in binary operations, Long is coerced
        ;; to Integer.
        (defmethod op [Integer Long] [a b]
-         (op a (.fromNumber Integer b)))
+         (op a (Integer/fromNumber b)))
 
        (defmethod op [Long Integer] [a b]
-         (op (.fromNumber Integer a) b)))
+         (op (Integer/fromNumber a) b)))
 
      ;; These names are slightly different between the two types.
      (defmethod g/quotient [Long Long] [^Long a ^Long b] (.div a b))

--- a/src/sicmutils/numerical/derivative.cljc
+++ b/src/sicmutils/numerical/derivative.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.derivative
   "This namespace contains implementations of various approaches to [numerical

--- a/src/sicmutils/numerical/minimize.cljc
+++ b/src/sicmutils/numerical/minimize.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.minimize
   "Entrypoint for univariate and multivariate minimization routines."

--- a/src/sicmutils/numerical/multimin/nelder_mead.cljc
+++ b/src/sicmutils/numerical/multimin/nelder_mead.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.multimin.nelder-mead
   (:require [sicmutils.util :as u]))

--- a/src/sicmutils/numerical/ode.cljc
+++ b/src/sicmutils/numerical/ode.cljc
@@ -158,11 +158,17 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
   system is assumed to be a map from a structure to a structure of the
   same shape, as differentiating a function does not change its
   shape), and returns an integrator, which is a function of several
-  arguments: the initial state, an intermediate-state observation
-  function, the step size desired, the final time to seek, and an
-  error tolerance. If the observe function is not nil, it will be
-  invoked with the time as first argument and integrated state as the
-  second, at each intermediate step."
+  arguments:
+
+  - the initial state
+  - an intermediate-state observation function
+  - the step size desired
+  - the final time to seek, and
+  - an error tolerance.
+
+
+  If the `observe` function is not nil, it will be invoked with the time as
+  first argument and integrated state as the second, at each intermediate step."
   [state-derivative derivative-args]
   #?(:cljs
      (let [total-time (us/stopwatch :started? false)

--- a/src/sicmutils/numerical/ode.cljc
+++ b/src/sicmutils/numerical/ode.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.ode
   "ODE solvers for working with initial value problems."

--- a/src/sicmutils/numerical/quadrature.cljc
+++ b/src/sicmutils/numerical/quadrature.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature
   (:require [sicmutils.expression.compile :as c]

--- a/src/sicmutils/numerical/quadrature/adaptive.cljc
+++ b/src/sicmutils/numerical/quadrature/adaptive.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.adaptive
   (:require [sicmutils.numerical.quadrature.common :as qc]

--- a/src/sicmutils/numerical/quadrature/boole.cljc
+++ b/src/sicmutils/numerical/quadrature/boole.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.boole
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/bulirsch_stoer.cljc
+++ b/src/sicmutils/numerical/quadrature/bulirsch_stoer.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.bulirsch-stoer
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/common.cljc
+++ b/src/sicmutils/numerical/quadrature/common.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.common
   "Implements utilities shared by all integrators, for example:

--- a/src/sicmutils/numerical/quadrature/infinite.cljc
+++ b/src/sicmutils/numerical/quadrature/infinite.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.infinite
   (:require [clojure.core.match :refer [match]]

--- a/src/sicmutils/numerical/quadrature/midpoint.cljc
+++ b/src/sicmutils/numerical/quadrature/midpoint.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.midpoint
   (:require [sicmutils.generic :as g]

--- a/src/sicmutils/numerical/quadrature/milne.cljc
+++ b/src/sicmutils/numerical/quadrature/milne.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.milne
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/riemann.cljc
+++ b/src/sicmutils/numerical/quadrature/riemann.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.riemann
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/romberg.cljc
+++ b/src/sicmutils/numerical/quadrature/romberg.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.romberg
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/simpson.cljc
+++ b/src/sicmutils/numerical/quadrature/simpson.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.simpson
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/simpson38.cljc
+++ b/src/sicmutils/numerical/quadrature/simpson38.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.simpson38
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/substitute.cljc
+++ b/src/sicmutils/numerical/quadrature/substitute.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.substitute
   "### U Substitution and Variable Changes

--- a/src/sicmutils/numerical/quadrature/trapezoid.cljc
+++ b/src/sicmutils/numerical/quadrature/trapezoid.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.trapezoid
   "Trapezoid method."

--- a/src/sicmutils/numerical/unimin/bracket.cljc
+++ b/src/sicmutils/numerical/unimin/bracket.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.unimin.bracket
   (:require [sicmutils.generic :as g]

--- a/src/sicmutils/numerical/unimin/brent.cljc
+++ b/src/sicmutils/numerical/unimin/brent.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.unimin.brent
   "This namespace contains an implementation of Brent's method for finding the

--- a/src/sicmutils/numerical/unimin/golden.cljc
+++ b/src/sicmutils/numerical/unimin/golden.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.unimin.golden
   (:require [sicmutils.generic :as g]

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numsymb
   "Implementations of the generic operations for numeric types that have

--- a/src/sicmutils/operator.cljc
+++ b/src/sicmutils/operator.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.operator
   (:refer-clojure :rename {identity core-identity

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial
   (:refer-clojure :exclude [extend divide identity abs])

--- a/src/sicmutils/polynomial/exponent.cljc
+++ b/src/sicmutils/polynomial/exponent.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns ^:no-doc sicmutils.polynomial.exponent
   "This namespace provides an implementation of a sparse representation of the

--- a/src/sicmutils/polynomial/factor.cljc
+++ b/src/sicmutils/polynomial/factor.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.factor
   "This namespace contains functions for factoring polynomials and symbolic

--- a/src/sicmutils/polynomial/gcd.cljc
+++ b/src/sicmutils/polynomial/gcd.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.gcd
   (:require [clojure.set :as cs]

--- a/src/sicmutils/polynomial/impl.cljc
+++ b/src/sicmutils/polynomial/impl.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns ^:no-doc sicmutils.polynomial.impl
   (:require [sicmutils.generic :as g]

--- a/src/sicmutils/polynomial/interpolate.cljc
+++ b/src/sicmutils/polynomial/interpolate.cljc
@@ -74,8 +74,8 @@
 ;; ## Neville's Algorithm
 ;;
 ;; Start the recursion with a single point. Any point $(x, f(x))$ has a unique
-;; 0th order polynomial passing through it - the constant function $P(x) =
-;; f(x)$. For points $x_a$, $x_b$, let's call this $P_a$, $P_b$, etc.
+;; 0th order polynomial passing through it - the constant function $P(x) = f(x)$.
+;; For points $x_a$, $x_b$, let's call this $P_a$, $P_b$, etc.
 ;;
 ;; $P_{ab}$ is the unique FIRST order polynomial (ie, a line) going through
 ;; points $x_a$ and $x_b$.
@@ -136,6 +136,7 @@
 ;; You can write these out these relationships in a "tableau" that grows to the
 ;; right from an initial left column:
 ;;
+;;```
 ;; p0
 ;;  \
 ;;  p01
@@ -153,6 +154,7 @@
 ;;  p34
 ;;  /
 ;; p4
+;;```
 
 ;; The next few functions will discuss "rows" and "columns" of the tableau. That
 ;; refers to the rows and columns of this representation;

--- a/src/sicmutils/polynomial/interpolate.cljc
+++ b/src/sicmutils/polynomial/interpolate.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.interpolate
   "This namespace contains a discussion of polynomial interpolation, and different

--- a/src/sicmutils/polynomial/richardson.cljc
+++ b/src/sicmutils/polynomial/richardson.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.richardson
   "Richardson interpolation is a special case of polynomial interpolation; knowing

--- a/src/sicmutils/quaternion.cljc
+++ b/src/sicmutils/quaternion.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2022 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.quaternion
   "This namespace provides a number of functions and constructors for working

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.ratio
   "This namespace provides a number of functions and constructors for working

--- a/src/sicmutils/rational_function.cljc
+++ b/src/sicmutils/rational_function.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.rational-function
   (:refer-clojure :exclude [abs])

--- a/src/sicmutils/rational_function/interpolate.cljc
+++ b/src/sicmutils/rational_function/interpolate.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.rational-function.interpolate
   "This namespace contains a discussion of rational function interpolation, and

--- a/src/sicmutils/series.cljc
+++ b/src/sicmutils/series.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.series
   "This namespace contains an implementation of two data types:

--- a/src/sicmutils/series/impl.cljc
+++ b/src/sicmutils/series/impl.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns ^:no-doc sicmutils.series.impl
   "Backing implementation for the types defined in [[sicmutils.series]], written

--- a/src/sicmutils/simplify.cljc
+++ b/src/sicmutils/simplify.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.simplify
   (:require [sicmutils.expression :as x]

--- a/src/sicmutils/simplify/rules.cljc
+++ b/src/sicmutils/simplify/rules.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.simplify.rules
   "This namespace contains many sets of algebraic simplification rules you can use

--- a/src/sicmutils/special/elliptic.cljc
+++ b/src/sicmutils/special/elliptic.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.special.elliptic
   "This namespace contains function to compute various [elliptic

--- a/src/sicmutils/special/factorial.cljc
+++ b/src/sicmutils/special/factorial.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2022 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.special.factorial
   "Namespace holding implementations of variations on the factorial function."

--- a/src/sicmutils/sr/boost.cljc
+++ b/src/sicmutils/sr/boost.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sr.boost
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/sr/frames.cljc
+++ b/src/sicmutils/sr/frames.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sr.frames
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.structure
   (:require [clojure.string :refer [join]]

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util
   "Shared utilities between clojure and clojurescript."

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -89,11 +89,11 @@
 
 (defn int [x]
   #?(:clj (core-int x)
-     :cljs (.fromNumber goog.math.Integer x)))
+     :cljs (goog.math.Integer/fromNumber x)))
 
 (defn long [x]
   #?(:clj (core-long x)
-     :cljs (.fromNumber goog.math.Long x)))
+     :cljs (goog.math.Long/fromNumber x)))
 
 (defn double [x]
   #?(:clj (core-double x)

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.aggregate
   "Namespace with algorithms for aggregating sequences in various ways."

--- a/src/sicmutils/util/def.cljc
+++ b/src/sicmutils/util/def.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.def
   #?(:clj

--- a/src/sicmutils/util/logic.cljc
+++ b/src/sicmutils/util/logic.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.logic
   "Logic utilities!"

--- a/src/sicmutils/util/permute.cljc
+++ b/src/sicmutils/util/permute.cljc
@@ -42,18 +42,132 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
       (sequence (comp (map-indexed f) cat)
                 xs))))
 
+;; Helper function for bounded-distributions
+(defn- distribute [m index total distribution already-distributed]
+  (loop [distribution distribution
+         index index
+         already-distributed already-distributed]
+    (if (>= index (count m)) nil
+        (let [quantity-to-distribute (- total already-distributed)
+              mi (m index)]
+          (if (<= quantity-to-distribute mi)
+            (conj distribution [index quantity-to-distribute total])
+            (recur (conj distribution [index mi (+ already-distributed mi)])
+                   (inc index)
+                   (+ already-distributed mi)))))))
+
+;; Helper function for bounded-distributions
+(defn- next-distribution [m total distribution]
+  (let [[index this-bucket this-and-to-the-left] (peek distribution)]
+    (cond
+      (< index (dec (count m)))
+      (if (= this-bucket 1)
+        (conj (pop distribution) [(inc index) 1 this-and-to-the-left])
+        (conj (pop distribution)
+              [index (dec this-bucket) (dec this-and-to-the-left)]
+              [(inc index) 1 this-and-to-the-left])),
+                                        ; so we have stuff in the last bucket
+      (= this-bucket total) nil
+      :else
+      (loop [distribution (pop distribution)],
+        (let
+            [[index this-bucket this-and-to-the-left] (peek distribution),
+             distribution (if (= this-bucket 1)
+                            (pop distribution)
+                            (conj (pop distribution)
+                                  [index (dec this-bucket) (dec this-and-to-the-left)]))],
+          (cond
+            (<= (- total (dec this-and-to-the-left)) (apply + (subvec m (inc index))))
+            (distribute m (inc index) total distribution (dec this-and-to-the-left)),
+
+            (seq distribution) (recur distribution)
+            :else nil))))))
+
+;; Helper function for multi-comb
+(defn- bounded-distributions
+  [m t]
+  (let [step
+        (fn step [distribution]
+          (cons distribution
+                (lazy-seq (when-let [next-step (next-distribution m t distribution)]
+                            (step next-step)))))]
+    (step (distribute m 0 t [] 0))))
+
+(defn- join
+  "Lazily concatenates a collection of collections into a flat sequence,
+  because Clojure's `apply concat` is insufficiently lazy."
+  [colls]
+  (lazy-seq
+   (when-let [s (seq colls)]
+     (concat (first s) (join (rest s))))))
+
+(defn- multi-comb
+  "Handles the case when you want the combinations of a list with duplicate items."
+  [l t]
+  (let [f (frequencies l),
+        v (vec (distinct l)),
+        domain (range (count v))
+        m (vec (for [i domain] (f (v i))))
+        qs (bounded-distributions m t)]
+    (for [q qs]
+      (join
+       (for [[index this-bucket _] q]
+         (repeat this-bucket (v index)))))))
+
+
+(defn- all-different?
+  "Annoyingly, the built-in distinct? doesn't handle 0 args, so we need
+  to write our own version that considers the empty-list to be distinct"
+  [s]
+  (if (seq s)
+    (apply distinct? s)
+    true))
+
+
+(defn- index-combinations
+  [n cnt]
+  (lazy-seq
+   (let [c (vec (cons nil (for [j (range 1 (inc n))] (+ j cnt (- (inc n)))))),
+         iter-comb
+         (fn iter-comb [c j]
+           (if (> j n) nil
+               (let [c (assoc c j (dec (c j)))]
+                 (if (< (c j) j) [c (inc j)]
+                     (loop [c c, j j]
+                       (if (= j 1) [c j]
+                           (recur (assoc c (dec j) (dec (c j))) (dec j)))))))),
+         step
+         (fn step [c j]
+           (cons (rseq (subvec c 1 (inc n)))
+                 (lazy-seq (let [next-step (iter-comb c j)]
+                             (when next-step (step (next-step 0) (next-step 1)))))))]
+     (step c 1))))
+
 (defn combinations
-  "Returns a lazy sequence of every possible set of `p` elements chosen from
+  "All the unique ways of taking t different elements from items"
+  [items t]
+  (let [v-items (vec (reverse items))]
+    (if (zero? t) (list ())
+        (let [cnt (count items)]
+          (cond (> t cnt) nil
+                (= t 1) (for [item (distinct items)] (list item))
+                (all-different? items) (if (= t cnt)
+                                         (list (seq items))
+                                         (map #(map v-items %) (index-combinations t cnt))),
+                :else (multi-comb items t))))))
+
+#_(defn combinations
+    "Returns a lazy sequence of every possible set of `p` elements chosen from
   `xs`."
-  [xs p]
-  (cond (zero? p) '(())
-        (empty? xs) ()
-        :else (concat
-               (map (fn [more]
-                      (conj more (first xs)))
-                    (combinations (rest xs)
-                                  (dec p)))
-               (combinations (rest xs) p))))
+    [xs p]
+    (cond (zero? p) '(())
+          (empty? xs) ()
+          :else (let [[x & xs] xs]
+                  (concat
+                   (map (fn [more]
+                          (cons x more))
+                        (combinations xs (dec p)))
+                   (combinations xs p)))))
 
 (defn cartesian-product
   "Accepts a sequence of collections `colls` and returns a lazy sequence of the

--- a/src/sicmutils/util/permute.cljc
+++ b/src/sicmutils/util/permute.cljc
@@ -42,132 +42,18 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
       (sequence (comp (map-indexed f) cat)
                 xs))))
 
-;; Helper function for bounded-distributions
-(defn- distribute [m index total distribution already-distributed]
-  (loop [distribution distribution
-         index index
-         already-distributed already-distributed]
-    (if (>= index (count m)) nil
-        (let [quantity-to-distribute (- total already-distributed)
-              mi (m index)]
-          (if (<= quantity-to-distribute mi)
-            (conj distribution [index quantity-to-distribute total])
-            (recur (conj distribution [index mi (+ already-distributed mi)])
-                   (inc index)
-                   (+ already-distributed mi)))))))
-
-;; Helper function for bounded-distributions
-(defn- next-distribution [m total distribution]
-  (let [[index this-bucket this-and-to-the-left] (peek distribution)]
-    (cond
-      (< index (dec (count m)))
-      (if (= this-bucket 1)
-        (conj (pop distribution) [(inc index) 1 this-and-to-the-left])
-        (conj (pop distribution)
-              [index (dec this-bucket) (dec this-and-to-the-left)]
-              [(inc index) 1 this-and-to-the-left])),
-                                        ; so we have stuff in the last bucket
-      (= this-bucket total) nil
-      :else
-      (loop [distribution (pop distribution)],
-        (let
-            [[index this-bucket this-and-to-the-left] (peek distribution),
-             distribution (if (= this-bucket 1)
-                            (pop distribution)
-                            (conj (pop distribution)
-                                  [index (dec this-bucket) (dec this-and-to-the-left)]))],
-          (cond
-            (<= (- total (dec this-and-to-the-left)) (apply + (subvec m (inc index))))
-            (distribute m (inc index) total distribution (dec this-and-to-the-left)),
-
-            (seq distribution) (recur distribution)
-            :else nil))))))
-
-;; Helper function for multi-comb
-(defn- bounded-distributions
-  [m t]
-  (let [step
-        (fn step [distribution]
-          (cons distribution
-                (lazy-seq (when-let [next-step (next-distribution m t distribution)]
-                            (step next-step)))))]
-    (step (distribute m 0 t [] 0))))
-
-(defn- join
-  "Lazily concatenates a collection of collections into a flat sequence,
-  because Clojure's `apply concat` is insufficiently lazy."
-  [colls]
-  (lazy-seq
-   (when-let [s (seq colls)]
-     (concat (first s) (join (rest s))))))
-
-(defn- multi-comb
-  "Handles the case when you want the combinations of a list with duplicate items."
-  [l t]
-  (let [f (frequencies l),
-        v (vec (distinct l)),
-        domain (range (count v))
-        m (vec (for [i domain] (f (v i))))
-        qs (bounded-distributions m t)]
-    (for [q qs]
-      (join
-       (for [[index this-bucket _] q]
-         (repeat this-bucket (v index)))))))
-
-
-(defn- all-different?
-  "Annoyingly, the built-in distinct? doesn't handle 0 args, so we need
-  to write our own version that considers the empty-list to be distinct"
-  [s]
-  (if (seq s)
-    (apply distinct? s)
-    true))
-
-
-(defn- index-combinations
-  [n cnt]
-  (lazy-seq
-   (let [c (vec (cons nil (for [j (range 1 (inc n))] (+ j cnt (- (inc n)))))),
-         iter-comb
-         (fn iter-comb [c j]
-           (if (> j n) nil
-               (let [c (assoc c j (dec (c j)))]
-                 (if (< (c j) j) [c (inc j)]
-                     (loop [c c, j j]
-                       (if (= j 1) [c j]
-                           (recur (assoc c (dec j) (dec (c j))) (dec j)))))))),
-         step
-         (fn step [c j]
-           (cons (rseq (subvec c 1 (inc n)))
-                 (lazy-seq (let [next-step (iter-comb c j)]
-                             (when next-step (step (next-step 0) (next-step 1)))))))]
-     (step c 1))))
-
 (defn combinations
-  "All the unique ways of taking t different elements from items"
-  [items t]
-  (let [v-items (vec (reverse items))]
-    (if (zero? t) (list ())
-        (let [cnt (count items)]
-          (cond (> t cnt) nil
-                (= t 1) (for [item (distinct items)] (list item))
-                (all-different? items) (if (= t cnt)
-                                         (list (seq items))
-                                         (map #(map v-items %) (index-combinations t cnt))),
-                :else (multi-comb items t))))))
-
-#_(defn combinations
-    "Returns a lazy sequence of every possible set of `p` elements chosen from
+  "Returns a lazy sequence of every possible set of `p` elements chosen from
   `xs`."
-    [xs p]
-    (cond (zero? p) '(())
-          (empty? xs) ()
-          :else (let [[x & xs] xs]
-                  (concat
-                   (map (fn [more]
-                          (cons x more))
-                        (combinations xs (dec p)))
-                   (combinations xs p)))))
+  [xs p]
+  (cond (zero? p) '(())
+        (empty? xs) ()
+        :else (concat
+               (map (fn [more]
+                      (conj more (first xs)))
+                    (combinations (rest xs)
+                                  (dec p)))
+               (combinations (rest xs) p))))
 
 (defn cartesian-product
   "Accepts a sequence of collections `colls` and returns a lazy sequence of the

--- a/src/sicmutils/util/permute.cljc
+++ b/src/sicmutils/util/permute.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.permute
   "Utilities for generating permutations of sequences."

--- a/src/sicmutils/util/stopwatch.cljc
+++ b/src/sicmutils/util/stopwatch.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.stopwatch
   (:require [sicmutils.util :as u]

--- a/src/sicmutils/util/stream.cljc
+++ b/src/sicmutils/util/stream.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.stream
   "This namespace contains various standard sequences, as well as utilities for

--- a/src/sicmutils/util/vector_set.cljc
+++ b/src/sicmutils/util/vector_set.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.vector-set
   "Contains an implementation and API for an 'ordered set' data structure backed

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -440,11 +440,11 @@
 
        goog.math.Long
        (zero? [x] (.isZero x))
-       (one? [x] (core= (.getOne goog.math.Long) x))
-       (identity? [x] (core= (.getOne goog.math.Long) x))
-       (zero-like [_] (.getZero goog.math.Long))
-       (one-like [_] (.getOne goog.math.Long))
-       (identity-like [_] (.getOne goog.math.Long))
+       (one? [x] (core= (goog.math.Long/getOne) x))
+       (identity? [x] (core= (goog.math.Long/getOne) x))
+       (zero-like [_] (goog.math.Long/getZero))
+       (one-like [_] (goog.math.Long/getOne))
+       (identity-like [_] (goog.math.Long/getOne))
        (freeze [x] x)
        (exact? [_] true)
        (kind [_] goog.math.Long))))

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.value
   "The home of most of the protocol-based extensible generic operations offered by

--- a/test/pattern/match_test.cljc
+++ b/test/pattern/match_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns pattern.match-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/pattern/rule_test.cljc
+++ b/test/pattern/rule_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns pattern.rule-test
   (:require [clojure.test :as t :refer [is deftest testing]]

--- a/test/sicmutils/abstract/function_test.cljc
+++ b/test/sicmutils/abstract/function_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.abstract.function-test
   (:refer-clojure :exclude [partial =])

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.abstract.number-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/algebra/fold_test.cljc
+++ b/test/sicmutils/algebra/fold_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2022 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.algebra.fold-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/calculus/basis_test.cljc
+++ b/test/sicmutils/calculus/basis_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.basis-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/calculus/connection_test.cljc
+++ b/test/sicmutils/calculus/connection_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.connection-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/coordinate_test.cljc
+++ b/test/sicmutils/calculus/coordinate_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.coordinate-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.covariant-test
   (:refer-clojure :exclude [+ - * /  partial])

--- a/test/sicmutils/calculus/curvature_test.cljc
+++ b/test/sicmutils/calculus/curvature_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.curvature-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/derivative_test.cljc
+++ b/test/sicmutils/calculus/derivative_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.derivative-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/calculus/form_field_test.cljc
+++ b/test/sicmutils/calculus/form_field_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.form-field-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/hodge_star_test.cljc
+++ b/test/sicmutils/calculus/hodge_star_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.hodge-star-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/indexed_test.cljc
+++ b/test/sicmutils/calculus/indexed_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.indexed-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/manifold_test.cljc
+++ b/test/sicmutils/calculus/manifold_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.manifold-test
   (:refer-clojure :exclude [* - / +])

--- a/test/sicmutils/calculus/map_test.cljc
+++ b/test/sicmutils/calculus/map_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.map-test
   (:refer-clojure :exclude [+ - * /  partial])

--- a/test/sicmutils/calculus/metric_test.cljc
+++ b/test/sicmutils/calculus/metric_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.metric-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/tensor_test.cljc
+++ b/test/sicmutils/calculus/tensor_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.tensor-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/vector_calculus_test.cljc
+++ b/test/sicmutils/calculus/vector_calculus_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.vector-calculus-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/vector_field_test.cljc
+++ b/test/sicmutils/calculus/vector_field_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.calculus.vector-field-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/collection_test.cljc
+++ b/test/sicmutils/collection_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.collection-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.complex-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/differential_test.cljc
+++ b/test/sicmutils/differential_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.differential-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/env/sci_test.cljc
+++ b/test/sicmutils/env/sci_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.env.sci-test
   (:refer-clojure :exclude [eval])

--- a/test/sicmutils/env_test.cljc
+++ b/test/sicmutils/env_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.env-test
   (:refer-clojure :exclude [+ - * / zero? partial ref])

--- a/test/sicmutils/euclid_test.cljc
+++ b/test/sicmutils/euclid_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.euclid-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/examples/central_potential_test.cljc
+++ b/test/sicmutils/examples/central_potential_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.central-potential-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/examples/double_pendulum_test.cljc
+++ b/test/sicmutils/examples/double_pendulum_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.double-pendulum-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/examples/driven_pendulum_test.cljc
+++ b/test/sicmutils/examples/driven_pendulum_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.driven-pendulum-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/examples/pendulum_test.cljc
+++ b/test/sicmutils/examples/pendulum_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.pendulum-test
   (:require [clojure.test :refer [is deftest use-fixtures]]

--- a/test/sicmutils/examples/rigid_rotation_test.cljc
+++ b/test/sicmutils/examples/rigid_rotation_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.rigid-rotation-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/examples/top_test.cljc
+++ b/test/sicmutils/examples/top_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.examples.top-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/expression/analyze_test.cljc
+++ b/test/sicmutils/expression/analyze_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.expression.analyze-test
   (:require [clojure.string :as cs]

--- a/test/sicmutils/expression/compile_test.cljc
+++ b/test/sicmutils/expression/compile_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.expression.compile-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.expression.render-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/expression_test.cljc
+++ b/test/sicmutils/expression_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.expression-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/fdg/bianchi_test.cljc
+++ b/test/sicmutils/fdg/bianchi_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.bianchi-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/fdg/ch10_test.cljc
+++ b/test/sicmutils/fdg/ch10_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
 
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 (ns sicmutils.fdg.ch10-test
   (:refer-clojure :exclude [+ - * / zero? partial])
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/fdg/ch11_test.cljc
+++ b/test/sicmutils/fdg/ch11_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
 
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 (ns sicmutils.fdg.ch11-test
   (:refer-clojure :exclude [+ - * / zero? partial])
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/fdg/ch1_test.cljc
+++ b/test/sicmutils/fdg/ch1_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch1-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/fdg/ch2_test.cljc
+++ b/test/sicmutils/fdg/ch2_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch2-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/fdg/ch3_test.cljc
+++ b/test/sicmutils/fdg/ch3_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch3-test
   (:refer-clojure :exclude [+ - * /  partial])

--- a/test/sicmutils/fdg/ch4_test.cljc
+++ b/test/sicmutils/fdg/ch4_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch4-test
   (:refer-clojure :exclude [+ - * / zero? partial])

--- a/test/sicmutils/fdg/ch5_test.cljc
+++ b/test/sicmutils/fdg/ch5_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch5-test
   (:refer-clojure :exclude [+ - * / = partial zero?])

--- a/test/sicmutils/fdg/ch6_test.cljc
+++ b/test/sicmutils/fdg/ch6_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch6-test
   (:refer-clojure :exclude [+ - * / zero? partial])

--- a/test/sicmutils/fdg/ch7_test.cljc
+++ b/test/sicmutils/fdg/ch7_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch7-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])

--- a/test/sicmutils/fdg/ch8_test.cljc
+++ b/test/sicmutils/fdg/ch8_test.cljc
@@ -1,20 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch8-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])

--- a/test/sicmutils/fdg/ch9_test.cljc
+++ b/test/sicmutils/fdg/ch9_test.cljc
@@ -1,20 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.ch9-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])

--- a/test/sicmutils/fdg/einstein_test.cljc
+++ b/test/sicmutils/fdg/einstein_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.fdg.einstein-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/function_test.cljc
+++ b/test/sicmutils/function_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.function-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -1,3 +1,21 @@
+#_
+"Copyright © 2022 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
+
 (ns sicmutils.generators
   "test.check generators for the various types in the sicmutils project."
   (:refer-clojure :rename {bigint core-bigint

--- a/test/sicmutils/generic_test.cljc
+++ b/test/sicmutils/generic_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.generic-test
   (:refer-clojure :exclude [+ - * / zero?])

--- a/test/sicmutils/laws.cljc
+++ b/test/sicmutils/laws.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.laws
   "test.check laws useful for checking the algebraic properties of different types

--- a/test/sicmutils/matrix_test.cljc
+++ b/test/sicmutils/matrix_test.cljc
@@ -1,21 +1,20 @@
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
 
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
 
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
 
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.matrix-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/mechanics/hamilton_test.cljc
+++ b/test/sicmutils/mechanics/hamilton_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.mechanics.hamilton-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/mechanics/lagrange_test.cljc
+++ b/test/sicmutils/mechanics/lagrange_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.mechanics.lagrange-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/mechanics/rotation_test.cljc
+++ b/test/sicmutils/mechanics/rotation_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.mechanics.rotation-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/modint_test.cljc
+++ b/test/sicmutils/modint_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.modint-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numbers-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/derivative_test.cljc
+++ b/test/sicmutils/numerical/derivative_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.derivative-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/minimize_test.cljc
+++ b/test/sicmutils/numerical/minimize_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.minimize-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/ode_test.cljc
+++ b/test/sicmutils/numerical/ode_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.ode-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/adaptive_test.cljc
+++ b/test/sicmutils/numerical/quadrature/adaptive_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.adaptive-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/boole_test.cljc
+++ b/test/sicmutils/numerical/quadrature/boole_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.boole-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/bulirsch_stoer_test.cljc
+++ b/test/sicmutils/numerical/quadrature/bulirsch_stoer_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.bulirsch-stoer-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/common_test.cljc
+++ b/test/sicmutils/numerical/quadrature/common_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.common-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/infinite_test.cljc
+++ b/test/sicmutils/numerical/quadrature/infinite_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.infinite-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/midpoint_test.cljc
+++ b/test/sicmutils/numerical/quadrature/midpoint_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.midpoint-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/milne_test.cljc
+++ b/test/sicmutils/numerical/quadrature/milne_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.milne-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/riemann_test.cljc
+++ b/test/sicmutils/numerical/quadrature/riemann_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.riemann-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/riemann_test.cljc
+++ b/test/sicmutils/numerical/quadrature/riemann_test.cljc
@@ -189,9 +189,9 @@
   (testing "upper-integral"
     (is (ish?
          {:converged? true
-          :terms-checked #?(:cljs 15 :clj 13)
+          :terms-checked 13
           :result 2}
          (qr/upper-integral
           g/sin 0 Math/PI {:accelerate? true
                            :tolerance v/machine-epsilon}))
-        "upper-integral converges, with slightly different speeds on CLJS vs Clojure (at machine epsilon!).")))
+        "upper-integral converges (at machine epsilon!)")))

--- a/test/sicmutils/numerical/quadrature/romberg_test.cljc
+++ b/test/sicmutils/numerical/quadrature/romberg_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.romberg-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/simpson38_test.cljc
+++ b/test/sicmutils/numerical/quadrature/simpson38_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.simpson38-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/simpson_test.cljc
+++ b/test/sicmutils/numerical/quadrature/simpson_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.simpson-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/substitute_test.cljc
+++ b/test/sicmutils/numerical/quadrature/substitute_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.substitute-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/trapezoid_test.cljc
+++ b/test/sicmutils/numerical/quadrature/trapezoid_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature.trapezoid-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature_test.cljc
+++ b/test/sicmutils/numerical/quadrature_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.quadrature-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/unimin/bracket_test.cljc
+++ b/test/sicmutils/numerical/unimin/bracket_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.unimin.bracket-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/unimin/brent_test.cljc
+++ b/test/sicmutils/numerical/unimin/brent_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.unimin.brent-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/unimin/golden_test.cljc
+++ b/test/sicmutils/numerical/unimin/golden_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.numerical.unimin.golden-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/operator_test.cljc
+++ b/test/sicmutils/operator_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
                                         ;
 (ns sicmutils.operator-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/polynomial/exponent_test.cljc
+++ b/test/sicmutils/polynomial/exponent_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.exponent-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/polynomial/factor_test.cljc
+++ b/test/sicmutils/polynomial/factor_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.factor-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/polynomial/gcd_test.cljc
+++ b/test/sicmutils/polynomial/gcd_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is bansed on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is bansed on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.gcd-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/polynomial/interpolate_test.cljc
+++ b/test/sicmutils/polynomial/interpolate_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.interpolate-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/polynomial/richardson_test.cljc
+++ b/test/sicmutils/polynomial/richardson_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial.richardson-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.polynomial-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/quaternion_test.cljc
+++ b/test/sicmutils/quaternion_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2022 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.quaternion-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/ratio_test.cljc
+++ b/test/sicmutils/ratio_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.ratio-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/rational_function/interpolate_test.cljc
+++ b/test/sicmutils/rational_function/interpolate_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.rational-function.interpolate-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/rational_function_test.cljc
+++ b/test/sicmutils/rational_function_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.rational-function-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/series/impl_test.cljc
+++ b/test/sicmutils/series/impl_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.series.impl-test
   (:require [clojure.test :refer [is deftest testing ]]

--- a/test/sicmutils/series_test.cljc
+++ b/test/sicmutils/series_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.series-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/sicm/ch1_test.cljc
+++ b/test/sicmutils/sicm/ch1_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sicm.ch1-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/sicm/ch2_test.cljc
+++ b/test/sicmutils/sicm/ch2_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sicm.ch2-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])

--- a/test/sicmutils/sicm/ch3_test.cljc
+++ b/test/sicmutils/sicm/ch3_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sicm.ch3-test
   (:refer-clojure :exclude [+ - * / zero? partial])

--- a/test/sicmutils/sicm/ch5_test.cljc
+++ b/test/sicmutils/sicm/ch5_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sicm.ch5-test
   (:refer-clojure :exclude [+ - * /  ref partial])

--- a/test/sicmutils/sicm/ch6_test.cljc
+++ b/test/sicmutils/sicm/ch6_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sicm.ch6-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/sicm/ch7_test.cljc
+++ b/test/sicmutils/sicm/ch7_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sicm.ch7-test
   (:refer-clojure :exclude [+ - * / = partial])

--- a/test/sicmutils/simplify/rules_test.cljc
+++ b/test/sicmutils/simplify/rules_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.simplify.rules-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/simplify_test.cljc
+++ b/test/sicmutils/simplify_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.simplify-test
   (:refer-clojure :exclude [=])

--- a/test/sicmutils/special/elliptic_test.cljc
+++ b/test/sicmutils/special/elliptic_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.special.elliptic-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/special/factorial_test.cljc
+++ b/test/sicmutils/special/factorial_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2022 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.special.factorial-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/sr/boost_test.cljc
+++ b/test/sicmutils/sr/boost_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sr.boost-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/sr/frames_test.cljc
+++ b/test/sicmutils/sr/frames_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.sr.frames-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.structure-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/tex_web_test.clj
+++ b/test/sicmutils/tex_web_test.clj
@@ -16,15 +16,14 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this code; if not, see <http://www.gnu.org/licenses/>."
 
+#_{:clj-kondo/ignore [:refer-all]}
 (ns sicmutils.tex-web-test
   (:refer-clojure :exclude [+ - * / = compare ref partial zero? numerator denominator])
   (:require [nextjournal.clerk :as clerk]
-            [sicmutils.env :as e]
+            [sicmutils.env :as e :refer :all]
             [sicmutils.examples.central-potential :as central]
             [sicmutils.examples.double-pendulum :as double]
             [sicmutils.examples.driven-pendulum :as driven]))
-
-(e/bootstrap-repl!)
 
 ;; ## Showing Off Renderers
 

--- a/test/sicmutils/tex_web_test.clj
+++ b/test/sicmutils/tex_web_test.clj
@@ -62,7 +62,7 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 ;; ## central-potential
 
-(->tex (central/equations 'm 'M))
+(->tex (central/equations))
 
 ;; ## down-of-ups
 

--- a/test/sicmutils/tex_web_test.clj
+++ b/test/sicmutils/tex_web_test.clj
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.tex-web-test
   (:refer-clojure :exclude [+ - * / = compare ref partial zero?

--- a/test/sicmutils/util/aggregate_test.cljc
+++ b/test/sicmutils/util/aggregate_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.aggregate-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/util/permute_test.cljc
+++ b/test/sicmutils/util/permute_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.permute-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/util/stream_test.cljc
+++ b/test/sicmutils/util/stream_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.stream-test
   "Tests of the various sequence convergence and generation utilities in the SICM

--- a/test/sicmutils/util/vector_set_test.cljc
+++ b/test/sicmutils/util/vector_set_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2020 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2020 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util.vector-set-test
   (:require [clojure.set :as cs]

--- a/test/sicmutils/util_test.cljc
+++ b/test/sicmutils/util_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2021 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2021 Sam Ritchie.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.util-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/value_test.cljc
+++ b/test/sicmutils/value_test.cljc
@@ -1,21 +1,20 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_
+"Copyright © 2017 Colin Smith.
+This work is based on the Scmutils system of MIT/GNU Scheme:
+Copyright © 2002 Massachusetts Institute of Technology
+
+This is free software;  you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at
+your option) any later version.
+
+This software is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.value-test
   (:require [clojure.test :refer [is deftest testing]]


### PR DESCRIPTION
Thank you to @ozimos for getting this started! This PR extends his work to other namespaces meant to be rendered in literate style.

Include the `example` macro like this:

```clj
(defmacro examples [& body]
  (when (some-> (requiring-resolve 'nextjournal.clerk.config/*in-clerk*) deref)
    `(nextjournal.clerk/with-viewer {:render-fn '#(v/html (into [:div.flex.flex-col] (v/inspect-children %2) %1))}
       (vector ~@body))))
```

More examples:

https://github.com/nextjournal/clerk/blob/a44f021a5f90defe877f3cfec81e164a844f7b39/notebooks/multiviewer.clj#L7

Do something similar for setup-viewers! to work with no library.

```clj
(ns clerk-viewers
  (:require [nextjournal.clerk.viewer :as viewer]
            [sicmutils.expression :as e]
            [sicmutils.expression.render :as r]))

(def sicmutils-viewers
  [{:pred e/literal?
    :transform-fn (comp viewer/tex r/->TeX)}])

(defn setup-viewers! []
  (swap! viewer/!viewers
         update :root (fn [default-viewers]
                        (into (mapv viewer/process-render-fn sicmutils-viewers)
                              default-viewers))))
```

- [x] don't start clerk on npm run test; fixing this fixes cljs tests, woohoo
- [x] replace all file headers with clerk-friendly headers, somehow do a better find-replace...