### PR TITLE
Add bisect namespace for bisection search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- Add bisect.cljc
+
 - #484 adds `sicmutils.polynomial/from-power-series`, for generating a
   polynomial instance from some prefix of a (univariate) power series.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## unreleased
 
-- Add bisect.cljc
+- #490 adds `sicmutils.numerical.roots.bisect` with implementations of bisection
+  search, secant search and a mixed method found in `scmutils`. These all live
+  under a `bisect` function.
+
+  The data structure returned is similar to the minimization functions in the
+  `sicmutils.numeric.{unimin, multimin}` namespaces. As more root-finding
+  methods come online this should all standardize nicely.
 
 - #484 adds `sicmutils.polynomial/from-power-series`, for generating a
   polynomial instance from some prefix of a (univariate) power series.

--- a/src/sicmutils/numerical/roots/bisect.cljc
+++ b/src/sicmutils/numerical/roots/bisect.cljc
@@ -1,0 +1,186 @@
+;;
+;; Copyright © 2022 Sam Ritchie.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
+
+(ns sicmutils.numerical.roots.bisect
+  (:require [sicmutils.util :as u]
+            [sicmutils.util.stream :as us]
+            [taoensso.timbre :as log]))
+
+;; ## Root finding by successive bisection
+
+;; ### Simple bisection search
+
+;; In IEEE 754 binary floating point I think this will always converge to full
+;; precision, but I have not proved it. GJS
+
+(defn bisect-1 [f x0 x1]
+  (let [fx0 (f x0)
+        fx1 (f x1)]
+    (when (> (* fx0 fx1) 0.0)
+      (throw
+       (ex-info "root not bounded"
+                {:x0 x0 :x1 x1 :fx0 fx0 :fx1 fx1})))
+    (loop [x0 x0 fx0 fx0 x1 x1 fx1 fx1]
+      (cond (zero? fx0) x0
+	          (zero? fx1) x1
+	          :else
+	          (let [xm (/ (+ x0 x1) 2.0)]
+	            (cond (= x0 xm) x0
+		                (= x1 xm) x1
+		                :else
+		                (let [fxm (f xm)]
+			                (if (< (* fx1 fxm) 0.0)
+			                  (recur xm fxm x1 fx1)
+			                  (recur x0 fx0 xm fxm)))))))))
+
+(defn bisect-2
+  "Simple bisection search terminating when x0 close to x1."
+  [f x0 x1 eps]
+  (let [close? (us/close-enuf? eps)]
+    (loop [x0 x0 fx0 (f x0) x1 x1 fx1 (f x1)]
+      (cond (zero? fx0) x0
+	          (zero? fx1) x1
+	          :else
+            (if (> (* fx1 fx0) 0.0)
+		          (u/illegal "root not bounded")
+		          (let [xm (/ (+ x0 x1) 2.0)]
+		            (if (close? x0 x1)
+		              xm
+		              (let [fxm (f xm)]
+			              (if (< (* fx1 fxm) 0.0)
+			                (recur xm fxm x1 fx1)
+			                (recur x0 fx0 xm fxm))))))))))
+
+
+;;; Bisection with interpolation
+
+(defn bisect-fp [f x0 x1 eps]
+  (let [close? (us/close-enuf? eps)]
+    (loop [x0 x0 fx0 (f x0) x1 x1 fx1 (f x1)]
+      (cond (zero? fx0) x0
+	          (zero? fx1) x1
+            :else
+            (if (> (* fx1 fx0) 0.0)
+		          (u/illegal "root not bounded")
+		          (let [xm (/ (- (* fx1 x0)
+                             (* fx0 x1))
+                          (- fx1 fx0))]
+		            (if (close? x0 x1)
+		              xm
+		              (let [fxm (f xm)]
+			              (if (< (* fx1 fxm) 0.0)
+			                (recur xm fxm x1 fx1)
+			                (recur x0 fx0 xm fxm))))))))))
+
+;; for example
+
+;; (define (kepler ecc m)
+;;   (bisect-fp
+;;    (lambda (e)
+;;            (write-line e)
+;;            (- e (* ecc (sin e)) m))
+;;    0.0
+;;    2pi
+;;    1e-15))
+
+;; (kepler .99 .01)
+;; 6.283185307179586
+;; 0.
+;; .01
+;; .01988423649613729
+;; 2.9653394755776365e-2
+;; 3.9307245802801455e-2
+;; ;;; Total of 536 lines here -- ugh!
+;; .3422703164917746
+;; .3422703164917747
+;; .34227031649177475
+;; .3422703164917748
+;; .34227031649177486
+;; .342270316491775
+;;                                         ;Value: .342270316491775
+
+;;; Mixed strategy
+;;;   for iterations up to *bisect-break* uses midpoint
+;;;   for iterations after *bisect-break* uses linear interpolation
+
+(def ^:dynamic *bisect-break* 60)
+
+(def ^:dynamic *bisect-wallp* false)
+
+(def ^:dynamic *bisect-error?* false)
+
+(defn bisect
+  ([f x0 x1 eps]
+   (bisect f x0 x1 eps *bisect-break*))
+  ([f x0 x1 eps n-break]
+   (let [done? (us/close-enuf? eps)]
+     (loop [x0 x0
+            fx0 (f x0)
+            x1 x1
+            fx1 (f x1)
+            iter 0]
+       (when *bisect-wallp* (log/info [x0 x1]))
+       (cond (zero? fx0) x0
+	           (zero? fx1) x1
+
+             (> (* fx1 fx0) 0.0)
+             (if *bisect-error?*
+               (u/illegal "root not bounded")
+               false)
+		         :else
+             (let [xm (if (< iter n-break)
+				                (/ (+ x0 x1) 2.0)
+				                (/ (- (* fx1 x0) (* fx0 x1))
+                           (- fx1 fx0)))]
+		           (if (done? x0 x1)
+			           xm
+			           (let [fxm (f xm)]
+			             (if (< (* fx1 fxm) 0.0)
+			               (recur xm fxm x1 fx1 (inc iter))
+			               (recur x0 fx0 xm fxm (inc iter)))))))))))
+
+;; If we don't know anything, it is usually a good idea to break the interval
+;; into dx-sized pieces and look for roots in each interval.
+
+(defn find-a-root [f x0 x1 dx eps continue failure]
+  (letfn [(find [x0 x1]
+            (if (> (Math/abs (- x0 x1)) dx)
+	            (let [f1 (f x1)
+                    f0 (f x0)]
+	              (if (< (* f0 f1) 0)
+	                (continue (bisect f x0 x1 eps))
+	                (let [xm (/ (+ x0 x1) 2)]
+		                (find x0 xm)
+		                (find xm x1))))
+	            failure))]
+    (find x0 x1)))
+
+;; Collect the roots found.
+
+(defn search-for-roots [f x0 x1 eps small]
+  (letfn [(find-roots [x0 x1]
+            (let [f1 (f x1) f0 (f x0)]
+              (if (< (Math/abs (- x1 x0)) small)
+	              (if (< (* f0 f1) 0)
+	                [(bisect f x0 x1 eps)]
+	                [])
+	              (let [xm (/ (+ x0 x1) 2)]
+	                (into (find-roots x0 xm)
+		                    (find-roots xm x1))))))]
+    (find-roots x0 x1)))

