### PR TITLE
replace all license headers with spdx identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- new: replace all long-form GPL headers with `"SPDX-License-Identifier: GPL-3.0"`.
+
 - #496:
 
   - replaces the function values in `sicmutils.expression.compile` with symbols;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-- new: replace all long-form GPL headers with `"SPDX-License-Identifier: GPL-3.0"`.
+- #498: replace all long-form GPL headers with `"SPDX-License-Identifier:
+  GPL-3.0"`.
 
 - #496:
 

--- a/demo.clj
+++ b/demo.clj
@@ -1,20 +1,6 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
+#_"SPDX-License-Identifier: GPL-3.0"
 
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
 
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
 
 (ns sicmutils.demo
   (:refer-clojure :exclude [+ - * / zero? ref compare])

--- a/logging.properties
+++ b/logging.properties
@@ -1,21 +1,4 @@
-#
-# Copyright © 2017 Colin Smith.
-# This work is based on the Scmutils system of MIT/GNU Scheme:
-# Copyright © 2002 Massachusetts Institute of Technology
-#
-# This is free software;  you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or (at
-# your option) any later version.
-#
-# This software is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this code; if not, see <http://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: GPL-3.0
 
 handlers = java.util.logging.ConsoleHandler
 

--- a/project.clj
+++ b/project.clj
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (defproject sicmutils "0.21.1"
   :description "A port of the scmutils computer algebra/mechanics system to Clojure."

--- a/src/pattern/consequence.cljc
+++ b/src/pattern/consequence.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns pattern.consequence
   "Code for defining and compiling 'consequence' functions, ie, functions from a

--- a/src/pattern/match.cljc
+++ b/src/pattern/match.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns pattern.match
   "Implementation of a pattern matching system inspired by [Gerald Jay Sussman's

--- a/src/pattern/rule.cljc
+++ b/src/pattern/rule.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns pattern.rule
   "This namespace provides an API for building rules out of the matchers and

--- a/src/pattern/syntax.cljc
+++ b/src/pattern/syntax.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns pattern.syntax
   "The syntax namespace defines the default syntax for patterns corresponding to

--- a/src/sicmutils/abstract/function.cljc
+++ b/src/sicmutils/abstract/function.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.abstract.function
   "Implementation of a [[literal-function]] constructor. Literal functions can be

--- a/src/sicmutils/abstract/number.cljc
+++ b/src/sicmutils/abstract/number.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.abstract.number
   "Symbolic expressions in SICMUtils are created through the [[literal-number]]

--- a/src/sicmutils/algebra/fold.cljc
+++ b/src/sicmutils/algebra/fold.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2022 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.algebra.fold
   "Namespace implementing various aggregation functions using the `fold`

--- a/src/sicmutils/calculus/basis.cljc
+++ b/src/sicmutils/calculus/basis.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.basis
   (:require [sicmutils.calculus.form-field :as ff]

--- a/src/sicmutils/calculus/connection.cljc
+++ b/src/sicmutils/calculus/connection.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.connection
   (:require [sicmutils.calculus.basis :as b]

--- a/src/sicmutils/calculus/coordinate.cljc
+++ b/src/sicmutils/calculus/coordinate.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.coordinate
   (:require [sicmutils.calculus.form-field :as ff]

--- a/src/sicmutils/calculus/covariant.cljc
+++ b/src/sicmutils/calculus/covariant.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.covariant
   (:require [sicmutils.calculus.basis :as b]

--- a/src/sicmutils/calculus/curvature.cljc
+++ b/src/sicmutils/calculus/curvature.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.curvature
   (:require [sicmutils.calculus.basis :as b]

--- a/src/sicmutils/calculus/derivative.cljc
+++ b/src/sicmutils/calculus/derivative.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.derivative
   "This namespace implements a number of differential operators like [[D]], and

--- a/src/sicmutils/calculus/form_field.cljc
+++ b/src/sicmutils/calculus/form_field.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.form-field
   "This namespace implements a form field operator and a number of functions for

--- a/src/sicmutils/calculus/frame.cljc
+++ b/src/sicmutils/calculus/frame.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.frame
   (:require [sicmutils.util :as u]))

--- a/src/sicmutils/calculus/hodge_star.cljc
+++ b/src/sicmutils/calculus/hodge_star.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.hodge-star
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/calculus/indexed.cljc
+++ b/src/sicmutils/calculus/indexed.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.indexed
   "This namespace implements minimal support for indexed objects and typed

--- a/src/sicmutils/calculus/manifold.cljc
+++ b/src/sicmutils/calculus/manifold.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.manifold
   "This namespace defines a functional API for:

--- a/src/sicmutils/calculus/map.cljc
+++ b/src/sicmutils/calculus/map.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.map
   "Various definitions and utilities for working with maps between manifolds."

--- a/src/sicmutils/calculus/metric.cljc
+++ b/src/sicmutils/calculus/metric.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.metric
   (:require [sicmutils.calculus.basis :as b]

--- a/src/sicmutils/calculus/vector_calculus.cljc
+++ b/src/sicmutils/calculus/vector_calculus.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.vector-calculus
   "This namespace contains vector calculus operators, in versions built on top

--- a/src/sicmutils/calculus/vector_field.cljc
+++ b/src/sicmutils/calculus/vector_field.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.vector-field
   "This namespace implements a vector field operator and a number of functions for

--- a/src/sicmutils/collection.cljc
+++ b/src/sicmutils/collection.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.collection
   "This namespace contains implementations of various SICMUtils protocols for

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.complex
   "This namespace provides a number of functions and constructors for working

--- a/src/sicmutils/differential.cljc
+++ b/src/sicmutils/differential.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 ^{:nextjournal.clerk/visibility #{:hide-ns}}
 (ns sicmutils.differential

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.env
   "Batteries-included namespace for the [SICMUtils](https://github.com/sicmutils/sicmutils/) library.

--- a/src/sicmutils/env/sci.cljc
+++ b/src/sicmutils/env/sci.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.env.sci
   (:refer-clojure :exclude [ns-map])

--- a/src/sicmutils/env/sci/macros.cljc
+++ b/src/sicmutils/env/sci/macros.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.env.sci.macros
   "This namespace contains reimplementations of various macros from sicmutils,

--- a/src/sicmutils/euclid.cljc
+++ b/src/sicmutils/euclid.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.euclid
   "Implementations of various [greatest common

--- a/src/sicmutils/examples/central_potential.cljc
+++ b/src/sicmutils/examples/central_potential.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.central-potential
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/examples/double_pendulum.cljc
+++ b/src/sicmutils/examples/double_pendulum.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.double-pendulum
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/examples/driven_pendulum.cljc
+++ b/src/sicmutils/examples/driven_pendulum.cljc
@@ -1,21 +1,4 @@
-;;
-;; Copyright © 2017 Colin Smith.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.driven-pendulum
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/examples/pendulum.cljc
+++ b/src/sicmutils/examples/pendulum.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 ;; The simple pendulum supported at the point x (in the plane; x should
 ;; be a function of t returning an up-tuple (up xt yt).

--- a/src/sicmutils/examples/rigid_rotation.cljc
+++ b/src/sicmutils/examples/rigid_rotation.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.rigid-rotation
   (:require [sicmutils.env :as e :refer [up]]

--- a/src/sicmutils/examples/top.cljc
+++ b/src/sicmutils/examples/top.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.top
   (:refer-clojure :exclude [- *])

--- a/src/sicmutils/expression.cljc
+++ b/src/sicmutils/expression.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.expression
   "This namespace contains a number of functions and utilities for manipulating

--- a/src/sicmutils/expression/analyze.cljc
+++ b/src/sicmutils/expression/analyze.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with thixs code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.expression.analyze
   "This namespace defines an API for working with 'expression analyzers' and

--- a/src/sicmutils/expression/compile.cljc
+++ b/src/sicmutils/expression/compile.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.expression.compile
   "This namespace contains tools for compiling functions implemented with the

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.expression.render
   "Functions and utilities for rendering symbolic expressions to various backends

--- a/src/sicmutils/function.cljc
+++ b/src/sicmutils/function.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.function
   "Procedures that act on Clojure's function and multimethod types, along with

--- a/src/sicmutils/generic.cljc
+++ b/src/sicmutils/generic.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.generic
   "The home of most of the SICMUtils extensible generic operations. The bulk of

--- a/src/sicmutils/matrix.cljc
+++ b/src/sicmutils/matrix.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.matrix
   "This namespace contains an implementation of a [[Matrix]] datatype and various

--- a/src/sicmutils/mechanics/hamilton.cljc
+++ b/src/sicmutils/mechanics/hamilton.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.mechanics.hamilton
   (:refer-clojure :exclude [+ - * /  partial])

--- a/src/sicmutils/mechanics/lagrange.cljc
+++ b/src/sicmutils/mechanics/lagrange.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.mechanics.lagrange
   (:refer-clojure :exclude [+ - * / partial])

--- a/src/sicmutils/mechanics/rigid.cljc
+++ b/src/sicmutils/mechanics/rigid.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.mechanics.rigid
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/mechanics/rotation.cljc
+++ b/src/sicmutils/mechanics/rotation.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2022 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.mechanics.rotation
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/modint.cljc
+++ b/src/sicmutils/modint.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.modint
   "This namespace contains an implementation of a [[ModInt]] datatype and various

--- a/src/sicmutils/numbers.cljc
+++ b/src/sicmutils/numbers.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numbers
   "This namespace extends of all appropriate SICMUtils generic operations

--- a/src/sicmutils/numerical/derivative.cljc
+++ b/src/sicmutils/numerical/derivative.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.derivative
   "This namespace contains implementations of various approaches to [numerical

--- a/src/sicmutils/numerical/minimize.cljc
+++ b/src/sicmutils/numerical/minimize.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.minimize
   "Entrypoint for univariate and multivariate minimization routines."

--- a/src/sicmutils/numerical/multimin/nelder_mead.cljc
+++ b/src/sicmutils/numerical/multimin/nelder_mead.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.multimin.nelder-mead
   (:require [sicmutils.util :as u]))

--- a/src/sicmutils/numerical/ode.cljc
+++ b/src/sicmutils/numerical/ode.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.ode
   "ODE solvers for working with initial value problems."

--- a/src/sicmutils/numerical/quadrature.cljc
+++ b/src/sicmutils/numerical/quadrature.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature
   (:require [sicmutils.expression.compile :as c]

--- a/src/sicmutils/numerical/quadrature/adaptive.cljc
+++ b/src/sicmutils/numerical/quadrature/adaptive.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.adaptive
   (:require [sicmutils.numerical.quadrature.common :as qc]

--- a/src/sicmutils/numerical/quadrature/boole.cljc
+++ b/src/sicmutils/numerical/quadrature/boole.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.boole
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/bulirsch_stoer.cljc
+++ b/src/sicmutils/numerical/quadrature/bulirsch_stoer.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.bulirsch-stoer
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/common.cljc
+++ b/src/sicmutils/numerical/quadrature/common.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.common
   "Implements utilities shared by all integrators, for example:

--- a/src/sicmutils/numerical/quadrature/infinite.cljc
+++ b/src/sicmutils/numerical/quadrature/infinite.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.infinite
   (:require [clojure.core.match :refer [match]]

--- a/src/sicmutils/numerical/quadrature/midpoint.cljc
+++ b/src/sicmutils/numerical/quadrature/midpoint.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.midpoint
   (:require [sicmutils.generic :as g]

--- a/src/sicmutils/numerical/quadrature/milne.cljc
+++ b/src/sicmutils/numerical/quadrature/milne.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.milne
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/riemann.cljc
+++ b/src/sicmutils/numerical/quadrature/riemann.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.riemann
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/romberg.cljc
+++ b/src/sicmutils/numerical/quadrature/romberg.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.romberg
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/simpson.cljc
+++ b/src/sicmutils/numerical/quadrature/simpson.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.simpson
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/simpson38.cljc
+++ b/src/sicmutils/numerical/quadrature/simpson38.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.simpson38
   (:require [sicmutils.numerical.quadrature.common :as qc

--- a/src/sicmutils/numerical/quadrature/substitute.cljc
+++ b/src/sicmutils/numerical/quadrature/substitute.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.substitute
   "### U Substitution and Variable Changes

--- a/src/sicmutils/numerical/quadrature/trapezoid.cljc
+++ b/src/sicmutils/numerical/quadrature/trapezoid.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.trapezoid
   "Trapezoid method."

--- a/src/sicmutils/numerical/roots/bisect.cljc
+++ b/src/sicmutils/numerical/roots/bisect.cljc
@@ -1,21 +1,4 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.roots.bisect
   "This namespace contains implementations of a number of methods for root-finding

--- a/src/sicmutils/numerical/unimin/bracket.cljc
+++ b/src/sicmutils/numerical/unimin/bracket.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.unimin.bracket
   (:require [sicmutils.generic :as g]

--- a/src/sicmutils/numerical/unimin/brent.cljc
+++ b/src/sicmutils/numerical/unimin/brent.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.unimin.brent
   "This namespace contains an implementation of Brent's method for finding the

--- a/src/sicmutils/numerical/unimin/golden.cljc
+++ b/src/sicmutils/numerical/unimin/golden.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.unimin.golden
   (:require [sicmutils.generic :as g]

--- a/src/sicmutils/numsymb.cljc
+++ b/src/sicmutils/numsymb.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numsymb
   "Implementations of the generic operations for numeric types that have

--- a/src/sicmutils/operator.cljc
+++ b/src/sicmutils/operator.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.operator
   (:refer-clojure :rename {identity core-identity

--- a/src/sicmutils/polynomial.cljc
+++ b/src/sicmutils/polynomial.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial
   (:refer-clojure :exclude [extend divide identity abs])

--- a/src/sicmutils/polynomial/exponent.cljc
+++ b/src/sicmutils/polynomial/exponent.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns ^:no-doc sicmutils.polynomial.exponent
   "This namespace provides an implementation of a sparse representation of the

--- a/src/sicmutils/polynomial/factor.cljc
+++ b/src/sicmutils/polynomial/factor.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.factor
   "This namespace contains functions for factoring polynomials and symbolic

--- a/src/sicmutils/polynomial/gcd.cljc
+++ b/src/sicmutils/polynomial/gcd.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.gcd
   (:require [clojure.set :as cs]

--- a/src/sicmutils/polynomial/impl.cljc
+++ b/src/sicmutils/polynomial/impl.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns ^:no-doc sicmutils.polynomial.impl
   (:require [sicmutils.generic :as g]

--- a/src/sicmutils/polynomial/interpolate.cljc
+++ b/src/sicmutils/polynomial/interpolate.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.interpolate
   "This namespace contains a discussion of polynomial interpolation, and different

--- a/src/sicmutils/polynomial/richardson.cljc
+++ b/src/sicmutils/polynomial/richardson.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.richardson
   "Richardson interpolation is a special case of polynomial interpolation; knowing

--- a/src/sicmutils/quaternion.cljc
+++ b/src/sicmutils/quaternion.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2022 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.quaternion
   "This namespace provides a number of functions and constructors for working

--- a/src/sicmutils/ratio.cljc
+++ b/src/sicmutils/ratio.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.ratio
   "This namespace provides a number of functions and constructors for working

--- a/src/sicmutils/rational_function.cljc
+++ b/src/sicmutils/rational_function.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.rational-function
   (:refer-clojure :exclude [abs])

--- a/src/sicmutils/rational_function/interpolate.cljc
+++ b/src/sicmutils/rational_function/interpolate.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.rational-function.interpolate
   "This namespace contains a discussion of rational function interpolation, and

--- a/src/sicmutils/series.cljc
+++ b/src/sicmutils/series.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.series
   "This namespace contains an implementation of two data types:

--- a/src/sicmutils/series/impl.cljc
+++ b/src/sicmutils/series/impl.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns ^:no-doc sicmutils.series.impl
   "Backing implementation for the types defined in [[sicmutils.series]], written

--- a/src/sicmutils/simplify.cljc
+++ b/src/sicmutils/simplify.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.simplify
   (:require [sicmutils.expression :as x]

--- a/src/sicmutils/simplify/rules.cljc
+++ b/src/sicmutils/simplify/rules.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.simplify.rules
   "This namespace contains many sets of algebraic simplification rules you can use

--- a/src/sicmutils/special/elliptic.cljc
+++ b/src/sicmutils/special/elliptic.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.special.elliptic
   "This namespace contains function to compute various [elliptic

--- a/src/sicmutils/special/factorial.cljc
+++ b/src/sicmutils/special/factorial.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2022 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.special.factorial
   "Namespace holding implementations of variations on the factorial function."

--- a/src/sicmutils/sr/boost.cljc
+++ b/src/sicmutils/sr/boost.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sr.boost
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/sr/frames.cljc
+++ b/src/sicmutils/sr/frames.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sr.frames
   (:refer-clojure :exclude [+ - * /])

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.structure
   (:require [clojure.string :refer [join]]

--- a/src/sicmutils/util.cljc
+++ b/src/sicmutils/util.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util
   "Shared utilities between clojure and clojurescript."

--- a/src/sicmutils/util/aggregate.cljc
+++ b/src/sicmutils/util/aggregate.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.aggregate
   "Namespace with algorithms for aggregating sequences in various ways."

--- a/src/sicmutils/util/def.cljc
+++ b/src/sicmutils/util/def.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.def
   #?(:clj

--- a/src/sicmutils/util/logic.cljc
+++ b/src/sicmutils/util/logic.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.logic
   "Logic utilities!"

--- a/src/sicmutils/util/permute.cljc
+++ b/src/sicmutils/util/permute.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.permute
   "Utilities for generating permutations of sequences."

--- a/src/sicmutils/util/stopwatch.cljc
+++ b/src/sicmutils/util/stopwatch.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.stopwatch
   (:require [sicmutils.util :as u]

--- a/src/sicmutils/util/stream.cljc
+++ b/src/sicmutils/util/stream.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.stream
   "This namespace contains various standard sequences, as well as utilities for

--- a/src/sicmutils/util/vector_set.cljc
+++ b/src/sicmutils/util/vector_set.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.vector-set
   "Contains an implementation and API for an 'ordered set' data structure backed

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.value
   "The home of most of the protocol-based extensible generic operations offered by

--- a/test/pattern/match_test.cljc
+++ b/test/pattern/match_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns pattern.match-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/pattern/rule_test.cljc
+++ b/test/pattern/rule_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns pattern.rule-test
   (:require [clojure.test :as t :refer [is deftest testing]]

--- a/test/sicmutils/abstract/function_test.cljc
+++ b/test/sicmutils/abstract/function_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.abstract.function-test
   (:refer-clojure :exclude [partial =])

--- a/test/sicmutils/abstract/number_test.cljc
+++ b/test/sicmutils/abstract/number_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.abstract.number-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/algebra/fold_test.cljc
+++ b/test/sicmutils/algebra/fold_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2022 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.algebra.fold-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/calculus/basis_test.cljc
+++ b/test/sicmutils/calculus/basis_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.basis-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/calculus/connection_test.cljc
+++ b/test/sicmutils/calculus/connection_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.connection-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/coordinate_test.cljc
+++ b/test/sicmutils/calculus/coordinate_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.coordinate-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/covariant_test.cljc
+++ b/test/sicmutils/calculus/covariant_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.covariant-test
   (:refer-clojure :exclude [+ - * /  partial])

--- a/test/sicmutils/calculus/curvature_test.cljc
+++ b/test/sicmutils/calculus/curvature_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.curvature-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/derivative_test.cljc
+++ b/test/sicmutils/calculus/derivative_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.derivative-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/calculus/form_field_test.cljc
+++ b/test/sicmutils/calculus/form_field_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.form-field-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/hodge_star_test.cljc
+++ b/test/sicmutils/calculus/hodge_star_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.hodge-star-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/indexed_test.cljc
+++ b/test/sicmutils/calculus/indexed_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.indexed-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/manifold_test.cljc
+++ b/test/sicmutils/calculus/manifold_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.manifold-test
   (:refer-clojure :exclude [* - / +])

--- a/test/sicmutils/calculus/map_test.cljc
+++ b/test/sicmutils/calculus/map_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.map-test
   (:refer-clojure :exclude [+ - * /  partial])

--- a/test/sicmutils/calculus/metric_test.cljc
+++ b/test/sicmutils/calculus/metric_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.metric-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/tensor_test.cljc
+++ b/test/sicmutils/calculus/tensor_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.tensor-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/vector_calculus_test.cljc
+++ b/test/sicmutils/calculus/vector_calculus_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.vector-calculus-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/calculus/vector_field_test.cljc
+++ b/test/sicmutils/calculus/vector_field_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.calculus.vector-field-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/collection_test.cljc
+++ b/test/sicmutils/collection_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.collection-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/complex_test.cljc
+++ b/test/sicmutils/complex_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.complex-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/differential_test.cljc
+++ b/test/sicmutils/differential_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.differential-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/env/sci_test.cljc
+++ b/test/sicmutils/env/sci_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.env.sci-test
   (:refer-clojure :exclude [eval])

--- a/test/sicmutils/env_test.cljc
+++ b/test/sicmutils/env_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.env-test
   (:refer-clojure :exclude [+ - * / zero? partial ref])

--- a/test/sicmutils/euclid_test.cljc
+++ b/test/sicmutils/euclid_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.euclid-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/examples/central_potential_test.cljc
+++ b/test/sicmutils/examples/central_potential_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.central-potential-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/examples/double_pendulum_test.cljc
+++ b/test/sicmutils/examples/double_pendulum_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.double-pendulum-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/examples/driven_pendulum_test.cljc
+++ b/test/sicmutils/examples/driven_pendulum_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.driven-pendulum-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/examples/pendulum_test.cljc
+++ b/test/sicmutils/examples/pendulum_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.pendulum-test
   (:require [clojure.test :refer [is deftest use-fixtures]]

--- a/test/sicmutils/examples/rigid_rotation_test.cljc
+++ b/test/sicmutils/examples/rigid_rotation_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.rigid-rotation-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/examples/top_test.cljc
+++ b/test/sicmutils/examples/top_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.examples.top-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/expression/analyze_test.cljc
+++ b/test/sicmutils/expression/analyze_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.expression.analyze-test
   (:require [clojure.string :as cs]

--- a/test/sicmutils/expression/compile_test.cljc
+++ b/test/sicmutils/expression/compile_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.expression.compile-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/expression/render_test.cljc
+++ b/test/sicmutils/expression/render_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.expression.render-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/expression_test.cljc
+++ b/test/sicmutils/expression_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.expression-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/fdg/bianchi_test.cljc
+++ b/test/sicmutils/fdg/bianchi_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.bianchi-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/fdg/ch10_test.cljc
+++ b/test/sicmutils/fdg/ch10_test.cljc
@@ -1,20 +1,5 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
+#_"SPDX-License-Identifier: GPL-3.0"
 
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
 (ns sicmutils.fdg.ch10-test
   (:refer-clojure :exclude [+ - * / zero? partial])
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/fdg/ch11_test.cljc
+++ b/test/sicmutils/fdg/ch11_test.cljc
@@ -1,20 +1,5 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
+#_"SPDX-License-Identifier: GPL-3.0"
 
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
 (ns sicmutils.fdg.ch11-test
   (:refer-clojure :exclude [+ - * / zero? partial])
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/fdg/ch1_test.cljc
+++ b/test/sicmutils/fdg/ch1_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch1-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/fdg/ch2_test.cljc
+++ b/test/sicmutils/fdg/ch2_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch2-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/fdg/ch3_test.cljc
+++ b/test/sicmutils/fdg/ch3_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch3-test
   (:refer-clojure :exclude [+ - * /  partial])

--- a/test/sicmutils/fdg/ch4_test.cljc
+++ b/test/sicmutils/fdg/ch4_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch4-test
   (:refer-clojure :exclude [+ - * / zero? partial])

--- a/test/sicmutils/fdg/ch5_test.cljc
+++ b/test/sicmutils/fdg/ch5_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch5-test
   (:refer-clojure :exclude [+ - * / = partial zero?])

--- a/test/sicmutils/fdg/ch6_test.cljc
+++ b/test/sicmutils/fdg/ch6_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch6-test
   (:refer-clojure :exclude [+ - * / zero? partial])

--- a/test/sicmutils/fdg/ch7_test.cljc
+++ b/test/sicmutils/fdg/ch7_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch7-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])

--- a/test/sicmutils/fdg/ch8_test.cljc
+++ b/test/sicmutils/fdg/ch8_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch8-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])

--- a/test/sicmutils/fdg/ch9_test.cljc
+++ b/test/sicmutils/fdg/ch9_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.ch9-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])

--- a/test/sicmutils/fdg/einstein_test.cljc
+++ b/test/sicmutils/fdg/einstein_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.fdg.einstein-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/function_test.cljc
+++ b/test/sicmutils/function_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.function-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/generators.cljc
+++ b/test/sicmutils/generators.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2022 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.generators
   "test.check generators for the various types in the sicmutils project."

--- a/test/sicmutils/generic_test.cljc
+++ b/test/sicmutils/generic_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.generic-test
   (:refer-clojure :exclude [+ - * / zero?])

--- a/test/sicmutils/laws.cljc
+++ b/test/sicmutils/laws.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.laws
   "test.check laws useful for checking the algebraic properties of different types

--- a/test/sicmutils/matrix_test.cljc
+++ b/test/sicmutils/matrix_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.matrix-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/mechanics/hamilton_test.cljc
+++ b/test/sicmutils/mechanics/hamilton_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.mechanics.hamilton-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/mechanics/lagrange_test.cljc
+++ b/test/sicmutils/mechanics/lagrange_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.mechanics.lagrange-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/mechanics/rotation_test.cljc
+++ b/test/sicmutils/mechanics/rotation_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.mechanics.rotation-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/modint_test.cljc
+++ b/test/sicmutils/modint_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.modint-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numbers_test.cljc
+++ b/test/sicmutils/numbers_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numbers-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/derivative_test.cljc
+++ b/test/sicmutils/numerical/derivative_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.derivative-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/minimize_test.cljc
+++ b/test/sicmutils/numerical/minimize_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.minimize-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/ode_test.cljc
+++ b/test/sicmutils/numerical/ode_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.ode-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/adaptive_test.cljc
+++ b/test/sicmutils/numerical/quadrature/adaptive_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.adaptive-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/boole_test.cljc
+++ b/test/sicmutils/numerical/quadrature/boole_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.boole-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/bulirsch_stoer_test.cljc
+++ b/test/sicmutils/numerical/quadrature/bulirsch_stoer_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.bulirsch-stoer-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/common_test.cljc
+++ b/test/sicmutils/numerical/quadrature/common_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.common-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/infinite_test.cljc
+++ b/test/sicmutils/numerical/quadrature/infinite_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.infinite-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/midpoint_test.cljc
+++ b/test/sicmutils/numerical/quadrature/midpoint_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.midpoint-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/milne_test.cljc
+++ b/test/sicmutils/numerical/quadrature/milne_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.milne-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/riemann_test.cljc
+++ b/test/sicmutils/numerical/quadrature/riemann_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.riemann-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/romberg_test.cljc
+++ b/test/sicmutils/numerical/quadrature/romberg_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.romberg-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/simpson38_test.cljc
+++ b/test/sicmutils/numerical/quadrature/simpson38_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.simpson38-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/simpson_test.cljc
+++ b/test/sicmutils/numerical/quadrature/simpson_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.simpson-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/numerical/quadrature/substitute_test.cljc
+++ b/test/sicmutils/numerical/quadrature/substitute_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.substitute-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature/trapezoid_test.cljc
+++ b/test/sicmutils/numerical/quadrature/trapezoid_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature.trapezoid-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/quadrature_test.cljc
+++ b/test/sicmutils/numerical/quadrature_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.quadrature-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/roots/bisect_test.cljc
+++ b/test/sicmutils/numerical/roots/bisect_test.cljc
@@ -1,21 +1,4 @@
-;;
-;; Copyright © 2022 Sam Ritchie.
-;; This work is based on the Scmutils system of MIT/GNU Scheme:
-;; Copyright © 2002 Massachusetts Institute of Technology
-;;
-;; This is free software;  you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3 of the License, or (at
-;; your option) any later version.
-;;
-;; This software is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this code; if not, see <http://www.gnu.org/licenses/>.
-;;
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.roots.bisect-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/unimin/bracket_test.cljc
+++ b/test/sicmutils/numerical/unimin/bracket_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.unimin.bracket-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/unimin/brent_test.cljc
+++ b/test/sicmutils/numerical/unimin/brent_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.unimin.brent-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/numerical/unimin/golden_test.cljc
+++ b/test/sicmutils/numerical/unimin/golden_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.numerical.unimin.golden-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/operator_test.cljc
+++ b/test/sicmutils/operator_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
                                         ;
 (ns sicmutils.operator-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/polynomial/exponent_test.cljc
+++ b/test/sicmutils/polynomial/exponent_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.exponent-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/polynomial/factor_test.cljc
+++ b/test/sicmutils/polynomial/factor_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.factor-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/polynomial/gcd_test.cljc
+++ b/test/sicmutils/polynomial/gcd_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is bansed on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.gcd-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/polynomial/interpolate_test.cljc
+++ b/test/sicmutils/polynomial/interpolate_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.interpolate-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/polynomial/richardson_test.cljc
+++ b/test/sicmutils/polynomial/richardson_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial.richardson-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/polynomial_test.cljc
+++ b/test/sicmutils/polynomial_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.polynomial-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/quaternion_test.cljc
+++ b/test/sicmutils/quaternion_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2022 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.quaternion-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/ratio_test.cljc
+++ b/test/sicmutils/ratio_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.ratio-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/rational_function/interpolate_test.cljc
+++ b/test/sicmutils/rational_function/interpolate_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.rational-function.interpolate-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/rational_function_test.cljc
+++ b/test/sicmutils/rational_function_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.rational-function-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/series/impl_test.cljc
+++ b/test/sicmutils/series/impl_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.series.impl-test
   (:require [clojure.test :refer [is deftest testing ]]

--- a/test/sicmutils/series_test.cljc
+++ b/test/sicmutils/series_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.series-test
   (:require [clojure.test :refer [is deftest testing use-fixtures]]

--- a/test/sicmutils/sicm/ch1_test.cljc
+++ b/test/sicmutils/sicm/ch1_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sicm.ch1-test
   (:refer-clojure :exclude [+ - * / partial])

--- a/test/sicmutils/sicm/ch2_test.cljc
+++ b/test/sicmutils/sicm/ch2_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sicm.ch2-test
   (:refer-clojure :exclude [+ - * / zero? ref partial])

--- a/test/sicmutils/sicm/ch3_test.cljc
+++ b/test/sicmutils/sicm/ch3_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sicm.ch3-test
   (:refer-clojure :exclude [+ - * / zero? partial])

--- a/test/sicmutils/sicm/ch5_test.cljc
+++ b/test/sicmutils/sicm/ch5_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sicm.ch5-test
   (:refer-clojure :exclude [+ - * /  ref partial])

--- a/test/sicmutils/sicm/ch6_test.cljc
+++ b/test/sicmutils/sicm/ch6_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sicm.ch6-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/sicm/ch7_test.cljc
+++ b/test/sicmutils/sicm/ch7_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sicm.ch7-test
   (:refer-clojure :exclude [+ - * / = partial])

--- a/test/sicmutils/simplify/rules_test.cljc
+++ b/test/sicmutils/simplify/rules_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.simplify.rules-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/simplify_test.cljc
+++ b/test/sicmutils/simplify_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.simplify-test
   (:refer-clojure :exclude [=])

--- a/test/sicmutils/special/elliptic_test.cljc
+++ b/test/sicmutils/special/elliptic_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.special.elliptic-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/special/factorial_test.cljc
+++ b/test/sicmutils/special/factorial_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2022 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.special.factorial-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/sr/boost_test.cljc
+++ b/test/sicmutils/sr/boost_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sr.boost-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/sr/frames_test.cljc
+++ b/test/sicmutils/sr/frames_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.sr.frames-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/structure_test.cljc
+++ b/test/sicmutils/structure_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.structure-test
   (:refer-clojure :exclude [+ - * /])

--- a/test/sicmutils/tex_web_test.clj
+++ b/test/sicmutils/tex_web_test.clj
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 #_{:clj-kondo/ignore [:refer-all]}
 (ns sicmutils.tex-web-test

--- a/test/sicmutils/util/aggregate_test.cljc
+++ b/test/sicmutils/util/aggregate_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.aggregate-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/util/permute_test.cljc
+++ b/test/sicmutils/util/permute_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.permute-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/util/stream_test.cljc
+++ b/test/sicmutils/util/stream_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.stream-test
   "Tests of the various sequence convergence and generation utilities in the SICM

--- a/test/sicmutils/util/vector_set_test.cljc
+++ b/test/sicmutils/util/vector_set_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2020 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util.vector-set-test
   (:require [clojure.set :as cs]

--- a/test/sicmutils/util_test.cljc
+++ b/test/sicmutils/util_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2021 Sam Ritchie.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.util-test
   (:require [clojure.test :refer [is deftest testing]]

--- a/test/sicmutils/value_test.cljc
+++ b/test/sicmutils/value_test.cljc
@@ -1,20 +1,4 @@
-#_
-"Copyright © 2017 Colin Smith.
-This work is based on the Scmutils system of MIT/GNU Scheme:
-Copyright © 2002 Massachusetts Institute of Technology
-
-This is free software;  you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at
-your option) any later version.
-
-This software is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this code; if not, see <http://www.gnu.org/licenses/>."
+#_"SPDX-License-Identifier: GPL-3.0"
 
 (ns sicmutils.value-test
   (:require [clojure.test :refer [is deftest testing]]


### PR DESCRIPTION
This tidies up the source code a bit and makes it easier to pull this convention forward.

- #498: replace all long-form GPL headers with `"SPDX-License-Identifier:
  GPL-3.0"`.