### PR TITLE
Complex number type-hints, fast compiled functions

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,4 +3,4 @@
      (cider-default-cljs-repl . node)))
  (clojurec-mode
   . ((cider-preferred-build-tool . clojure-cli)
-     (cider-clojure-cli-aliases . ":test:dev/repl"))))
+     (cider-clojure-cli-aliases . ":test:cljs:dev/repl"))))

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ the Github page. Citation information is generated from
 Here is the generated BibTeX entry:
 
 ```
-@software{Ritchie_SICMUtils_Functional_Computer_2016,
+@software{Ritchie_SICMUtils_Functional_Computer_2016},
 author = {Ritchie, Sam and Smith, Colin},
 license = {GPL-3.0},
 month = {4},
@@ -215,7 +215,6 @@ title = {{SICMUtils: Functional Computer Algebra in Clojure}},
 url = {https://github.com/sicmutils/sicmutils},
 version = {0.22.0},
 year = {2016}
-}
 ```
 
 In the above BibTeX entry, the version number is intended to be that from

--- a/demo/src/demo/minimal.cljs
+++ b/demo/src/demo/minimal.cljs
@@ -2,7 +2,7 @@
   (:require
    ;; sicmutils.env has aliases for common functions. If you are using a REPL, run
    ;; `sicmutils.env/bootstrap-repl!` to pull in all the aliases into the current namespace.
-   [sicmutils.env :as e :include-macros true]))
+   [sicmutils.env :as e]))
 
 (defn output [expr]
   ;; `simplify` collapses expressions while `->infix` prints them using Unicode operators.

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
   dm3/stopwatch {:mvn/version "0.1.1" :exclusions [org.clojure/clojurescript]}
   hiccup/hiccup {:mvn/version "1.0.5"}
   org.apache.commons/commons-math3 {:mvn/version "3.6.1"}
-  org.babashka/sci {:mvn/version "0.3.2"}
+  org.babashka/sci {:mvn/version "0.4.33"}
   potemkin/potemkin {:mvn/version "0.4.5"}}
 
  :aliases

--- a/src/pattern/rule.cljc
+++ b/src/pattern/rule.cljc
@@ -11,8 +11,9 @@
             [pattern.syntax :as ps]
             [sicmutils.util :as u]
             #?(:cljs
-               [sicmutils.util.def
-                :refer-macros [import-def]])))
+               [sicmutils.util.def :refer-macros [import-def]]))
+  #?(:cljs
+     (:include-macros [pattern.rule])))
 
 ;; ## Rules
 ;;
