### PR TITLE
Bump clerk dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
   {:extra-paths ["dev"]
    :extra-deps
    {io.github.nextjournal/clerk
-    {:git/sha "a44f021a5f90defe877f3cfec81e164a844f7b39"}}}
+    {:git/sha "d08c26043efe19a92fe33dd9eb4499e304e4cff7"}}}
 
   :clj-kondo
   {:replace-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}

--- a/project.clj
+++ b/project.clj
@@ -55,8 +55,7 @@ along with this code; if not, see <http://www.gnu.org/licenses/>."
                              [cider/piggieback "0.5.3"]
                              [com.taoensso/tufte "2.2.0"]
                              [com.gfredericks/test.chuck "0.2.13"]
-                             [io.github.nextjournal/clerk "0.5.346"
-                              :exclusions [org.clojure/tools.deps.alpha]]
+                             [io.github.nextjournal/clerk "0.6.387"]
                              [nrepl "0.9.0"]
                              [same/ish "0.1.4"]
                              [thheller/shadow-cljs "2.17.4"]]}}


### PR DESCRIPTION
This PR bumps clerk to the latest release, which excludes `tools.deps.alpha`.