### PR TITLE
Sicmutils as JavaScript module

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -16,4 +16,4 @@ Follow the [ClojureScript Quick Start](https://clojurescript.org/guides/quick-st
 
 * Run `shadow-cljs watch sicm-browser` to run the demo in the browser using the config in `shadow-cljs.edn`. Open http://localhost:9000 and the page will automatically update as the file changes.
 * Run `shadow-cljs release sicm-browser` to create a release build and open `index.html`.
-* Run `shadow-cljs watch sicm-esm` and open `esmdemo.html` to code the demo in the browser in JavaScript. SICMUtils is a JavaScript library after all. (For good measure, we also provide a little Scheme compiler :-).
+* Run `shadow-cljs watch sicm-esm` and open `esmdemo.html` to code the demo in the browser in JavaScript. SICMUtils is also a JavaScript library after all. (For good measure, we also provide a little Scheme compiler :-).

--- a/demo/README.md
+++ b/demo/README.md
@@ -16,4 +16,4 @@ Follow the [ClojureScript Quick Start](https://clojurescript.org/guides/quick-st
 
 * Run `shadow-cljs watch sicm-browser` to run the demo in the browser using the config in `shadow-cljs.edn`. Open http://localhost:9000 and the page will automatically update as the file changes.
 * Run `shadow-cljs release sicm-browser` to create a release build and open `index.html`.
-* Run `shadow-cljs watch sicm-esm` and open `esmdemo.html` to code the demo in the browser in JavaScript. SICMUtils is also a JavaScript library after all. (For good measure, we also provide a little Scheme compiler :-).
+* Run `shadow-cljs watch sicm-esm` and open http://localhost:9000/esmdemo.html to code the demo in the browser in JavaScript. SICMUtils is also a JavaScript library after all. (For good measure, we also provide a little Scheme compiler :-).

--- a/demo/README.md
+++ b/demo/README.md
@@ -16,3 +16,4 @@ Follow the [ClojureScript Quick Start](https://clojurescript.org/guides/quick-st
 
 * Run `shadow-cljs watch sicm-browser` to run the demo in the browser using the config in `shadow-cljs.edn`. Open http://localhost:9000 and the page will automatically update as the file changes.
 * Run `shadow-cljs release sicm-browser` to create a release build and open `index.html`.
+* Run `shadow-cljs watch sicm-esm` and open `esmdemo.html` to code the demo in the browser in JavaScript. SICMUtils is a JavaScript library after all. (For good measure, we also provide a little Scheme compiler :-).

--- a/demo/esmdemo.html
+++ b/demo/esmdemo.html
@@ -77,8 +77,7 @@ window.compile_scheme = (exp) => {
              [/(\w+)/g,'"$1",'], [/\,\s\]/g," ]"], [/,$/,""]
             ].reduce((s,r) => s.replace(r[0],r[1]), exp);
     return toJS(JSON.parse(s));
-};
-</textarea>
+};</textarea>
     </div>
 
     <div>