@@ -429,7 +430,8 @@
   returning its input on a failed match."
   [the-rule expr]
   (cond (sequential? expr)
-        (let [processed (map the-rule expr)]
+        ;; TODO good change??
+        (let [processed (doall (map the-rule expr))]
           (if (= expr processed)
             expr
             (if (vector? expr)

--- a/src/sicmutils/complex.cljc
+++ b/src/sicmutils/complex.cljc
@@ -109,7 +109,7 @@
      IEquiv
      (-equiv [this other]
        (cond (complex? other)
-             (.equals this other)
+             (.equals ^js this other)
 
              (v/real? other)
              (and (zero? (imaginary this))
@@ -140,7 +140,7 @@
   (zero? [c]
     #?(:clj (and (zero? (real c))
                  (zero? (imaginary c)))
-       :cljs (.isZero c)))
+       :cljs (.isZero ^js c)))
 
   (one? [c]
     (and (v/one? (real c))
@@ -198,7 +198,8 @@
           (g/negate z)
           z)
 
-        (v/real? z) (Math/abs z)
+        (v/real? z)
+        (Math/abs ^double (u/double z))
 
         :else (u/illegal "not supported!")))
 
@@ -259,9 +260,18 @@
 
 (defmethod g/real-part [::complex] [a] (real a))
 (defmethod g/imag-part [::complex] [a] (imaginary a))
-(defmethod g/magnitude [::complex] [^Complex a] (.abs a))
-(defmethod g/angle [::complex] [^Complex a] (#?(:clj .getArgument :cljs .arg) a))
-(defmethod g/conjugate [::complex] [^Complex a] (.conjugate a))
+
+(defmethod g/magnitude [::complex] [a]
+  #?(:clj (.abs ^Complex a)
+     :cljs (.abs ^js a)))
+
+(defmethod g/angle [::complex] [a]
+  #?(:clj (.getArgument ^Complex a)
+     :cljs (.arg ^js a)))
+
+(defmethod g/conjugate [::complex] [a]
+  #?(:clj (.conjugate ^Complex a)
+     :cljs (.conjugate ^js a)))
 
 (defmethod g/dot-product [::complex ::complex] [a b]
   (+ (* (real a) (real b))
@@ -269,8 +279,9 @@
 (defmethod g/dot-product [::complex ::v/real] [a b] (* (real a) b))
 (defmethod g/dot-product [::v/real ::complex] [a b] (* a (real b)))
 
-(defmethod v/= [::complex ::complex] [^Complex a ^Complex b]
-  (.equals a b))
+(defmethod v/= [::complex ::complex] [a b]
+  #?(:clj (.equals ^Complex a ^Complex b)
+     :cljs (.equals ^js a b)))
 
 (defmethod v/= [::complex ::v/real] [^Complex a n]
   (and (zero? (imaginary a))
@@ -280,42 +291,88 @@
   (and (zero? (imaginary a))
        (v/= n (real a))))
 
-(defmethod g/add [::complex ::complex] [^Complex a ^Complex b]
-  (.add a b))
+(defmethod g/add [::complex ::complex] [a b]
+  #?(:clj (.add ^Complex a ^Complex b)
+     :cljs (.add ^js a b)))
 
-(defmethod g/add [::complex ::v/real] [^Complex a n]
-  (.add a ^double (u/double n)))
+(defmethod g/add [::complex ::v/real] [a n]
+  #?(:clj (.add ^Complex a ^double (u/double n))
+     :cljs (.add ^js a (u/double n))))
 
-(defmethod g/add [::v/real ::complex] [n ^Complex a]
-  (.add a ^double (u/double n)))
+(defmethod g/add [::v/real ::complex] [n a]
+  #?(:clj (.add ^Complex a ^double (u/double n))
+     :cljs (.add ^js a (u/double n))))
 
-(defmethod g/expt [::complex ::complex] [^Complex a ^Complex b] (.pow a b))
+(defmethod g/expt [::complex ::complex] [a b]
+  #?(:clj (.pow ^Complex a ^Complex b)
+     :cljs (.pow ^js a b)))
 
 (let [choices [1 I -1 -I]]
-  (defmethod g/expt [::complex ::v/real] [^Complex a n]
+  (defmethod g/expt [::complex ::v/real] [a n]
     (if (= a I)
       (choices (mod n 4))
-      (.pow a ^double (u/double n)))))
-(defmethod g/expt [::v/real ::complex] [n ^Complex a] (.pow ^Complex (complex n) a))
+      #?(:clj (.pow ^Complex a ^double (u/double n))
+         :cljs (.pow ^js a ^double (u/double n))))))
+
+(defmethod g/expt [::v/real ::complex] [n a]
+  #?(:clj (.pow ^Complex (complex n) ^Complex a)
+     :cljs (.pow ^js (complex n) a)))
 
 ;; Take advantage of the `expt` optimizations above for `I`.
 (defmethod g/square [::complex] [z] (g/expt z 2))
 (defmethod g/cube [::complex] [z] (g/expt z 3))
 
-(defmethod g/abs [::complex] [^Complex a] (.abs a))
-(defmethod g/exp [::complex] [^Complex a] (.exp a))
-(defmethod g/log [::complex] [^Complex a] (.log a))
-(defmethod g/sqrt [::complex] [^Complex a] (.sqrt a))
+(defmethod g/abs [::complex] [a]
+  #?(:clj (.abs ^Complex a)
+     :cljs (.abs ^js a)))
 
