### PR TITLE
Enhance compilation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
     call `eval` on this or call `sci-eval` to get an SCI-evaluated function with
     all proper bindings in place.
 
+  - `compile-state-fn` now takes an optional options map, with support for
+    `:flatten?` and `:generic-params?` keywords. These can be used to tune the
+    shape of the function returned by `compile-state-fn`.
+
 - #485:
 
   - Bumps the JDK version for Github Actions to 17 from 8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## unreleased
 
+- #496 replaces the function values in `sicmutils.expression.compile` with
+  symbols; I hadn't realized before that substituting in symbolic `Math/sqrt`,
+  for example, was possible, vs a `#(Math/sqrt %)` function value. Compiled
+  functions are now faster!!
+
 - #485:
 
   - Bumps the JDK version for Github Actions to 17 from 8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,35 @@
 
 ## unreleased
 
-- #496 replaces the function values in `sicmutils.expression.compile` with
-  symbols; I hadn't realized before that substituting in symbolic `Math/sqrt`,
-  for example, was possible, vs a `#(Math/sqrt %)` function value. Compiled
-  functions are now faster!!
+- #496:
+
+  - replaces the function values in `sicmutils.expression.compile` with symbols;
+    I hadn't realized before that substituting in symbolic `Math/sqrt`, for
+    example, was possible, vs a `#(Math/sqrt %)` function value. Compiled
+    functions are now faster!
+
+    A simulation run of the double pendulum example in the [clerk-demo
+    repository](https://github.com/nextjournal/clerk-demo/blob/20a404a271bea29ef98ee4e60a05e54345aa43ba/notebooks/sicmutils.clj)
+    now runs in 700ms vs the former 2.2 seconds, a major win.
+
+  - Function compilation now pre-simplifies numerical forms encountered inside a
+    function, like `(/ 1 2)`, instead of letting them be evaluated on every fn
+    call.
+
+  - All numerical forms encountered in function compilation are now converted to
+    either `double` on the JVM or `js/Number` in javascript; this way no
+    `BigInt` values etc are left around.
+
+  - In `sicmutils.expression.compile`:
+
+    - gains a new, validating `compiler-mode` function for fetching the compiler
+      function.
+
+    - `set-compiler-mode!` now actually works. It never did!
+
+  - New `:source` compile mode that returns a source code form. You can either
+    call `eval` on this or call `source->sci-fn` to get an SCI-evaluated
+    function with all proper bindings in place.
 
 - #485:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
     - `set-compiler-mode!` now actually works. It never did!
 
   - New `:source` compile mode that returns a source code form. You can either
-    call `eval` on this or call `source->sci-fn` to get an SCI-evaluated
-    function with all proper bindings in place.
+    call `eval` on this or call `sci-eval` to get an SCI-evaluated function with
+    all proper bindings in place.
 
 - #485:
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "npm": "6.14.8"
   },
   "devDependencies": {
-    "markdown-it": "12.2.0",
+    "markdown-it": "12.3.2",
     "markdown-it-block-image": "0.0.3",
     "markdown-it-sidenote": "github:gerwitz/markdown-it-sidenote",
     "markdown-it-texmath": "0.9.1",

--- a/src/sicmutils/expression/compile.cljc
+++ b/src/sicmutils/expression/compile.cljc
@@ -563,6 +563,7 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
               (gensym-fn 'y)))]
     (rec state)))
 
+#_{:clj-kondo/ignore [:redundant-fn-wrapper]}
 (defn compile-state-fn*
   "Returns a compiled, simplified function with signature `(f state params)`,
   given:
@@ -598,7 +599,9 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
    (compile-state-fn* f params initial-state {}))
   ([f params initial-state {:keys [generic-params? gensym-fn]
                             :or {generic-params? true
-                                 gensym-fn gensym}
+                                 ;; redundant fn wrapper since `gensym` is a
+                                 ;; macro in CLJS.
+                                 gensym-fn #(gensym %)}
                             :as opts}]
    (let [sw             (us/stopwatch)
          params         (if generic-params?

--- a/src/sicmutils/expression/compile.cljc
+++ b/src/sicmutils/expression/compile.cljc
@@ -94,8 +94,7 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
        library assumes that your function operates only on doubles (even though
        you wrote it with generic routines)."}
   compiled-fn-whitelist
-  {'up {:sym 'sicmutils.structure/up
-        :f struct/up}
+  {'up {:sym `vector :f vector}
    'down {:sym 'sicmutils.structure/down
           :f struct/down}
    '+ {:sym `+ :f +}
@@ -563,7 +562,6 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
               (gensym-fn 'y)))]
     (rec state)))
 
-#_{:clj-kondo/ignore [:redundant-fn-wrapper]}
 (defn compile-state-fn*
   "Returns a compiled, simplified function with signature `(f state params)`,
   given:
@@ -599,9 +597,7 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
    (compile-state-fn* f params initial-state {}))
   ([f params initial-state {:keys [generic-params? gensym-fn]
                             :or {generic-params? true
-                                 ;; redundant fn wrapper since `gensym` is a
-                                 ;; macro in CLJS.
-                                 gensym-fn #(gensym %)}
+                                 gensym-fn gensym}
                             :as opts}]
    (let [sw             (us/stopwatch)
          params         (if generic-params?

--- a/src/sicmutils/expression/compile.cljc
+++ b/src/sicmutils/expression/compile.cljc
@@ -110,6 +110,9 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
    'quotient 'clojure.core/quot
    'integer-part #?(:clj 'long
                     :cljs 'Math/trunc)
+   ;; NOTE that the proper way to handle this substitution is to add a
+   ;; simplification rule that does this transformation for us. If you hit this
+   ;; and it's slow, consider opening a PR for that.
    'fractional-part '(fn [^double x]
                        (- x (Math/floor x)))
    #?@(:cljs


### PR DESCRIPTION
- #496:

  - replaces the function values in `sicmutils.expression.compile` with symbols;
    I hadn't realized before that substituting in symbolic `Math/sqrt`, for
    example, was possible, vs a `#(Math/sqrt %)` function value. Compiled
    functions are now faster!

    A simulation run of the double pendulum example in the [clerk-demo
    repository](https://github.com/nextjournal/clerk-demo/blob/20a404a271bea29ef98ee4e60a05e54345aa43ba/notebooks/sicmutils.clj)
    now runs in 700ms vs the former 2.2 seconds, a major win.

  - Function compilation now pre-simplifies numerical forms encountered inside a
    function, like `(/ 1 2)`, instead of letting them be evaluated on every fn
    call.

  - All numerical forms encountered in function compilation are now converted to
    either `double` on the JVM or `js/Number` in javascript; this way no
    `BigInt` values etc are left around.

  - In `sicmutils.expression.compile`:

    - gains a new, validating `compiler-mode` function for fetching the compiler
      function.

    - `set-compiler-mode!` now actually works. It never did!

  - New `:source` compile mode that returns a source code form. You can either
    call `eval` on this or call `sci-eval` to get an SCI-evaluated function with
    all proper bindings in place.

  - `compile-state-fn` now takes an optional options map, with support for
    `:flatten?` and `:generic-params?` keywords. These can be used to tune the
    shape of the function returned by `compile-state-fn`.