### PR TITLE
Add M->Euler to sicmutils.mechanics.rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## unreleased
 
-- add `sicmutils.mechanics.rotation/M->Euler`
+- #491 adds `sicmutils.mechanics.rotation/M->Euler`, for converting from a
+  rotation matrix to a triple of Euler angles. Now we can successfully round
+  trip.
 
 - #489:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- add `sicmutils.mechanics.rotation/M->Euler`
+
 - #484 adds `sicmutils.polynomial/from-power-series`, for generating a
   polynomial instance from some prefix of a (univariate) power series.
 

--- a/src/sicmutils/mechanics/rotation.cljc
+++ b/src/sicmutils/mechanics/rotation.cljc
@@ -147,27 +147,33 @@
 (def rotate-y Ry)
 (def rotate-z Rz)
 
-(defn Euler->M
-  "Compute the rotation matrix from a set of Euler angles."
-  [[θ φ ψ]]
-  (* (rotate-z-matrix φ)
-     (rotate-x-matrix θ)
-     (rotate-z-matrix ψ)))
-
 (defn wcross->w [A]
   (up (get-in A [1 2])
       (get-in A [2 0])
       (get-in A [0 1])))
 
+;; ## Rotation Matrix to Euler Angles
 
-;; RotationMatrix->EulerAngles.scm
+(defn Euler->M
+  "Compute the rotation matrix from a 3-vector of Euler angles.
 
-;;   Rotation Matrix to Euler Angles -- GJS, 28 Sept 2020
+  Our Euler Angle convention:
 
-;; Our Euler Angle convention:
-;;   M(theta, phi, psi) = R_z(phi)*R_x(theta)*R_z(psi)
+  M(theta, phi, psi) = R_z(phi)*R_x(theta)*R_z(psi)"
+  [[theta phi psi]]
+  (* (rotate-z-matrix phi)
+     (rotate-x-matrix theta)
+     (rotate-z-matrix psi)))
+
+;; Ported from code added to scmutils by GJS, 28 Sept 2020.
 
 (defn M->Euler
+  "Given a 3x3 rotation matrix, returns a [[sicmutils.structure/up]] of the
+  corresponding Euler angles.
+
+  Our Euler Angle convention:
+
+  M(theta, phi, psi) = R_z(phi)*R_x(theta)*R_z(psi)"
   ([M]
    (M->Euler M nil))
   ([M tolerance-in-ulps]

--- a/src/sicmutils/mechanics/rotation.cljc
+++ b/src/sicmutils/mechanics/rotation.cljc
@@ -1,27 +1,29 @@
-;
-; Copyright © 2017 Colin Smith.
-; This work is based on the Scmutils system of MIT/GNU Scheme:
-; Copyright © 2002 Massachusetts Institute of Technology
-;
-; This is free software;  you can redistribute it and/or modify
-; it under the terms of the GNU General Public License as published by
-; the Free Software Foundation; either version 3 of the License, or (at
-; your option) any later version.
-;
-; This software is distributed in the hope that it will be useful, but
-; WITHOUT ANY WARRANTY; without even the implied warranty of
-; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-; General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License
-; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;
+;;
+;; Copyright © 2022 Sam Ritchie.
+;; This work is based on the Scmutils system of MIT/GNU Scheme:
+;; Copyright © 2002 Massachusetts Institute of Technology
+;;
+;; This is free software;  you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or (at
+;; your option) any later version.
+;;
+;; This software is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this code; if not, see <http://www.gnu.org/licenses/>.
+;;
 
 (ns sicmutils.mechanics.rotation
   (:refer-clojure :exclude [+ - * /])
-  (:require [sicmutils.generic :as g :refer [cos sin + - *]]
+  (:require [sicmutils.generic :as g :refer [cos sin + - * /]]
             [sicmutils.matrix :as matrix]
-            [sicmutils.structure :as s :refer [up]]))
+            [sicmutils.structure :as s :refer [up]]
+            [sicmutils.util.stream :as us]
+            [sicmutils.value :as v]))
 
 (defn- rotate-x-matrix-2 [c s]
   (matrix/by-rows [1 0 0]
@@ -156,3 +158,46 @@
   (up (get-in A [1 2])
       (get-in A [2 0])
       (get-in A [0 1])))
+
+
+;; RotationMatrix->EulerAngles.scm
+
+;;   Rotation Matrix to Euler Angles -- GJS, 28 Sept 2020
+
+;; Our Euler Angle convention:
+;;   M(theta, phi, psi) = R_z(phi)*R_x(theta)*R_z(psi)
+
+(defn M->Euler
+  ([M]
+   (M->Euler M nil))
+  ([M tolerance-in-ulps]
+   (let [tolerance (if (nil? tolerance-in-ulps)
+                     v/machine-epsilon
+                     (* tolerance-in-ulps v/machine-epsilon))
+         close? (us/close-enuf? tolerance)
+         cx (get-in M [2 2])
+         cx-number? (v/number? cx)]
+     (cond (and cx-number? (close? cx -1)) ;; Nonunique
+           (let [theta Math/PI
+                 phi (- (g/atan
+                         (- (get-in M [0 1]))
+                         (get-in M [0 0])))
+                 psi 0]
+             (up theta phi psi))
+
+           (and cx-number? (close? cx +1)) ;; Nonunique
+           (let [theta 0
+                 phi (g/atan
+                      (- (get-in M [0 1]))
+                      (get-in M [0 0]))
+                 psi 0]
+             (up theta phi psi))
+
+           :else
+           (let [theta (g/acos cx)
+                 sx (sin theta)
+                 phi (g/atan (/ (get-in M [0 2]) sx)
+                             (- (/ (get-in M [1 2]) sx)))
+                 psi (g/atan (/ (get-in M [2 0]) sx)
+                             (/ (get-in M [2 1]) sx))]
+             (up theta phi psi))))))

--- a/src/sicmutils/util/stream.cljc
+++ b/src/sicmutils/util/stream.cljc
@@ -81,7 +81,7 @@
 ;; available ideas about relative and maximum tolerance so we can share (and
 ;; combine) them across different stream functions.
 
-(defn- close-enuf?
+(defn ^:no-doc close-enuf?
   "relative closeness, transitioning to absolute closeness when we get
   significantly smaller than 1."
   [tolerance]

--- a/test/sicmutils/mechanics/rotation_test.cljc
+++ b/test/sicmutils/mechanics/rotation_test.cljc
@@ -20,7 +20,9 @@
 (ns sicmutils.mechanics.rotation-test
   (:refer-clojure :exclude [+ - * /])
   (:require [clojure.test :refer [is deftest testing use-fixtures]]
-            [sicmutils.generic :as g :refer [- * cos sin]]
+            [sicmutils.abstract.number]
+            [sicmutils.generic :as g :refer [- * / cos sin]]
+            [sicmutils.matrix :as matrix]
             [sicmutils.mechanics.rotation :as r]
             [sicmutils.simplify :refer [hermetic-simplify-fixture]]
             [sicmutils.structure :refer [up]]
@@ -102,3 +104,71 @@
               ((- (r/Rz 'a) (rotate-z 'a))
                (up 'x 'y 'z))))
           "r/Rz matches alternative definition from scmutils."))))
+
+(deftest euler-angles-to-rotation-tests
+  (testing "Euler->M"
+    (is (= '(matrix-by-rows
+             (up (+ (* -1 (sin phi) (cos theta) (sin psi)) (* (cos phi) (cos psi)))
+                 (+ (* -1 (sin phi) (cos theta) (cos psi)) (* -1 (sin psi) (cos phi)))
+                 (* (sin phi) (sin theta)))
+             (up (+ (* (cos theta) (sin psi) (cos phi)) (* (sin phi) (cos psi)))
+                 (+ (* (cos theta) (cos phi) (cos psi)) (* -1 (sin phi) (sin psi)))
+                 (* -1 (cos phi) (sin theta)))
+             (up (* (sin psi) (sin theta)) (* (cos psi) (sin theta)) (cos theta)))
+           (simplify
+            (r/Euler->M (up 'theta 'phi 'psi))))))
+
+  (is (= (up 'theta 'phi 'psi)
+         (g/simplify
+          (r/M->Euler
+           (r/Euler->M (up 'theta 'phi 'psi))))))
+
+  (let [Rtest (* (r/rotate-x-matrix 'a)
+                 (r/rotate-y-matrix 'b)
+                 (r/rotate-z-matrix 'c))]
+    (is (= '(matrix-by-rows
+             (up 0 0 0)
+             (up 0 0 0)
+             (up 0 0 0))
+           (simplify
+            (- (r/Euler->M (r/M->Euler Rtest))
+               Rtest)))
+        "slightly harder"))
+
+  (testing "A more serious test"
+    (letfn [(abs-max [M]
+              (let [n (matrix/num-rows M)
+                    m (matrix/num-cols M)]
+                (letfn [(rlp [i max]
+                          (if (= i n)
+                            max
+                            (letfn [(clp [j max]
+                                      (if (= j m)
+                                        (rlp (inc i) max)
+                                        (let [candidate (Math/abs (get-in M [i j]))]
+                                          (if (> candidate max)
+                                            (clp (inc j) candidate)
+                                            (clp (inc j) max)))))]
+                              (clp 0 max))))]
+                  (rlp 0 0))))
+            (centered-random [max]
+              (let [c (/ max 2.0)]
+                (- (rand-int max) c)))
+            (test [range n-trials]
+              (loop [i 0]
+                (if (= i n-trials)
+                  :win!
+                  (let [theta (centered-random range)
+                        phi (centered-random range)
+                        psi (centered-random range)
+                        v (up theta phi psi)
+                                        ; 10 ulps
+                        alternate-angles (r/M->Euler (r/Euler->M v) 10)
+                        result (- (r/Euler->M v)
+                                  (r/Euler->M alternate-angles))]
+                    (if (< (abs-max result) 1e-10)
+                      (recur (inc i))
+                      [:Failed theta phi psi])))))]
+      (is (= :win! (test 10 1000)))
+      (is (= :win! (test 100 1000)))
+      (is (= :win! (test 10.0 1000))))))


### PR DESCRIPTION
- #491 adds `sicmutils.mechanics.rotation/M->Euler`, for converting from a
  rotation matrix to a triple of Euler angles. Now we can successfully round
  trip.