-(defmethod g/sin [::complex] [^Complex a] (.sin a))
-(defmethod g/cos [::complex] [^Complex a] (.cos a))
-(defmethod g/tan [::complex] [^Complex a] (.tan a))
-(defmethod g/asin [::complex] [^Complex a] (.asin a))
-(defmethod g/acos [::complex] [^Complex a] (.acos a))
-(defmethod g/atan [::complex] [^Complex a] (.atan a))
-(defmethod g/cosh [::complex] [^Complex a] (.cosh a))
-(defmethod g/sinh [::complex] [^Complex a] (.sinh a))
-(defmethod g/tanh [::complex] [^Complex a] (.tanh a))
+(defmethod g/exp [::complex] [a]
+  #?(:clj (.exp ^Complex a)
+     :cljs (.exp ^js a)))
+
+(defmethod g/log [::complex] [a]
+  #?(:clj (.log ^Complex a)
+     :cljs (.log ^js a)))
+
+(defmethod g/sqrt [::complex] [a]
+  #?(:clj (.sqrt ^Complex a)
+     :cljs (.sqrt ^js a)))
+
+(defmethod g/sin [::complex] [a]
+  #?(:clj (.sin ^Complex a)
+     :cljs (.sin ^js a)))
+
+(defmethod g/cos [::complex] [a]
+  #?(:clj (.cos ^Complex a)
+     :cljs (.cos ^js a)))
+
+(defmethod g/tan [::complex] [a]
+  #?(:clj (.tan ^Complex a)
+     :cljs (.tan ^js a)))
+
+(defmethod g/asin [::complex] [a]
+  #?(:clj (.asin ^Complex a)
+     :cljs (.asin ^js a)))
+
+(defmethod g/acos [::complex] [a]
+  #?(:clj (.acos ^Complex a)
+     :cljs (.acos ^js a)))
+
+(defmethod g/atan [::complex] [a]
+  #?(:clj (.atan ^Complex a)
+     :cljs (.atan ^js a)))
+
+(defmethod g/cosh [::complex] [a]
+  #?(:clj (.cosh ^Complex a)
+     :cljs (.cosh ^js a)))
+
+(defmethod g/sinh [::complex] [a]
+  #?(:clj (.sinh ^Complex a)
+     :cljs (.sinh ^js a)))
+
+(defmethod g/tanh [::complex] [a]
+  #?(:clj (.tanh ^Complex a)
+     :cljs (.tanh ^js a)))
 
 (defmethod g/integer-part [::complex] [a]
   (let [re (g/integer-part (real a))
@@ -342,15 +399,15 @@
 #?(:cljs
    ;; These are all defined explicitly in Complex.js.
    (do
-     (defmethod g/cot [::complex] [^Complex a] (.cot a))
-     (defmethod g/sec [::complex] [^Complex a] (.sec a))
-     (defmethod g/csc [::complex] [^Complex a] (.csc a))
-     (defmethod g/tanh [::complex] [^Complex a] (.tanh a))
-     (defmethod g/sech [::complex] [^Complex a] (.sech a))
-     (defmethod g/csch [::complex] [^Complex a] (.csch a))
-     (defmethod g/acosh [::complex] [^Complex a] (.acosh a))
-     (defmethod g/asinh [::complex] [^Complex a] (.asinh a))
-     (defmethod g/atanh [::complex] [^Complex a] (.atanh a))))
+     (defmethod g/cot [::complex] [a] (.cot ^js a))
+     (defmethod g/sec [::complex] [a] (.sec ^js a))
+     (defmethod g/csc [::complex] [a] (.csc ^js a))
+     (defmethod g/tanh [::complex] [a] (.tanh ^js a))
+     (defmethod g/sech [::complex] [a] (.sech ^js a))
+     (defmethod g/csch [::complex] [a] (.csch ^js a))
+     (defmethod g/acosh [::complex] [a] (.acosh ^js a))
+     (defmethod g/asinh [::complex] [a] (.asinh ^js a))
+     (defmethod g/atanh [::complex] [a] (.atanh ^js a))))
 
 ;;The remaining methods have different names in the Clojure vs JS
 ;;implementations.