@@ -88,9 +87,9 @@ window.compile_scheme = (exp) => {
     </div>
     <p></p>
 
-    <p>
-        Now you can run a Scheme one-liner:
-    </p>
+    <h2>
+        Run a Scheme one-liner Sicmutils demo:
+    </h2>
     <div>
         <textarea rows="7" cols="80" id="schemeCode">(output ((D (* 3 (expt sin 2))) 'x))</textarea>
     </div>

--- a/demo/esmdemo.html
+++ b/demo/esmdemo.html
@@ -31,6 +31,13 @@
   </head>
 
   <body>
+      <h2>
+          Sicmutils is a JavaScript library
+      </h2>
+      <p>
+          Press the button below to run the SICM demo calculations youself, in JavaScript, that is:
+      </p>
+
       <div>
           <textarea rows="7" cols="80" id="jsCode">output(eminus(emul(7, ediv(1,2)), 2));
 (output ((7 * (1 / 2)) - 2));
@@ -44,7 +51,13 @@ output(D.call(null, f).call(null, x));</textarea>
               Run Javascript!
           </button>
       </div>
-    <p></p>
+
+      <h2>
+          A small Scheme to JS compiler in 20 lines of code
+      </h2>
+    <p>
+        If you prefer Lisp syntax when doing symbolic calculations, load the following Scheme compiler:
+    </p>
 
     <div>
         <textarea rows="7" cols="80" id="schemeCompiler">window.toJS = (d) => {
@@ -75,6 +88,9 @@ window.compile_scheme = (exp) => {
     </div>
     <p></p>
 
+    <p>
+        Now you can run a Scheme one-liner:
+    </p>
     <div>
         <textarea rows="7" cols="80" id="schemeCode">(output ((D (* 3 (expt sin 2))) 'x))</textarea>
     </div>

--- a/demo/esmtest.html
+++ b/demo/esmtest.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Sicmutils Js demo</title>
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+
+    <script type="module">
+     import { output, eminus, emul, ediv, expt, sin, D, esymbol }
+     from "./out/main.js";
+     var counter = 0;
+     window.compile = (input_code_node, output_code_node) => {
+        document.body.append(document.createElement("p"));
+        let code = document.querySelector(input_code_node).value;
+         if (output_code_node == null) {
+             eval(code);
+         } else {
+             if (window.compile_scheme != undefined) {
+                 let js = compile_scheme(code);
+                 document.querySelector(output_code_node).innerText = js;
+                 eval(js);
+             } else {
+                 document.querySelector(output_code_node).innerText =
+                     "Load the Scheme compiler first!";
+             }
+         }
+      }
+      console.log('done')
+    </script>
+  </head>
+
+  <body>
+      <div>
+          <textarea rows="7" cols="80" id="jsCode">output(eminus(emul(7, ediv(1,2)), 2));
+(output ((7 * (1 / 2)) - 2));
+let f = emul(3, expt.call(null, sin, 2));
+let x = esymbol("x");
+output(f.call(null,x));
+output(D.call(null, f).call(null, x));</textarea>
+      </div>
+      <div>
+          <button onClick="compile('#jsCode', null)">
+              Run Javascript!
+          </button>
+      </div>
+    <p></p>
+
+    <div>
+        <textarea rows="7" cols="80" id="schemeCompiler">window.toJS = (d) => {
+    if (d.constructor == Array) {
+        return toJS(d[0])+ ".call(null," + d.slice(1).map(toJS) + ")";
+    } else if (d.substring(0, 8) == "esymbol_") {
+        return "esymbol(\"" + d.substring(8, d.length) + "\")";
+    } else {
+        return d;
+    }
+};
+
+window.compile_scheme = (exp) => {
+    let s = [[/\(/g,"[ "], [/\)/g," ],"],
+             [/\'(\w+)/g,"esymbol_$1"],
+             [/\*/g,"emul"],[/\-/g,"eminus"],[/\//g,"ediv"],
+             [/(\w+)/g,'"$1",'], [/\,\s\]/g," ]"], [/,$/,""]
+            ].reduce((s,r) => s.replace(r[0],r[1]), exp);
+    return toJS(JSON.parse(s));
+};
+</textarea>
+    </div>
+
+    <div>
+        <button onClick="compile('#schemeCompiler', null)">
+            Load Scheme compiler
+        </button>
+    </div>
+    <p></p>
+
+    <div>
+        <textarea rows="7" cols="80" id="schemeCode">(output ((D (* 3 (expt sin 2))) 'x))</textarea>
+    </div>
+    <div>
+        <pre><code id="compiledCode">Compiled JS code appears here</code></pre>
+    </div>
+    <div>
+        <button onClick="compile('#schemeCode', '#compiledCode')">
+        Compile and run Scheme code!
+      </button>
+    </div>
+    <p></p>
+   </body>
+</html>

--- a/demo/shadow-cljs.edn
+++ b/demo/shadow-cljs.edn
@@ -1,11 +1,28 @@
 {:deps true
  :builds {:sicm-browser
           {:asset-path "out"
-          :compiler-options {:optimizations :advanced
+           :compiler-options {:optimizations :advanced
                               :output-wrapper false
-                              :source-map true}                    
+                              :source-map true}
            :devtools {:http-root "."
                       :http-port 9000}
            :modules {:main {:entries [demo.minimal]}}
            :output-dir "out"
-           :target :browser}}}
+           :target :browser}
+          :sicm-esm
+          {:asset-path "out"
+           :compiler-options {:optimizations :advanced
+                              :output-wrapper false
+                              :source-map true}
+           :devtools {:http-root "."
+                      :http-port 9000}
+           :modules {:main {:exports {output demo.minimal/output
+                                      eminus sicmutils.env/-
+                                      emul sicmutils.env/*
+                                      ediv sicmutils.env//
+                                      expt sicmutils.env/expt
+                                      sin sicmutils.env/sin
+                                      D sicmutils.env/D
+                                      esymbol cljs.core/symbol}}}
+           :output-dir "out"
+           :target :esm}}}


### PR DESCRIPTION
Use schdow-cljs to compile  Sicmutils as ECMAScript module. Run demo calculations using JavaScript code. Coded a little Scheme compiler (20 loc) to show that a user of Sicmutils does not need any Clojure tooling whatsoever. In this way, the demo makes a connection to the original SICP (= write a Scheme compiler) and SICM (= use Scheme for Physics) books.

For some reason, I was not able to produce a release version. I get the error
```
ReferenceError: Can't find variable: module$node_modules$fraction_DOT_js$bigfraction
```