--- a/src/sicmutils/numerical/roots/bisect.cljc
+++ b/src/sicmutils/numerical/roots/bisect.cljc
@@ -18,114 +18,154 @@
 ;;
 
 (ns sicmutils.numerical.roots.bisect
-  (:require [sicmutils.util :as u]
-            [sicmutils.util.stream :as us]
-            [taoensso.timbre :as log]))
+  (:require [sicmutils.util.stream :as us]))
 
 ;; ## Root finding by successive bisection
 
+(def ^{:dynamic true
+       :doc "If `true` the functions in this namespace will throw an error when
+  encountering bounds of the same sign (in which no root is guaranteed.) If
+  `false`, functions will return false.
+
+  `false` by default."}
+  *bisect-error?* false)
+
+(def ^{:dynamic true
+       :doc "If bound to some function `f`, [[bisect]] will pass each vector `[x0,
+  x1]` it encounters during search to `f`."}
+  *bisect-tap* false)
+
+(def ^{:dynamic true
+       :doc "Controls the default behavior of [[bisect]]'s search.
+  See [[bisect]]'s docstring for more info."}
+  *bisect-break* 60)
+
 ;; ### Simple bisection search
+;;
+;; Note from GJS: "In IEEE 754 binary floating point I think this will always
+;; converge to full precision, but I have not proved it."
 
-;; In IEEE 754 binary floating point I think this will always converge to full
-;; precision, but I have not proved it. GJS
+(defn bisect-1
+  "Given a smooth function `f` and (inclusive) lower and upper bounds `x0` and
+  `x1` on the domain, attempts to find a root of `f`, ie, a value `x` for
+  which `(f x)` is equal to 0.
 
-(defn bisect-1 [f x0 x1]
+  [[bisect-1]] works by successively bisecting the range until it's not possible
+  to distinguish neighboring values.
+
+  Errors if the bounds `x0` and `x1` do not contain a root."
+  [f x0 x1]
   (let [fx0 (f x0)
         fx1 (f x1)]
-    (when (> (* fx0 fx1) 0.0)
-      (throw
-       (ex-info "root not bounded"
-                {:x0 x0 :x1 x1 :fx0 fx0 :fx1 fx1})))
-    (loop [x0 x0 fx0 fx0 x1 x1 fx1 fx1]
-      (cond (zero? fx0) x0
-	          (zero? fx1) x1
-	          :else
-	          (let [xm (/ (+ x0 x1) 2.0)]
-	            (cond (= x0 xm) x0
-		                (= x1 xm) x1
-		                :else
-		                (let [fxm (f xm)]
-			                (if (< (* fx1 fxm) 0.0)
-			                  (recur xm fxm x1 fx1)
-			                  (recur x0 fx0 xm fxm)))))))))
+    (if (> (* fx0 fx1) 0.0)
+      (if *bisect-error?*
+        (throw
+         (ex-info "root not bounded"
+                  {:x0 x0 :x1 x1 :fx0 fx0 :fx1 fx1}))
+        false)
+      (loop [x0 x0 fx0 fx0 x1 x1 fx1 fx1]
+        (cond (zero? fx0) x0
+              (zero? fx1) x1
+              :else
+              (let [xm (/ (+ x0 x1) 2.0)]
+                (cond (= x0 xm) x0
+                      (= x1 xm) x1
+                      :else
+                      (let [fxm (f xm)]
+                        (if (< (* fx1 fxm) 0.0)
+                          (recur xm fxm x1 fx1)
+                          (recur x0 fx0 xm fxm))))))))))
 
 (defn bisect-2
-  "Simple bisection search terminating when x0 close to x1."
+  "Given a smooth function `f` and (inclusive) lower and upper bounds `x0` and
+  `x1` on the domain, attempts to find a root of `f`, ie, a value `x` for
+  which `(f x)` is equal to 0.
+
+  Like [[bisect-1]], [[bisect-2]] successively bisects the domain of `f` in its
+  search for a root. Unlike [[bisect-1]], [[bisect-2]] terminates (and returns
+  the midpoint) when the down search narrows down to a bound less than `eps`
+  wide.
+
+  Errors if the bounds `x0` and `x1` do not contain a root."
   [f x0 x1 eps]
   (let [close? (us/close-enuf? eps)]
     (loop [x0 x0 fx0 (f x0) x1 x1 fx1 (f x1)]
       (cond (zero? fx0) x0
-	          (zero? fx1) x1
-	          :else
+            (zero? fx1) x1
+            :else
             (if (> (* fx1 fx0) 0.0)
-		          (u/illegal "root not bounded")
-		          (let [xm (/ (+ x0 x1) 2.0)]
-		            (if (close? x0 x1)
-		              xm
-		              (let [fxm (f xm)]
-			              (if (< (* fx1 fxm) 0.0)
-			                (recur xm fxm x1 fx1)
-			                (recur x0 fx0 xm fxm))))))))))
+              (if *bisect-error?*
+                (throw
+                 (ex-info "root not bounded"
+                          {:x0 x0 :x1 x1 :fx0 fx0 :fx1 fx1}))
+                false)
+              (let [xm (/ (+ x0 x1) 2.0)]
+                (if (close? x0 x1)
+                  xm
+                  (let [fxm (f xm)]
+                    (if (< (* fx1 fxm) 0.0)
+                      (recur xm fxm x1 fx1)
+                      (recur x0 fx0 xm fxm))))))))))
 
+;; ### Bisection with interpolation
 
-;;; Bisection with interpolation
+(defn bisect-fp
+  "Given a smooth function `f` and (inclusive) lower and upper bounds `x0` and
+  `x1` on the domain, attempts to find a root of `f`, ie, a value `x` for
+  which `(f x)` is equal to 0.
 
-(defn bisect-fp [f x0 x1 eps]
+  [[bisect-fp]] chooses the split point for its searches by interpolating
+  between `(x0, f(x0))` and `(x1, f(x1))` during each cut.
+
+  [[bisect-fp]] terminates (and returns the midpoint) when the search narrows
+  down to a bound less than `eps` wide.
+
+  Errors if the bounds `x0` and `x1` do not contain a root."
+  [f x0 x1 eps]
   (let [close? (us/close-enuf? eps)]
     (loop [x0 x0 fx0 (f x0) x1 x1 fx1 (f x1)]
       (cond (zero? fx0) x0
-	          (zero? fx1) x1
+            (zero? fx1) x1
             :else
             (if (> (* fx1 fx0) 0.0)
-		          (u/illegal "root not bounded")
-		          (let [xm (/ (- (* fx1 x0)
+              (if *bisect-error?*
+                (throw
+                 (ex-info "root not bounded"
+                          {:x0 x0 :x1 x1 :fx0 fx0 :fx1 fx1}))
+                false)
+              (let [xm (/ (- (* fx1 x0)
                              (* fx0 x1))
                           (- fx1 fx0))]
-		            (if (close? x0 x1)
-		              xm
-		              (let [fxm (f xm)]
-			              (if (< (* fx1 fxm) 0.0)
-			                (recur xm fxm x1 fx1)
-			                (recur x0 fx0 xm fxm))))))))))
+                (if (close? x0 x1)
+                  xm
+                  (let [fxm (f xm)]
+                    (if (< (* fx1 fxm) 0.0)
+                      (recur xm fxm x1 fx1)
+                      (recur x0 fx0 xm fxm))))))))))
 
-;; for example
-
-;; (define (kepler ecc m)
-;;   (bisect-fp
-;;    (lambda (e)
-;;            (write-line e)
-;;            (- e (* ecc (sin e)) m))
-;;    0.0
-;;    2pi
-;;    1e-15))
-
-;; (kepler .99 .01)
-;; 6.283185307179586
-;; 0.
-;; .01
-;; .01988423649613729
-;; 2.9653394755776365e-2
-;; 3.9307245802801455e-2
-;; ;;; Total of 536 lines here -- ugh!
-;; .3422703164917746
-;; .3422703164917747
-;; .34227031649177475
-;; .3422703164917748
-;; .34227031649177486
-;; .342270316491775
-;;                                         ;Value: .342270316491775
-
-;;; Mixed strategy
-;;;   for iterations up to *bisect-break* uses midpoint
-;;;   for iterations after *bisect-break* uses linear interpolation
-
-(def ^:dynamic *bisect-break* 60)
-
-(def ^:dynamic *bisect-wallp* false)
-
-(def ^:dynamic *bisect-error?* false)
+;; ### Mixed strategy
 
 (defn bisect
+  "Given a smooth function `f` and (inclusive) lower and upper bounds `x0` and
+  `x1` on the domain, attempts to find a root of `f`, ie, a value `x` for
+  which `(f x)` is equal to 0.
+
+  [[bisect]] uses a strategy mixed between that of [[bisect-2]]
+  and [[bisect-fp]]:
+
+  - for iterations up to `n-break` uses midpoint
+  - for iterations after `n-break` uses linear interpolation
+
+  `n-break` defaults to the dynamically bindable `*bisect-break*` (which
+  defaults to 60). Bind `*bisect-break*` to modify the behavior of [[bisect]]
+  when it's used inside a nested routine.
+
+  If `*bisect-tap*` is bound to a function, it will be called with the vector
+  `[x0 x1]` for each range investigated.
+
+    If `*bisect-error*` is bound to true, [[bisect]] will throw if the bounds
+  `x0` and `x1` do not contain a root. If bound to `false`, returns `false` if
+  no root is found."
   ([f x0 x1 eps]
    (bisect f x0 x1 eps *bisect-break*))
   ([f x0 x1 eps n-break]
@@ -135,52 +175,49 @@
             x1 x1
             fx1 (f x1)
             iter 0]
-       (when *bisect-wallp* (log/info [x0 x1]))
+       (when *bisect-tap*
+         (*bisect-tap* [x0 x1]))
+
        (cond (zero? fx0) x0
-	           (zero? fx1) x1
+             (zero? fx1) x1
 
              (> (* fx1 fx0) 0.0)
              (if *bisect-error?*
-               (u/illegal "root not bounded")
+               (throw
+                (ex-info "root not bounded"
+                         {:x0 x0 :x1 x1 :fx0 fx0 :fx1 fx1}))
                false)
-		         :else
+             :else
              (let [xm (if (< iter n-break)
-				                (/ (+ x0 x1) 2.0)
-				                (/ (- (* fx1 x0) (* fx0 x1))
+                        (/ (+ x0 x1) 2.0)
+                        (/ (- (* fx1 x0) (* fx0 x1))
                            (- fx1 fx0)))]
-		           (if (done? x0 x1)
-			           xm
-			           (let [fxm (f xm)]
-			             (if (< (* fx1 fxm) 0.0)
-			               (recur xm fxm x1 fx1 (inc iter))
-			               (recur x0 fx0 xm fxm (inc iter)))))))))))
+               (if (done? x0 x1)
+                 xm
+                 (let [fxm (f xm)]
+                   (if (< (* fx1 fxm) 0.0)
+                     (recur xm fxm x1 fx1 (inc iter))
+                     (recur x0 fx0 xm fxm (inc iter)))))))))))
 
 ;; If we don't know anything, it is usually a good idea to break the interval
 ;; into dx-sized pieces and look for roots in each interval.
 
-(defn find-a-root [f x0 x1 dx eps continue failure]
-  (letfn [(find [x0 x1]
-            (if (> (Math/abs (- x0 x1)) dx)
-	            (let [f1 (f x1)
-                    f0 (f x0)]
-	              (if (< (* f0 f1) 0)
-	                (continue (bisect f x0 x1 eps))
-	                (let [xm (/ (+ x0 x1) 2)]
-		                (find x0 xm)
-		                (find xm x1))))
-	            failure))]
-    (find x0 x1)))
+(defn search-for-roots
+  "Given a smooth function `f` and (inclusive) lower and upper bounds `x0` and
+  `x1` on the domain, attempts to find all roots of `f`, ie, a vector of values
+  `x_n` such that each `(f x_n)` is equal to 0.
 
-;; Collect the roots found.
-
-(defn search-for-roots [f x0 x1 eps small]
+  [[search-for-roots]] first attempts to cut the (inclusive) range `[x0, x1]`
+  into pieces at most `dx` wide; then [[bisect]] is used to search each segment
+  for a root."
+  [f x0 x1 eps dx]
   (letfn [(find-roots [x0 x1]
             (let [f1 (f x1) f0 (f x0)]
-              (if (< (Math/abs (- x1 x0)) small)
-	              (if (< (* f0 f1) 0)
-	                [(bisect f x0 x1 eps)]
-	                [])
-	              (let [xm (/ (+ x0 x1) 2)]
-	                (into (find-roots x0 xm)
-		                    (find-roots xm x1))))))]
+              (if (< (Math/abs (- x1 x0)) dx)
+                (if (< (* f0 f1) 0.0)
+                  [(bisect f x0 x1 eps)]
+                  [])
+                (let [xm (/ (+ x0 x1) 2.0)]
+                  (into (find-roots x0 xm)
+                        (find-roots xm x1))))))]
     (find-roots x0 x1)))

--- a/src/sicmutils/util/stream.cljc
+++ b/src/sicmutils/util/stream.cljc
@@ -81,7 +81,7 @@
 ;; available ideas about relative and maximum tolerance so we can share (and
 ;; combine) them across different stream functions.
 
-(defn- close-enuf?
+(defn ^:no-doc close-enuf?
   "relative closeness, transitioning to absolute closeness when we get
   significantly smaller than 1."
   [tolerance]

--- a/test/sicmutils/numerical/roots/bisect_test.cljc
+++ b/test/sicmutils/numerical/roots/bisect_test.cljc
@@ -1,0 +1,95 @@
+;;
+;; Copyright © 2022 Sam Ritchie.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
+
+(ns sicmutils.numerical.roots.bisect-test
+  (:require [clojure.test :refer [is deftest testing]]
+            [same :refer [ish?]
+             #?@(:cljs [:include-macros true])]
+            [sicmutils.generic :as g]
+            [sicmutils.numerical.roots.bisect :as bi]
+            [sicmutils.value :as v]))
+
+(deftest bisect-tests
+  (testing "bisect-1"
+    (letfn [(kepler-1 [ecc m]
+              (let [evals (atom 0)
+                    result (bi/bisect-1
+                            (fn [e]
+                              (swap! evals inc)
+                              (- e (* ecc (g/sin e)) m))
+                            0.0
+                            v/twopi)]
+                [@evals result]))]
+      (testing "for example, this took 51 evaluations of f."
+        (let [[evals result] (kepler-1 0.99 0.01)]
+          (is (= 58 evals))
+          (is (ish? 0.34227031649177486
+                    result))))))
+
+  (testing "bisect-2"
+    (letfn [(kepler-2 [ecc m]
+              (let [evals (atom 0)
+                    result (bi/bisect-2
+                            (fn [e]
+                              (swap! evals inc)
+                              (- e (* ecc (g/sin e)) m))
+                            0.0
+                            v/twopi
+                            1e-15)]
+                [@evals result]))]
+      (testing "for example, this took 51 evaluations of f."
+        (let [[evals result] (kepler-2 0.99 0.01)]
+          (is (= 55 evals))
+          (is (ish? 0.34227031649177453
+                    result))))))
+
+  (testing "bisect-fp"
+    (letfn [(kepler-fp [ecc m]
+              (let [evals (atom 0)
+                    result (bi/bisect-fp
+                            (fn [e]
+                              (swap! evals inc)
+                              (- e (* ecc (g/sin e)) m))
+                            0.0
+                            v/twopi
+                            1e-15)]
+                [@evals result]))]
+      (testing "for example, this took 51 evaluations of f."
+        (let [[evals result] (kepler-fp 0.99 0.01)]
+          (is (= 542 evals))
+          (is (ish? 0.342270316491775
+                    result))))))
+
+  (testing "bisect"
+    (letfn [(kepler [ecc m]
+              (let [evals (atom 0)
+                    result (bi/bisect
+                            (fn [e]
+                              (swap! evals inc)
+                              (- e (* ecc (g/sin e)) m))
+                            0.0
+                            v/twopi
+                            1e-15
+                            20)]
+                [@evals result]))]
+      (testing "for example, this took 51 evaluations of f."
+        (let [[evals result] (kepler 0.99 0.01)]
+          (is (= 25 evals))
+          (is (ish? 0.3422703164917752
+                    result)))))))

--- a/test/sicmutils/numerical/roots/bisect_test.cljc
+++ b/test/sicmutils/numerical/roots/bisect_test.cljc
@@ -22,6 +22,7 @@
             [same :refer [ish?]
              #?@(:cljs [:include-macros true])]
             [sicmutils.generic :as g]
+            [sicmutils.numbers]
             [sicmutils.numerical.roots.bisect :as bi]
             [sicmutils.value :as v]))
 
@@ -92,4 +93,12 @@
         (let [[evals result] (kepler 0.99 0.01)]
           (is (= 25 evals))
           (is (ish? 0.3422703164917752
-                    result)))))))
+                    result))))))
+
+  (testing "search-for-roots"
+    (letfn [(poly [x] (* (- x 1) (- x 2) (- x 3)))]
+      (let [eps 1e-15
+            dx 2]
+        (is (ish? [1 2 3]
+                  (bi/search-for-roots poly -10 10 eps dx))
+            "search-for-roots finds all roots.")))))


### PR DESCRIPTION
- #490 adds `sicmutils.numerical.roots.bisect` with implementations of bisection
  search, secant search and a mixed method found in `scmutils`. These all live
  under a `bisect` function.

  The data structure returned is similar to the minimization functions in the
  `sicmutils.numeric.{unimin, multimin}` namespaces. As more root-finding
  methods come online this should all standardize nicely.