@@ -387,19 +444,20 @@
 
    :cljs
    (do
-     (defmethod g/floor [::complex] [^Complex a] (.floor a))
-     (defmethod g/ceiling [::complex] [^Complex a] (.ceil a))
-     (defmethod g/sub [::complex ::complex] [^Complex a ^Complex b] (.sub a b))
-     (defmethod g/sub [::complex ::v/real] [^Complex a n] (.sub a (u/double n)))
-     (defmethod g/sub [::v/real ::complex] [n ^Complex a] (.add (.neg a) (u/double n)))
+     (defmethod g/floor [::complex] [a] (.floor ^js a))
+     (defmethod g/ceiling [::complex] [a] (.ceil ^js a))
+     (defmethod g/sub [::complex ::complex] [a b] (.sub ^js a b))
+     (defmethod g/sub [::complex ::v/real] [a n] (.sub ^js a (u/double n)))
+     (defmethod g/sub [::v/real ::complex] [n a] (.add ^js (.neg ^js a) (u/double n)))
 
-     (defmethod g/mul [::complex ::complex] [^Complex a ^Complex b] (.mul a b))
-     (defmethod g/mul [::complex ::v/real] [^Complex a n] (.mul a (u/double n)))
-     (defmethod g/mul [::v/real ::complex] [n ^Complex a] (.mul a (u/double n)))
+     (defmethod g/mul [::complex ::complex] [a b] (.mul ^js a b))
+     (defmethod g/mul [::complex ::v/real] [a n] (.mul ^js a (u/double n)))
+     (defmethod g/mul [::v/real ::complex] [n a] (.mul ^js a (u/double n)))
 
-     (defmethod g/div [::complex ::complex] [^Complex a ^Complex b] (.div a b))
-     (defmethod g/div [::complex ::v/real] [^Complex a n] (.div a (u/double n)))
-     (defmethod g/div [::v/real ::complex] [n ^Complex a] (.mul ^Complex (.inverse a) (u/double n)))
+     (defmethod g/div [::complex ::complex] [a b] (.div ^js a b))
+     (defmethod g/div [::complex ::v/real] [a n] (.div ^js a (u/double n)))
+     (defmethod g/div [::v/real ::complex] [n a]
+       (.mul ^js (.inverse ^js a) (u/double n)))
 
-     (defmethod g/negate [::complex] [^Complex a] (.neg a))
-     (defmethod g/invert [::complex] [^Complex a] (.inverse a))))
+     (defmethod g/negate [::complex] [a] (.neg ^js a))
+     (defmethod g/invert [::complex] [a] (.inverse ^js a))))

--- a/src/sicmutils/env.cljc
+++ b/src/sicmutils/env.cljc
@@ -83,7 +83,9 @@
                       :refer-macros [import-def import-vars]])
             [sicmutils.util.permute]
             [sicmutils.util.stream :as us]
