### PR TITLE
Remove js* forms, enable log, exp for js/BigInt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- PR:
+- #489:
 
   - Installs `g/log` and `g/exp` for `js/BigInt` instances, enabling `g/log2` and
     `g/log10` in the mix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## unreleased
 
+- PR:
+
+  - Installs `g/log` and `g/exp` for `js/BigInt` instances, enabling `g/log2` and
+    `g/log10` in the mix.
+
+  - Removes most `js*` calls using `coercive-=` and `js-mod`. This form is
+    internal and should be avoided.
+
 - #484 adds `sicmutils.polynomial/from-power-series`, for generating a
   polynomial instance from some prefix of a (univariate) power series.
 

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -257,9 +257,9 @@
              (bigint-gcd [a b]
                (loop [a (abs a)
                       b (abs b)]
-                 (if (js* "~{} == ~{}" b 0)
+                 (if (coercive-= b 0)
                    a
-                   (recur b (js* "~{} % ~{}" a b)))))]
+                   (recur b (js-mod a b)))))]
 
        ;; The following GCD implementations use native operations to get more
        ;; speed than the generic implementation in `sicmutils.euclid`.
@@ -312,19 +312,14 @@
          (g/invert (js* "~{} ** ~{}" a (core-minus b)))
          (js* "~{} ** ~{}" a b)))
 
-     ;; Not ideal; TODO find a better way to calculate this without the
-     ;; downcast.
-     (defmethod g/sqrt [js/BigInt] [a]
-       (Math/sqrt (js/Number a)))
-
      (defmethod g/abs [js/BigInt] [a] (if (neg? a) (core-minus a) a))
      (defmethod g/quotient [js/BigInt js/BigInt] [a b] (core-div a b))
-     (defmethod g/remainder [js/BigInt js/BigInt] [a b] (js* "~{} % ~{}" a b))
+     (defmethod g/remainder [js/BigInt js/BigInt] [a b] (js-mod a b))
      (defmethod g/magnitude [js/BigInt] [a]
        (if (neg? a) (core-minus a) a))
 
      (defmethod g/div [js/BigInt js/BigInt] [a b]
-       (let [rem (js* "~{} % ~{}" a b)]
+       (let [rem (js-mod a b)]
          (if (v/zero? rem)
            (core-div a b)
            (r/rationalize a b))))
@@ -347,12 +342,12 @@
 
      ;; BigInt can't handle these operations natively, so we override with a
      ;; downcast to number for now.
-
      (doseq [op [g/cos g/sin g/tan
                  g/asin g/acos g/atan
                  g/cosh g/sinh g/tanh
                  g/asinh g/acosh g/acosh
-                 g/cot g/sec g/csc g/sech g/csch]]
+                 g/cot g/sec g/csc g/sech g/csch
+                 g/log g/exp g/sqrt]]
        (defmethod op [js/BigInt] [a]
          (op (js/Number a))))
 

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -296,10 +296,10 @@
    ;; These definitions are required for the protocol implementation below.
    (do
      (defmethod = [::native-integral js/BigInt] [l r]
-       (js*  "~{} == ~{}" l r))
+       (coercive-= l r))
 
      (defmethod = [js/BigInt ::native-integral] [l r]
-       (js*  "~{} == ~{}" l r))
+       (coercive-= l r))
 
      (doseq [[from to f] [[goog.math.Long goog.math.Integer u/int]
                           [::native-integral goog.math.Integer u/int]
@@ -342,7 +342,7 @@
      (-equiv [this o]
        (let [other (.valueOf o)]
          (if (u/bigint? other)
-           (js*  "~{} == ~{}" this other)
+           (coercive-= this other)
            (= this other))))
 
      IPrintWithWriter
@@ -412,9 +412,9 @@
 
      (extend-protocol Value
        js/BigInt
-       (zero? [x] (js*  "~{} == ~{}" big-zero x))
-       (one? [x] (js*  "~{} == ~{}" big-one x))
-       (identity? [x] (js*  "~{} == ~{}" big-one x))
+       (zero? [x] (coercive-= big-zero x))
+       (one? [x] (coercive-= big-one x))
+       (identity? [x] (coercive-= big-one x))
        (zero-like [_] big-zero)
        (one-like [_] big-one)
        (identity-like [_] big-one)

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -75,6 +75,19 @@
   (gt/integral-tests identity :exclusions #{:exact-divide})
   (gt/floating-point-tests identity :eq near)
 
+  (testing "log, exp works on bigint"
+    (is (ish? 59874.14171519782
+              (g/exp #sicm/bigint 11)))
+
+    (is (ish? 2.3978952727983707
+              (g/log #sicm/bigint 11)))
+
+    (is (ish? 3.4594316186372978
+              (g/log2 #sicm/bigint 11)))
+
+    (is (ish? 1.041392685158225
+              (g/log10 #sicm/bigint 11))))
+
   (testing "log converts to complex"
     (is (c/complex? (g/log -10)))
     (is (= (c/complex 0 Math/PI) (g/log -1))))


### PR DESCRIPTION
This PR:

  - Installs `g/log` and `g/exp` for `js/BigInt` instances, enabling `g/log2` and
    `g/log10` in the mix.

  - Removes most `js*` calls using `coercive-=` and `js-mod`. This form is
    internal and should be avoided.