-            [sicmutils.value :as v]))
+            [sicmutils.value :as v])
+  #?(:cljs
+     (:require-macros [sicmutils.env])))
 
 (defmacro bootstrap-repl!
   "Bootstraps a repl or Clojure namespace by requiring all public vars

--- a/src/sicmutils/expression/pendulum.cljc
+++ b/src/sicmutils/expression/pendulum.cljc
@@ -1,0 +1,170 @@
+;; # Exercise 1.44: The double pendulum
+
+;; This namespace explores [Exercise
+;; 1.44](https://tgvaughan.github.io/sicm/chapter001.html#Exe_1-44) from Sussman
+;; and Wisdom's [Structure and Interpretation of Classical
+;; Mechanics](https://tgvaughan.github.io/sicm/), using
+;; the [SICMUtils](https://github.com/sicmutils/sicmutils) Clojure library and
+;; the Clerk rendering environment.
+
+(ns sicmutils.expression.pendulum
+  (:refer-clojure
+   :exclude [+ - * / partial ref zero? numerator denominator compare = run!])
+  (:require [nextjournal.clerk :as clerk]
+            [sicmutils.env :as e :refer :all]
+            [sicmutils.expression.render :as xr]))
+
+;; ## Lagrangian
+;;
+;; Start with a coordinate transformation from `theta1`, `theta2` to rectangular
+;; coordinates. We'll generate our Lagrangian by composing this with an rectangular
+;; Lagrangian with the familiar form of `T - V`.
+
+(defn angles->rect [l1 l2]
+  (fn [[_ [theta1 theta2]]]
+    (let [x1 (* l1 (sin theta1))
+          y1 (- (* l1 (cos theta1)))
+          x2 (+ x1 (* l2 (sin (+ theta1 theta2))))
+          y2 (- y1 (* l2 (cos (+ theta1 theta2))))]
+      (up x1 y1 x2 y2))))
+
+;; `T` describes the sum of the kinetic energy of two particles in rectangular
+;; coordinates.
+
+(defn T [m1 m2]
+  (fn [[_ _ [xdot1 ydot1 xdot2 ydot2]]]
+    (+ (* (/ 1 2) m1 (+ (square xdot1)
+                        (square ydot1)))
+       (* (/ 1 2) m2 (+ (square xdot2)
+                        (square ydot2))))))
+
+
+;; `V` describes a uniform gravitational potential with coefficient `g`, acting
+;; on two particles with masses of, respectively, `m1` and `m2`. Again, this is
+;; written in rectangular coordinates.
+
+(defn V [m1 m2 g]
+  (fn [[_ [_ y1 _ y2]]]
+    (+ (* m1 g y1)
+       (* m2 g y2))))
+
+;; Form the rectangular Lagrangian `L` by subtracting `(V m1 m2 g)` from `(T m1 m2)`:
+
+(defn L-rect [m1 m2 g]
+  (- (T m1 m2)
+     (V m1 m2 g)))
+
+;; Form the final Langrangian in generalized coordinates (the angles of each
+;; segment) by composing `L-rect` with a properly transformed `angles->rect`
+;; coordinate transform!
+
+(defn L-double-pendulum [m1 m2 l1 l2 g]
+  (compose (L-rect m1 m2 g)
+           (F->C
+            (angles->rect l1 l2))))
+
+;; The Lagrangian is big and hairy:
+
+(def symbolic-L
+  ((L-double-pendulum 'm_1 'm_2 'l_1 'l_2 'g)
+   (up 't
+       (up 'theta_1 'theta_2)
+       (up 'theta_1dot 'theta_2dot))))
+
+;; Let's simplify that:
+
+(simplify symbolic-L)
+
+;; Better yet, let's render it as LaTeX, and create a helper function,
+;; `render-eq` to make it easier to render simplified equations:
+
+(def render-eq
+  (comp clerk/tex ->TeX simplify))
+
+(render-eq symbolic-L)
+
+;; And here are the equations of motion for the system:
+
+(let [L (L-double-pendulum 'm_1 'm_2 'l_1 'l_2 'g)]
+  (binding [xr/*TeX-vertical-down-tuples* true]
+    (render-eq
+     (((Lagrange-equations L)
+       (up (literal-function 'theta_1)
+           (literal-function 'theta_2)))
+      't))))
+
+;; What do these mean?
+;;
+;; - the system has two degrees of freedom: $\theta_1$ and $\theta_2$.
+;; - at any point `t` in time, the two equations above, full of first and second
+;; - order derivatives of the position functions, will stay true
+;; - the system can use these equations to simulate the system, one tick at a time.
+
+;; ## Simulation
+;;
+;; Next, let's run a simulation using those equations of motion and collect data
+;; on each coordinate's evolution.
+;;
+;; Here are the constants specified in exercise 1.44:
+;;
+;; masses in kg:
+
+(def m1 1.0)
+(def m2 3.0)
+
+;; lengths in meters:
+
+(def l1 1.0)
+(def l2 0.9)
+
+;; `g` in units of m/s^2:
+
+(def g 9.8)
+
+;; And two sets of initial pairs of `theta1`, `theta2` angles corresponding to
+;; chaotic and regular initial conditions:
+
+(def chaotic-initial-q (up (/ Math/PI 2) Math/PI))
+(def regular-initial-q (up (/ Math/PI 2) 0.0))
+
+;; Composing `Lagrangian->state-derivative` with `L-double-pendulum` produces
+;; a state derivative that we can use with our ODE solver:
+
+(def state-derivative
+  (compose
+   Lagrangian->state-derivative
+   L-double-pendulum))
+
+;; Finally, two default parameters for our simulation. We'll record data in
+;; steps of 0.01 seconds, and simulate to a horizon of 50 seconds.
+
+(def step 0.01)
+(def horizon 50)
+
+;; `run!` will return a sequence of 5001 states, one for each measured point in
+;; the simulation. The smaller-arity version simply passes in default masses and
+;; lengths, but you can override those with the larger arity version if you like.
+
+;; (The interface here could use some work: `integrate-state-derivative` tidies
+;; this up a bit, but I want it out in the open for now.)
+
+(defn run!
+  ([step horizon initial-coords]
+   (run! step horizon l1 l2 m1 m2 g initial-coords))
+  ([step horizon l1 l2 m1 m2 g initial-coords]
+   (let [collector     (atom (transient []))
+         initial-state (up 0.0
+                           initial-coords
+                           (up 0.0 0.0))]
+     ((evolve state-derivative m1 m2 l1 l2 g)
+      initial-state
+      step
+      horizon
+      {:compile? true
+       :epsilon 1.0e-13
+       :observe (fn [_ state]
+                  (swap!
+                   collector conj! state))})
+     (persistent! @collector))))
+
+(time (do (run! step horizon chaotic-initial-q) nil))

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -90,20 +90,26 @@
                  (v/integral? num)
                  (or (nil? denom)
                      (v/integral? denom))))
-          (precedence [op] (or (precedence-map op)
-                               (cond (seq? op)
-                                     ;; Some special cases:
-                                     ;; - give (expt X n) the precedence of X
-                                     ;; - give (partial ...) the precedence of D
-                                     ;; - otherwise (...) has the precedence of application
-                                     (cond (and (= 3 (count op))
-                                                (= 'expt (first op))) (recur (second op))
-                                           (= 'partial (first op)) (precedence-map 'D)
-                                           :else (precedence-map :apply))
-                                     (symbol? op) (precedence-map :apply)
-                                     :else 0)))
-          (precedence> [a b] (> (precedence a) (precedence b)))
-          (precedence<= [a b] (not (precedence> a b)))
+          (precedence [op]
+            (or (precedence-map op)
+                (cond (seq? op)
+                      ;; Some special cases:
+                      ;; - give (expt X n) the precedence of X
+                      ;; - give (partial ...) the precedence of D
+                      ;; - otherwise (...) has the precedence of application
+                      (cond (and (= 3 (count op))
+                                 (= 'expt (first op))) (recur (second op))
+                            (= 'partial (first op)) (precedence-map 'D)
+                            :else (precedence-map :apply))
+                      (symbol? op) (precedence-map :apply)
+                      :else 0)))
+
+          (precedence> [a b]
+            (> (precedence a) (precedence b)))
+
+          (precedence<= [a b]
+            (not (precedence> a b)))
+
           (parenthesize-if [b x]
             (if b (parenthesize x) x))
 
@@ -665,17 +671,20 @@
                                 'and (fn [[a b]] (str a " && " b))
                                 'or (fn [[a b]] (str a " || " b))
                                 '/ render-infix-ratio}))]
-    (fn [x & {:keys [symbol-generator parameter-order deterministic?]
+    (fn [x & {:keys [symbol-generator
+                    parameter-order
+                    deterministic?]
              :or {symbol-generator (make-symbol-generator "_")
                   parameter-order sort}}]
       (let [x      (v/freeze x)
+            ;; TODO
             params (set/difference (x/variables-in x) operators-known)
             ordered-params (if (fn? parameter-order)
                              (parameter-order params)
                              parameter-order)
             callback (fn [new-expression new-vars]
                        (doseq [[var val] new-vars]
-                         (print "  var ")
+                         (print " let ")
                          (print (str var " = "))
                          (print (R val))
                          (print ";\n"))

--- a/src/sicmutils/expression/render.cljc
+++ b/src/sicmutils/expression/render.cljc
@@ -489,6 +489,10 @@
       (fn [[x]]
         (str "\\lnot" (parenthesize x)))
 
+      'exp
+      (fn [[e]]
+        (str "\\exp" (parenthesize e)))
+
       'expt (fn [[x e]]
               (str (maybe-brace x) "^" (maybe-brace e)))
 

--- a/src/sicmutils/mechanics/lagrange.cljc
+++ b/src/sicmutils/mechanics/lagrange.cljc
@@ -2,7 +2,7 @@
 
 (ns sicmutils.mechanics.lagrange
   (:refer-clojure :exclude [+ - * / partial time])
-  (:require [pattern.rule :as r :include-macros true]
+  (:require [pattern.rule :as r]
             [sicmutils.calculus.derivative :refer [D partial]]
             [sicmutils.function :as f :refer [compose]]
             [sicmutils.generic :as g :refer [cos sin + - * /]]

--- a/src/sicmutils/quaternion.cljc
+++ b/src/sicmutils/quaternion.cljc
@@ -1415,6 +1415,10 @@
 
 (def ^:private quarter (g// 1 4))
 
+;; TODO can we revise on this here??
+;; https://d3cw3dd2w32x2b.cloudfront.net/wp-content/uploads/2015/01/matrix-to-quat.pdf
+;; I think we probably can...
+
 (defn from-rotation-matrix
   "Given an orthogonal 3x3 matrix M representing a rotation in 3-space, returns
   the unit quaternion that corresponds to the same transformation.
@@ -1507,7 +1511,9 @@
 
   [[->rotation-matrix]] will still work if `q` isn't normalized; but if
   a [[Quaternion]] isn't normalized it doesn't make sense to interpret it as a
-  rotation."
+  rotation.
+
+  See https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix"
   [q]
   {:pre [(quaternion? q)]}
   (let [q0 (get-r q) q1 (get-i q) q2 (get-j q) q3 (get-k q)

--- a/src/sicmutils/structure.cljc
+++ b/src/sicmutils/structure.cljc
@@ -29,6 +29,9 @@
 (def ^:no-doc orientation->symbol
   {::up 'up ::down 'down})
 
+(def ^:no-doc symbol-set
+  #{'up 'down})
+
 (def ^:no-doc orientation->separator
   {::up "↑" ::down "_"})
 

--- a/src/sicmutils/value.cljc
+++ b/src/sicmutils/value.cljc
@@ -317,7 +317,12 @@
            (= this (.valueOf other)))))))
 
 #?(:cljs
+   ;; TODO get this in??
    (extend-type js/BigInt
+     IHash
+     (-hash
+       [this] (hash (.toString this 16)))
+
      IEquiv
      (-equiv [this o]
        (let [other (.valueOf o)]

--- a/test/sicmutils/expression/compile_test.cljc
+++ b/test/sicmutils/expression/compile_test.cljc
@@ -303,3 +303,9 @@
     (is (= '(+ a b (sin x) (cos y))
            (c/cse-form '(+ a b (sin x) (cos y))))
         "No substitutions means no let binding.")))
+
+
+(deftest new-test
+  (fn [[_t theta thetadot]]
+    [1.0 thetadot (* -9.8 (Math/sin theta))])
+  )

--- a/test/sicmutils/fdg/ch11_test.cljc
+++ b/test/sicmutils/fdg/ch11_test.cljc
@@ -4,6 +4,7 @@
   (:refer-clojure :exclude [+ - * / zero? partial])
   (:require [clojure.test :refer [is deftest testing use-fixtures]]
             [sicmutils.env :as e :refer [+ - * /
+                                         compose
                                          zero?
                                          up
                                          rotate-x rotate-y rotate-z
@@ -34,7 +35,7 @@
     (testing "rotations, p177"
       (let [beta (up 'bx 'by 'bz)
             xi (e/make-four-tuple 'ct (up 'x 'y 'z))
-            R (compose
+            R (comp
                (rotate-x 'theta)
                (rotate-y 'phi)
                (rotate-z 'psi))


### PR DESCRIPTION
This PR:

- Adds `^js` type hints to the Complex namespace, similar to the approach in sicmutils/sicmutils#371. This should fix an issue that came up with operations on complex numbers under advanced compilation.
- adds the `cljs` alias into `.dir-locals.el`, fixing an issue where `cider-jack-in-cljs` failed to work in my emacs configuration.
- fixes a typo in the README.
- Working on sicmutils/placeholder#5 

wow, making JS literals is WAY faster than calling aset.


WAYYYYY faster to emit js and eval it if we're on the cljs side, vs using sci.

## Notes

- to get the state without triggering side effects in cljs, atom and ratom use (.-state my-ratom). that should let me delete the goofy thing I was doing to mirror state around in `emmy-viewers`.
- I can delete all `:include-macros true` code if I do the proper 

```
#?(:cljs
     (:include-macros [pattern.rule]))
```

in all cljc namespaces.